### PR TITLE
Plugin prefix actions and filters

### DIFF
--- a/gp-includes/misc.php
+++ b/gp-includes/misc.php
@@ -204,7 +204,7 @@ function gp_salt($scheme = 'auth') {
 			break;
 	}
 
-	return apply_filters( 'salt', $secret_key . $salt, $scheme );
+	return apply_filters( 'gp_salt', $secret_key . $salt, $scheme );
 }
 endif;
 

--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -31,7 +31,7 @@ class GP_Route {
 	}
 
 	function before_request() {
-		do_action( 'before_request', $this->class_name, $this->last_method_called );
+		do_action( 'gp_before_request', $this->class_name, $this->last_method_called );
 	}
 
 	function after_request() {
@@ -42,7 +42,7 @@ class GP_Route {
 		if ( !headers_sent() ) {
 			$this->set_notices_and_errors();
 		}
-		do_action( 'after_request', $this->class_name, $this->last_method_called );
+		do_action( 'gp_after_request', $this->class_name, $this->last_method_called );
 	}
 
 	/**

--- a/gp-includes/router.php
+++ b/gp-includes/router.php
@@ -15,7 +15,7 @@ class GP_Router {
 	public function set_default_routes() {
 		$this->urls = array_merge( $this->urls, $this->default_routes() );
 
-		do_action( 'router_default_routes_set', $this );
+		do_action( 'gp_router_default_routes_set', $this );
 	}
 
 	/**
@@ -175,7 +175,7 @@ class GP_Router {
 						register_shutdown_function( array( &$route, 'after_request') );
 						call_user_func_array( array( $route, $method ), array_slice( $matches, 1 ) );
 						$route->after_request();
-						do_action( 'after_request', $class, $method );
+						do_action( 'gp_after_request', $class, $method );
 						$route->request_running = false;
 					} else {
 						call_user_func_array( $func, array_slice( $matches, 1 ) );

--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -36,7 +36,7 @@ class GP_Route_Project extends GP_Route_Main {
 		usort( $translation_sets, function( $a, $b ) {
 			return( $a->current_count < $b->current_count );
 		});
-		$translation_sets = apply_filters( 'translation_sets_sort', $translation_sets );
+		$translation_sets = apply_filters( 'gp_translation_sets_sort', $translation_sets );
 
 		$title = sprintf( __('%s project '), esc_html( $project->name ) );
 		$can_write = $this->can( 'write', 'project', $project->id );

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -85,9 +85,9 @@ class GP_Route_Translation extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
-		$export_locale = apply_filters( 'export_locale', $locale->slug, $locale );
+		$export_locale = apply_filters( 'gp_export_locale', $locale->slug, $locale );
 		$filename = sprintf( '%s-%s.'.$format->extension, str_replace( '/', '-', $project->path ), $export_locale );
-		$filename = apply_filters( 'export_translations_filename', $filename, $format, $locale, $project, $translation_set );
+		$filename = apply_filters( 'gp_export_translations_filename', $filename, $format, $locale, $project, $translation_set );
 
 		$entries = GP::$translation->for_export( $project, $translation_set, gp_get( 'filters' ) );
 
@@ -414,7 +414,7 @@ class GP_Route_Translation extends GP_Route_Main {
 			'warning' => gp_post( 'key' ),
 			'user' => get_current_user_id()
 		);
-		do_action_ref_array( 'warning_discarded', $warning );
+		do_action_ref_array( 'gp_warning_discarded', $warning );
 
 		unset( $translation->warnings[gp_post( 'index' )][gp_post( 'key' )] );
 		if ( empty( $translation->warnings[gp_post( 'index' )] ) ) {
@@ -428,7 +428,7 @@ class GP_Route_Translation extends GP_Route_Main {
 		}
 
 		// Translations with warnings aren't propagated, try again.
-		if ( apply_filters( 'enable_propagate_translations_across_projects', true ) ) {
+		if ( apply_filters( 'gp_enable_propagate_translations_across_projects', true ) ) {
 			$translation->propagate_across_projects();
 		}
 	}

--- a/gp-includes/strings.php
+++ b/gp-includes/strings.php
@@ -81,7 +81,7 @@ function gp_sanitize_for_url( $name ) {
 function gp_esc_attr_with_entities( $text ) {
 	$safe_text = wp_check_invalid_utf8( $text );
 	$safe_text = _wp_specialchars( $safe_text, ENT_QUOTES, false, true );
-	return apply_filters( 'attribute_escape', $safe_text, $text );
+	return apply_filters( 'gp_attribute_escape', $safe_text, $text );
 
 }
 

--- a/gp-includes/template.php
+++ b/gp-includes/template.php
@@ -1,13 +1,13 @@
 <?php
 function gp_tmpl_load( $template, $args = array(), $template_path = null ) {
 	$args = gp_tmpl_filter_args( $args );
-	do_action_ref_array( 'pre_tmpl_load', array( $template, &$args ) );
+	do_action_ref_array( 'gp_pre_tmpl_load', array( $template, &$args ) );
 	require_once GP_TMPL_PATH . 'helper-functions.php';
 	$locations = array( GP_TMPL_PATH );
 	if ( !is_null( $template_path ) ) {
 		array_unshift( $locations, untrailingslashit( $template_path ) . '/' );
 	}
-	$locations = apply_filters( 'tmpl_load_locations', $locations, $template, $args, $template_path );
+	$locations = apply_filters( 'gp_tmpl_load_locations', $locations, $template, $args, $template_path );
 	if ( isset( $args['http_status'] ) )
 		status_header( $args['http_status'] );
 	foreach( $locations as $location ) {
@@ -18,7 +18,7 @@ function gp_tmpl_load( $template, $args = array(), $template_path = null ) {
 			break;
 		}
 	}
-	do_action_ref_array( 'post_tmpl_load', array( $template, &$args ) );
+	do_action_ref_array( 'gp_post_tmpl_load', array( $template, &$args ) );
 }
 
 function gp_tmpl_get_output() {

--- a/gp-includes/things/original.php
+++ b/gp-includes/things/original.php
@@ -104,7 +104,7 @@ class GP_Original extends GP_Thing {
 				'references' => implode( ' ', $entry->references ),
 				'status'     => '+active'
 			);
-			$data = apply_filters( 'import_original_array', $data );
+			$data = apply_filters( 'gp_import_original_array', $data );
 
 			// Original exists, let's update it.
 			if ( isset( $originals_by_key[ $entry->key() ] ) ) {
@@ -138,7 +138,7 @@ class GP_Original extends GP_Thing {
 				'references' => implode( ' ', $entry->references ),
 				'status'     => '+active'
 			);
-			$data = apply_filters( 'import_original_array', $data );
+			$data = apply_filters( 'gp_import_original_array', $data );
 
 			// Search for match in the dropped strings and existing obsolete strings.
 			$close_original = $this->closest_original( $entry->key(), $comparison_array );
@@ -161,7 +161,7 @@ class GP_Original extends GP_Thing {
 			} else { // Completely new string
 				$created = GP::$original->create( $data );
 
-				if ( apply_filters( 'enable_add_translations_from_other_projects', true ) ) {
+				if ( apply_filters( 'gp_enable_add_translations_from_other_projects', true ) ) {
 					$created->add_translations_from_other_projects();
 				}
 
@@ -180,7 +180,7 @@ class GP_Original extends GP_Thing {
 			wp_cache_delete( $project->id, self::$count_cache_group );
 		}
 
-		do_action( 'originals_imported', $project->id, $originals_added, $originals_existing, $originals_obsoleted, $originals_fuzzied );
+		do_action( 'gp_originals_imported', $project->id, $originals_added, $originals_existing, $originals_obsoleted, $originals_fuzzied );
 
 		return array( $originals_added, $originals_existing, $originals_fuzzied, $originals_obsoleted );
 	}
@@ -241,7 +241,7 @@ class GP_Original extends GP_Thing {
 		$min_score = apply_filters( 'gp_original_import_min_similarity_diff', 0.8 );
 		$close_enough = ( $closest_similarity > $min_score );
 
-		do_action( 'post_string_similiary_test', $input, $closest, $closest_similarity, $close_enough );
+		do_action( 'gp_post_string_similiary_test', $input, $closest, $closest_similarity, $close_enough );
 
 		if ( $close_enough ) {
 			return $closest;
@@ -307,13 +307,13 @@ class GP_Original extends GP_Thing {
 
 			$matched_sets[] = $o_translation_set->id;
 
-			$copy_status = apply_filters( 'translations_from_other_projects_status', 'current' );
+			$copy_status = apply_filters( 'gp_translations_from_other_projects_status', 'current' );
 			$t->copy_into_set( $o_translation_set->id, $this->id, $copy_status );
 		}
 	}
 
 	function after_create() {
-		do_action( 'original_created', $this );
+		do_action( 'gp_original_created', $this );
 		return true;
 	}
 }

--- a/gp-includes/things/project.php
+++ b/gp-includes/things/project.php
@@ -19,14 +19,14 @@ class GP_Project extends GP_Thing {
 
 	function sub_projects() {
 		$sub_projects = $this->many( "SELECT * FROM $this->table WHERE parent_project_id = %d ORDER BY active DESC, id ASC", $this->id );
-		$sub_projects = apply_filters( 'projects', $sub_projects, $this->id );
+		$sub_projects = apply_filters( 'gp_projects', $sub_projects, $this->id );
 
 		return $sub_projects;
 	}
 
 	function top_level() {
 		$projects = $this->many( "SELECT * FROM $this->table WHERE parent_project_id IS NULL OR parent_project_id < 1 ORDER BY name ASC" );
-		$projects = apply_filters( 'projects', $projects, 0 );
+		$projects = apply_filters( 'gp_projects', $projects, 0 );
 
 		return $projects;
 	}
@@ -34,14 +34,14 @@ class GP_Project extends GP_Thing {
 	// Triggers
 
 	function after_save() {
-		do_action( 'project_saved', $this );
+		do_action( 'gp_project_saved', $this );
 		// TODO: pass the update args to after/pre_save?
 		// TODO: only call it if the slug or parent project were changed
 		return !is_null( $this->update_path() );
 	}
 
 	function after_create() {
-		do_action( 'project_created', $this );
+		do_action( 'gp_project_created', $this );
 		// TODO: pass some args to pre/after_create?
 		if ( is_null( $this->update_path() ) ) return false;
 	}

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -77,7 +77,7 @@ class GP_Translation_Set extends GP_Thing {
 				// create a new one if they don't match
 				$entry->original_id = $translated->original_id;
 				$translated_is_different = array_pad( $entry->translations, $locale->nplurals, null ) != $translated->translations;
-				$create = apply_filters( 'translation_set_import_over_existing', $translated_is_different );
+				$create = apply_filters( 'gp_translation_set_import_over_existing', $translated_is_different );
 			} else {
 				// we don't have the string translated, let's see if the original is there
 				$original = GP::$original->by_project_id_and_entry( $this->project->id, $entry, '+active' );
@@ -92,7 +92,7 @@ class GP_Translation_Set extends GP_Thing {
 				}
 
 				$entry->translation_set_id = $this->id;
-				$entry->status = apply_filters( 'translation_set_import_status', in_array( 'fuzzy', $entry->flags ) ? 'fuzzy' : 'current' );
+				$entry->status = apply_filters( 'gp_translation_set_import_status', in_array( 'fuzzy', $entry->flags ) ? 'fuzzy' : 'current' );
 				// check for errors
 				$translation = GP::$translation->create( $entry );
 				$translation->set_status( $entry->status );
@@ -102,7 +102,7 @@ class GP_Translation_Set extends GP_Thing {
 
 		gp_clean_translation_set_cache( $this->id );
 
-		do_action( 'translations_imported', $this->id );
+		do_action( 'gp_translations_imported', $this->id );
 
 		return $translations_added;
 	}

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -156,7 +156,7 @@ class GP_Translation extends GP_Thing {
 			$join_where[] = $statuses_where;
 		}
 
-		$where = apply_filters( 'for_translation_where', $where, $translation_set );
+		$where = apply_filters( 'gp_for_translation_where', $where, $translation_set );
 
 		$where = implode( ' AND ', $where );
 		if ( $where ) {
@@ -219,7 +219,7 @@ class GP_Translation extends GP_Thing {
 			array('original_id' => $this->original_id, 'translation_set_id' => $this->translation_set_id, 'status' => 'fuzzy') )
 		&& $this->save( array('status' => 'current') );
 
-		if ( apply_filters( 'enable_propagate_translations_across_projects', true ) ) {
+		if ( apply_filters( 'gp_enable_propagate_translations_across_projects', true ) ) {
 			$this->propagate_across_projects();
 		}
 
@@ -269,7 +269,7 @@ class GP_Translation extends GP_Thing {
 			$current_translation = GP::$translation->find_no_map( array( 'translation_set_id' => $o_translation_set->id, 'original_id' => $o->id, 'status' => 'current' ) );
 
 			if ( ! $current_translation  ) {
-				$copy_status = apply_filters( 'translations_to_other_projects_status', 'current' );
+				$copy_status = apply_filters( 'gp_translations_to_other_projects_status', 'current' );
 				$this->copy_into_set( $o_translation_set->id, $o->id, $copy_status );
 			}
 		}

--- a/gp-includes/things/user.php
+++ b/gp-includes/things/user.php
@@ -115,7 +115,7 @@ class GP_User extends GP_Thing {
 		$args = $filter_args = compact( 'user_id', 'action', 'object_type', 'object_id' );
 		$filter_args['user'] = $user;
 		$filter_args['extra'] = $extra;
-		$preliminary = apply_filters( 'pre_can_user', 'no-verdict', $filter_args );
+		$preliminary = apply_filters( 'gp_pre_can_user', 'no-verdict', $filter_args );
 		if ( is_bool( $preliminary ) ) {
 			return $preliminary;
 		}
@@ -123,7 +123,7 @@ class GP_User extends GP_Thing {
 			GP::$permission->find_one( array( 'action' => 'admin', 'user_id' => $user_id ) ) ||
 			GP::$permission->find_one( $args ) ||
 			GP::$permission->find_one( array_merge( $args, array( 'object_id' => null ) ) );
-		return apply_filters( 'can_user', $verdict, $filter_args );
+		return apply_filters( 'gp_can_user', $verdict, $filter_args );
 	}
 
 	function get_meta( $key ) {

--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -106,7 +106,7 @@ class GP_Builtin_Translation_Warnings {
 	}
 
 	function warning_placeholders( $original, $translation, $locale ) {
-		$placeholders_re = apply_filters( 'warning_placeholders_re', '%(\d+\$(?:\d+)?)?[bcdefgosuxEFGX]' );
+		$placeholders_re = apply_filters( 'gp_warning_placeholders_re', '%(\d+\$(?:\d+)?)?[bcdefgosuxEFGX]' );
 
 		$original_counts = $this->_placeholders_counts( $original, $placeholders_re );
 		$translation_counts = $this->_placeholders_counts( $translation, $placeholders_re );

--- a/gp-templates/header.php
+++ b/gp-templates/header.php
@@ -30,7 +30,7 @@ gp_enqueue_script( 'jquery' );
 			<?php else: ?>
 				<strong><a href="<?php echo gp_url_login(); ?>"><?php _e('Log in'); ?></a></strong>
 			<?php endif; ?>
-			<?php do_action( 'after_hello' ); ?>
+			<?php do_action( 'gp_after_hello' ); ?>
 			</span>
 			<div class="clearfix"></div>
 		</h1>
@@ -45,4 +45,4 @@ gp_enqueue_script( 'jquery' );
 				<?php echo gp_notice(); ?>
 			</div>
 		<?php endif; ?>
-		<?php do_action( 'after_notices' ); ?>
+		<?php do_action( 'gp_after_notices' ); ?>

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -103,7 +103,7 @@ function display_status( $status ) {
 }
 
 function references( $project, $entry ) {
-	$show_references = apply_filters( 'show_references', (bool) $entry->references, $project, $entry );
+	$show_references = apply_filters( 'gp_show_references', (bool) $entry->references, $project, $entry );
 
 	if ( ! $show_references ) return;
 	?>

--- a/gp-templates/project.php
+++ b/gp-templates/project.php
@@ -13,7 +13,7 @@ gp_tmpl_header();
 ?>
 <h2><?php echo esc_html( $project->name ); ?> <?php echo $edit_link; ?></h2>
 <p class="description">
-	<?php echo apply_filters( 'project_description', $project->description, $project );?>
+	<?php echo apply_filters( 'gp_project_description', $project->description, $project );?>
 </p>
 
 <?php if ( $can_write ): ?>
@@ -67,7 +67,7 @@ gp_tmpl_header();
 							array('filters[translated]' => 'yes', 'filters[status]' => 'waiting') ), $set->waiting_count ); ?></td>
 				<?php if ( has_action( 'project_template_translation_set_extra' ) ) : ?>
 				<td class="extra">
-					<?php do_action( 'project_template_translation_set_extra', $set, $project ); ?>
+					<?php do_action( 'gp_project_template_translation_set_extra', $set, $project ); ?>
 				</td>
 				<?php endif; ?>
 			</tr>
@@ -91,7 +91,7 @@ gp_tmpl_header();
 		<?php if ( $sub_project->active ) echo "<span class='active bubble'>" . __('Active') . "</span>"; ?>
 	</dt>
 	<dd>
-		<?php echo esc_html( gp_html_excerpt( apply_filters( 'sub_project_description', $sub_project->description, $sub_project ), 111 ) ); ?>
+		<?php echo esc_html( gp_html_excerpt( apply_filters( 'gp_sub_project_description', $sub_project->description, $sub_project ), 111 ) ); ?>
 	</dd>
 <?php endforeach; ?>
 </dl>

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -137,7 +137,7 @@ $i = 0;
 			), gp_array_get( $sort, 'how', $default_sort['how'] ) );
 		?>
 		</dd>
-		<?php do_action( 'translation_set_filters' );?>
+		<?php do_action( 'gp_translation_set_filters' );?>
 		<dd><input type="submit" value="<?php echo esc_attr(__('Sort')); ?>" name="sorts" /></dd>
 	</dl>
 </form>
@@ -200,7 +200,7 @@ $i = 0;
 		/* translators: 1: export 2: what to export dropdown (all/filtered) 3: export format */
 		$footer_links[] = sprintf( __('%1$s %2$s as %3$s'), $export_link, $what_dropdown, $format_dropdown );
 
-		echo implode( ' &bull; ', apply_filters( 'translations_footer_links', $footer_links, $project, $locale, $translation_set ) );
+		echo implode( ' &bull; ', apply_filters( 'gp_translations_footer_links', $footer_links, $project, $locale, $translation_set ) );
 	?>
 </p>
 <?php gp_tmpl_footer();

--- a/t/tests/tests_things/test_thing_translation_set.php
+++ b/t/tests/tests_things/test_thing_translation_set.php
@@ -80,9 +80,9 @@ class GP_Test_Thing_Translation_set extends GP_UnitTestCase {
 		$translations_for_import = new Translations;
 		$translations_for_import->add_entry( array( 'singular' => 'A string', 'translations' => array( 'abab' ) ) );
 
-		add_filter( 'translation_set_import_over_existing', '__return_false' );
+		add_filter( 'gp_translation_set_import_over_existing', '__return_false' );
 		$translations_added = $set->import( $translations_for_import );
-		remove_filter( 'translation_set_import_over_existing', '__return_false' );
+		remove_filter( 'gp_translation_set_import_over_existing', '__return_false' );
 
 		$this->assertEquals( $translations_added, 0 );
 	}


### PR DESCRIPTION
The GlotPress action/filters currently are a mix of "action_desc_here" and "gp_action_desc_here".

To avoid conflicts with other WordPress plugins, we should prefix all action/filters in GlotPress with "gp_" (that are GlotPress action/filters of course, not WordPress action/filters the plugin will use).

This resolves issue #33.
Replaces pull request #37.
