### PR TITLE
Convert gp plugin system

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -65,6 +65,4 @@ You will need to install phpunit: http://www.phpunit.de/manual/current/en/instal
 - templates: links function
 - tests
 - init phase
-- plugins: where to put
-- plugins: GP_Plugin base class
 - API calls

--- a/gp-includes/gp.php
+++ b/gp-includes/gp.php
@@ -18,10 +18,4 @@ class GP {
 	public static $builtin_translation_warnings;
 	public static $current_route = null;
 	public static $formats;
-	// plugins can use this space
-	public static $vars = array();
-	// for plugin singletons
-	public static $plugins;
 }
-
-GP::$plugins = new stdClass();

--- a/gp-includes/meta.php
+++ b/gp-includes/meta.php
@@ -338,7 +338,6 @@ function gp_cache_all_options()
 		'page_topics',
 		'edit_lock',
 		'gp_active_theme',
-		'active_plugins',
 		'mod_rewrite',
 		'datetime_format',
 		'date_format',

--- a/gp-settings.php
+++ b/gp-settings.php
@@ -9,10 +9,6 @@ if ( !defined( 'GP_LANG_PATH' ) ) {
 	define( 'GP_LANG_PATH', GP_PATH . 'languages/' );
 }
 
-if ( !defined( 'GP_PLUGINS_PATH' ) ) {
-	define( 'GP_PLUGINS_PATH', GP_PATH . 'plugins/' );
-}
-
 if ( !defined( 'DATE_MYSQL' ) ) {
 	define( 'DATE_MYSQL', 'Y-m-d H:i:s' );
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,11 +12,7 @@
 	<filter>
 		<blacklist>
 			<directory suffix=".php">gp-templates</directory>
-			<directory suffix=".php">plugins</directory>
 			<directory suffix=".php">t</directory>
-			<exclude>
-				<directory suffix=".php">../plugins/google-translate</directory>
-			</exclude>
 		</blacklist>
 	</filter>
 </phpunit>


### PR DESCRIPTION
The majority of the GlotPress plugin has already been removed from the plugin code, this PR cleans up a few outstanding items.
1. Remove the GP_PLUGINS_PATH define as it is no longer required.
2.Remove $plugins and $vars from the GP class definition as it is no longer required.
3.Remove active_plugins from base options list as plugin activation is handled by WordPress now.

Resolves issue #7.
Replaces PR #34.

In addition, I've converted the Google Translate plugin and included some notes on how to convert a GP standalone plugin to a GP as a plugin WordPress plugin. I've published the new plugin on GitHub.

Note: I didn't convert the Google Translate that comes with GlotPress as I maintain an "improved" version separately, so I converted that one instead.
