### PR TITLE
Fix wp_localize_script handle names that were missed 

### DIFF
--- a/gp-templates/glossary-view.php
+++ b/gp-templates/glossary-view.php
@@ -11,7 +11,7 @@ $delete_url       = $url . '/-delete';
 $glossary_options = compact( 'can_edit', 'url', 'delete_url', 'ge_delete_ays' );
 
 gp_enqueue_script( 'gp-glossary' );
-wp_localize_script( 'glossary', '$gp_glossary_options', $glossary_options );
+wp_localize_script( 'gp-glossary', '$gp_glossary_options', $glossary_options );
 
 gp_tmpl_header();
 ?>

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -12,7 +12,7 @@ wp_localize_script( 'gp-translations-page', '$gp_translations_options', array( '
 // localizer adds var in front of the variable name, so we can't use $gp.editor.options
 $editor_options = compact('can_approve', 'can_write', 'url', 'discard_warning_url', 'set_priority_url', 'set_status_url');
 
-wp_localize_script( 'editor', '$gp_editor_options', $editor_options );
+wp_localize_script( 'gp-editor', '$gp_editor_options', $editor_options );
 
 gp_tmpl_header();
 $i = 0;


### PR DESCRIPTION
Resolves Issue #53. 

Two wp_localize_script() handles are wrong, one on the editor page and the other on the glossary page which causes some javascripts to fail (like saving translation strings).

This patch updates the handles to the new ones with gp- prepended to them.
