### PR TITLE
Remove GP_User

### DIFF
--- a/gp-includes/routes/profile.php
+++ b/gp-includes/routes/profile.php
@@ -13,10 +13,10 @@ class GP_Route_Profile extends GP_Route_Main {
 	function profile_post() {
 		if ( isset( $_POST['submit'] ) ) {
 			$per_page = (int) $_POST['per_page'];
-			GP::$user->current()->set_meta( 'per_page', $per_page );
+			update_user_meta( get_current_user_id(), 'gp_per_page', $per_page );
 
 			$default_sort = $_POST['default_sort'];
-			GP::$user->current()->set_meta( 'default_sort', $default_sort );
+			update_user_meta( get_current_user_id(), 'gp_default_sort', $default_sort );
 		}
 
 		$this->redirect( gp_url( '/profile' ) );

--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -55,10 +55,10 @@ class GP_Route_Project extends GP_Route_Main {
 		}
 
 		$user = GP::$user->current();
-		$source_url_templates = $user->get_meta( 'source_url_templates' );
+		$source_url_templates = get_user_meta( get_current_user_id(), 'gp_source_url_templates', true );
 		if ( !is_array( $source_url_templates ) ) $source_url_templates = array();
 		$source_url_templates[$project->id] = gp_post( 'source-url-template' );
-		if ( $user->set_meta( 'source_url_templates', $source_url_templates ) )
+		if ( update_user_meta( get_current_user_id(), 'gp_source_url_templates', $source_url_templates ) )
 			$this->notices[] = 'Source URL template was successfully updated.';
 		else
 			$this->errors[] = 'Error in updating source URL template.';

--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -261,7 +261,7 @@ class GP_Route_Project extends GP_Route_Main {
 		}
 		// we can't join on users table
 		foreach( array_merge( (array)$permissions, (array)$parent_permissions ) as $permission ) {
-			$permission->user = GP::$user->get( $permission->user_id );
+			$permission->user = get_userdata( $permission->user_id );
 		}
 		$this->tmpl( 'project-permissions', get_defined_vars() );
 	}

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -124,7 +124,7 @@ class GP_Route_Translation extends GP_Route_Main {
 			add_filter( 'gp_pagination', create_function( '$html', 'return "";' ) );
 		}
 
-		$per_page = GP::$user->current()->get_meta('per_page');
+		$per_page = get_user_meta( get_current_user_id(), 'gp_per_page', true );
 		if ( 0 == $per_page )
 			$per_page = GP::$translation->per_page;
 		else

--- a/gp-includes/things/project.php
+++ b/gp-includes/things/project.php
@@ -121,7 +121,7 @@ class GP_Project extends GP_Thing {
 		if ( isset( $this->user_source_url_template ) )
 			return $this->user_source_url_template;
 		else {
-			if ( $this->id && is_user_logged_in() && ($templates = GP::$user->current()->get_meta( 'source_url_templates' ))
+			if ( $this->id && is_user_logged_in() && ( $templates = get_user_meta( get_current_user_id(), 'gp_source_url_templates', true ) )
 					 && isset( $templates[$this->id] ) ) {
 				$this->user_source_url_template = $templates[$this->id];
 				return $this->user_source_url_template;

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -86,7 +86,7 @@ class GP_Translation extends GP_Thing {
 			'random' => 'o.priority DESC, RAND()', 'translation_date_added' => 't.date_added %s', 'original_date_added' => 'o.date_added %s',
 			'references' => 'o.references' );
 
-		$default_sort = GP::$user->current()->get_meta('default_sort');
+		$default_sort = get_user_meta( get_current_user_id(), 'gp_default_sort', true );
 		if ( ! is_array($default_sort) ) {
 			$default_sort = array(
 				'by' => 'priority',

--- a/gp-includes/things/user.php
+++ b/gp-includes/things/user.php
@@ -7,39 +7,6 @@ class GP_User extends GP_Thing {
 	var $field_names = array( 'id', 'user_login', 'user_pass', 'user_nicename', 'user_email', 'user_url', 'user_registered', 'user_status', 'display_name' );
 	var $non_updatable_attributes = array( 'ID' );
 
-	function create( $args ) {
-		if ( isset( $args['id'] ) ) {
-			$args['ID'] = $args['id'];
-			unset( $args['id'] );
-		}
-		$user = wp_insert_user( $args );
-		$user = get_userdata( $user );
-		return $this->coerce( $user );
-	}
-
-	function update( $data, $where = null ) {
-		return false;
-	}
-
-	function delete() {
-		return false;
-	}
-
-	function delete_all( $where = false ) {
-		return false;
-	}
-	function normalize_fields( $args ) {
-		if ( $args instanceof WP_User ) {
-			$args = $args->data;
-		}
-		$args = (array)$args;
-		if ( isset( $args['ID'] ) ) {
-			$args['id'] = $args['ID'];
-			unset( $args['ID'] );
-		}
-		return $args;
-	}
-
 	function current() {
 		if ( is_user_logged_in() )
 			return $this->coerce( wp_get_current_user() );

--- a/gp-includes/things/user.php
+++ b/gp-includes/things/user.php
@@ -47,28 +47,11 @@ class GP_User extends GP_Thing {
 			return new GP_User( array( 'id' => 0, ) );
 	}
 
-	function logout() {
-		wp_logout();
-	}
-
 	/**
 	 * Determines whether the user is an admin
 	 */
 	function admin() {
 		return $this->can( 'admin' );
-	}
-
-	/**
-	 * Set $this as the current user if $password patches this user's password
-	 * and sets the auth cookies.
-	 */
-	function login( $password ) {
-		if ( ! wp_check_password( $password, $this->user_pass, $this->id ) ) {
-			return false;
-		}
-		$this->set_as_current();
-		wp_set_auth_cookie( $this->id );
-		return true;
 	}
 
 	/**

--- a/gp-includes/things/user.php
+++ b/gp-includes/things/user.php
@@ -49,25 +49,6 @@ class GP_User extends GP_Thing {
 		return apply_filters( 'can_user', $verdict, $filter_args );
 	}
 
-	function get_meta( $key ) {
-		if ( !$user = get_userdata( $this->id ) ) {
-			return;
-		}
-
-		if ( !isset( $user->$key ) ) {
-			return;
-		}
-		return $user->$key;
-	}
-
-	function set_meta( $key, $value ) {
-		return gp_update_meta( $this->id, $key, $value, 'user' );
-	}
-
-	function delete_meta( $key ) {
-		return gp_delete_meta( $this->id, $key, '', 'user' );
-	}
-
 	public function get_avatar( $size = 100 ) {
 		return '//www.gravatar.com/avatar/' . md5( strtolower( $this->user_email ) ) . '?s=' . $size;
 	}

--- a/gp-includes/things/user.php
+++ b/gp-includes/things/user.php
@@ -40,11 +40,6 @@ class GP_User extends GP_Thing {
 		return $args;
 	}
 
-	function get( $user_or_id ) {
-		if ( is_object( $user_or_id ) ) $user_or_id = $user_or_id->id;
-		return $this->coerce( get_userdata( $user_or_id ) );
-	}
-
 	function by_login( $login ) {
 		$user = get_user_by( 'login', $login );
 		return $this->coerce( $user );

--- a/gp-includes/things/user.php
+++ b/gp-includes/things/user.php
@@ -40,11 +40,6 @@ class GP_User extends GP_Thing {
 		return $args;
 	}
 
-	function by_email( $email ) {
-		$user = get_user_by( 'email', $email );
-		return $this->coerce( $user );
-	}
-
 	function logged_in() {
 		$coerced = $this->coerce( wp_get_current_user() );
 		return ( $coerced && $coerced->id );

--- a/gp-includes/things/user.php
+++ b/gp-includes/things/user.php
@@ -22,13 +22,6 @@ class GP_User extends GP_Thing {
 	}
 
 	/**
-	 * Makes the user the current user of this session.
-	 */
-	function set_as_current() {
-		wp_set_current_user( $this->id );
-	}
-
-	/**
 	 * Determines whether the user can do $action on the instance of $object_type with id $object_id.
 	 *
 	 * If the method is called statically, it uses the current session user.

--- a/gp-includes/things/user.php
+++ b/gp-includes/things/user.php
@@ -40,11 +40,6 @@ class GP_User extends GP_Thing {
 		return $args;
 	}
 
-	function by_login( $login ) {
-		$user = get_user_by( 'login', $login );
-		return $this->coerce( $user );
-	}
-
 	function by_email( $email ) {
 		$user = get_user_by( 'email', $email );
 		return $this->coerce( $user );

--- a/gp-includes/things/user.php
+++ b/gp-includes/things/user.php
@@ -15,13 +15,6 @@ class GP_User extends GP_Thing {
 	}
 
 	/**
-	 * Determines whether the user is an admin
-	 */
-	function admin() {
-		return $this->can( 'admin' );
-	}
-
-	/**
 	 * Determines whether the user can do $action on the instance of $object_type with id $object_id.
 	 *
 	 * If the method is called statically, it uses the current session user.

--- a/gp-includes/things/user.php
+++ b/gp-includes/things/user.php
@@ -40,13 +40,8 @@ class GP_User extends GP_Thing {
 		return $args;
 	}
 
-	function logged_in() {
-		$coerced = $this->coerce( wp_get_current_user() );
-		return ( $coerced && $coerced->id );
-	}
-
 	function current() {
-		if ( $this->logged_in() )
+		if ( is_user_logged_in() )
 			return $this->coerce( wp_get_current_user() );
 		else
 			return new GP_User( array( 'id' => 0, ) );
@@ -94,7 +89,7 @@ class GP_User extends GP_Thing {
 		$user = null;
 		if ( isset( $this ) && $this->id )
 			$user = $this;
-		elseif ( GP::$user->logged_in() )
+		elseif ( is_user_logged_in() )
 			$user = GP::$user->current();
 		$user_id = $user? $user->id : null;
 		$args = $filter_args = compact( 'user_id', 'action', 'object_type', 'object_id' );

--- a/gp-templates/profile-public.php
+++ b/gp-templates/profile-public.php
@@ -5,7 +5,7 @@ gp_breadcrumb( array( __('Profile') ) );
 gp_tmpl_header();
 ?>
 
-<h2><?php echo $user->display_name; ?> <?php if ( $user->admin() ) { _e('(Admin)'); }; ?></h2>
+<h2><?php echo $user->display_name; ?> <?php if ( current_user_can( 'manage_options' ) ) { _e('(Admin)'); }; ?></h2>
 
 <div>
 	<div class="user-card">

--- a/gp-templates/profile.php
+++ b/gp-templates/profile.php
@@ -3,11 +3,11 @@ gp_title( __('Profile &lt; GlotPress') );
 gp_breadcrumb( array( __('Profile') ) );
 gp_tmpl_header();
 
-$per_page = GP::$user->current()->get_meta('per_page');
+$per_page = get_user_meta( get_current_user_id(), 'gp_per_page', true );
 if ( 0 == $per_page )
 	$per_page = 15;
 
-$default_sort = GP::$user->current()->get_meta('default_sort');
+$default_sort = get_user_meta( get_current_user_id(), 'gp_default_sort', true );
 if ( ! is_array($default_sort) ) {
 	$default_sort = array(
 		'by' => 'priority',

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -118,7 +118,7 @@ $i = 0;
 		<dt><?php _x('By:','sort by'); ?></dt>
 		<dd>
 		<?php
-		$default_sort = GP::$user->current()->get_meta('default_sort');
+		$default_sort = get_user_meta( get_current_user_id(), 'gp_default_sort', true );
 		if ( ! is_array($default_sort) ) {
 			$default_sort = array(
 				'by' => 'priority',

--- a/scripts/add-admin.php
+++ b/scripts/add-admin.php
@@ -10,7 +10,7 @@ class GP_Script_Add_Admin extends GP_CLI {
 			$this->usage();
 		}
 		foreach( $this->args as $user_login ) {
-			$user_to_make_admin = GP::$user->by_login( $user_login );
+			$user_to_make_admin = get_user_by( 'login', $user_login );
 			if ( !$user_to_make_admin ) {
 				$this->to_stderr( "User '$user_login' doesn't exist." );
 				exit( 1 );

--- a/t/lib/testcase.php
+++ b/t/lib/testcase.php
@@ -35,7 +35,7 @@ class GP_UnitTestCase extends WP_UnitTestCase {
 
 	function set_normal_user_as_current() {
 		$user = $this->factory->user->create();
-		$user->set_as_current();
+		wp_set_current_user( $user->id );
 		return $user;
 	}
 

--- a/t/tests/test_user.php
+++ b/t/tests/test_user.php
@@ -42,7 +42,7 @@ class GP_Test_User extends GP_UnitTestCase {
 
 	function test_select_by_email() {
 		$user = $this->factory->user->create( array( 'user_login' => 'pijo', 'user_email' => 'pijo@glotpress.org' ) );
-		$from_db = GP::$user->by_email( 'pijo@glotpress.org' );
+		$from_db = get_user_by( 'email', 'pijo@glotpress.org' );
 		$this->assertEquals( $user->id, $from_db->id );
 	}
 

--- a/t/tests/test_user.php
+++ b/t/tests/test_user.php
@@ -54,20 +54,23 @@ class GP_Test_User extends GP_UnitTestCase {
 
 	function test_set_meta_should_set_meta() {
 		$user = $this->factory->user->create();
-		$user->set_meta( 'int', 5 );
-		$this->assertEquals( 5, $user->get_meta( 'int') );
+		wp_set_current_user( $user->id );
+		update_user_meta( get_current_user_id(), 'gp_int', 5 );
+		$this->assertEquals( 5, get_user_meta( get_current_user_id(), 'gp_int', true ) );
 	}
 
 	function test_delete_meta_should_delete_the_meta() {
 		$user = $this->factory->user->create();
-		$user->set_meta( 'int', 5 );
-		$user->delete_meta( 'int' );
-		$this->assertEquals( null, $user->get_meta( 'int') );
+		wp_set_current_user( $user->id );
+		update_user_meta( get_current_user_id(), 'gp_int', 5 );
+		delete_user_meta( get_current_user_id(), 'gp_int' );
+		$this->assertEquals( null, get_user_meta( get_current_user_id(), 'gp_int', true ) );
 	}
 
 	function test_setting_array_value_as_meta_should_come_out_as_an_array() {
 		$user = $this->factory->user->create();
-		$user->set_meta( 'mixed', array(1, 2, 3) );
-		$this->assertEquals( array(1, 2, 3), $user->get_meta( 'mixed' ) );
+		wp_set_current_user( $user->id );
+		update_user_meta( get_current_user_id(), 'gp_mixed', array(1, 2, 3) );
+		$this->assertEquals( array(1, 2, 3), get_user_meta( get_current_user_id(), 'gp_mixed', true ) );
 	}
 }

--- a/t/tests/test_user.php
+++ b/t/tests/test_user.php
@@ -35,8 +35,8 @@ class GP_Test_User extends GP_UnitTestCase {
 	}
 
 	function test_select_by_login() {
-		$user = $this->factory->user->create( array( 'user_login' => 'pijo' ) );
-		$from_db = GP::$user->by_login( 'pijo' );
+		$user    = $this->factory->user->create( array( 'user_login' => 'pijo' ) );
+		$from_db = get_user_by( 'login', 'pijo' );
 		$this->assertEquals( $user->id, $from_db->id );
 	}
 

--- a/t/tests/test_user.php
+++ b/t/tests/test_user.php
@@ -12,16 +12,6 @@ class GP_Test_User extends GP_UnitTestCase {
 		$this->assertFalse( $user->can( 'write' ) );
 	}
 
-	function test_admin_should_be_admin() {
-		$admin_user = $this->factory->user->create_admin();
-		$this->assertTrue( $admin_user->admin() );
-	}
-
-	function test_non_admin_user_should_not_be_admin() {
-		$nonadmin_user = $this->factory->user->create();
-		$this->assertFalse( $nonadmin_user->admin() );
-	}
-
 	function test_admin_should_be_able_to_do_random_actions() {
 		$admin_user = $this->factory->user->create_admin();
 		$this->assertTrue( $admin_user->can( 'milk', 'a cow' ) );

--- a/t/tests/test_user.php
+++ b/t/tests/test_user.php
@@ -48,7 +48,7 @@ class GP_Test_User extends GP_UnitTestCase {
 
 	function test_get() {
 		$user = $this->factory->user->create();
-		$from_db = GP::$user->get( $user );
+		$from_db = get_userdate( $user );
 		$this->assertEquals( $user->id, $from_db->id );
 	}
 


### PR DESCRIPTION
WIP

Resolves #5

Before the GP_User class can be completely removed we need to take care of the following:
- [ ] Remove create user factory methods from unit tests in favour of `wp_create_user`
- [ ] Permissions https://github.com/deliciousbrains/GlotPress/issues/19
- [ ] Extract remaining user methods to generic functions file (gp-includes/user-functions.php). Example methods `get_recent_translation_sets`, `get_translation_set`, `locales_known`, etc

Please feel free to jump on this PR if anyone gets chance.
