### PR TITLE
Add code to flush the rewrite rules if required during plugin init.

### DIFF
--- a/glotpress.php
+++ b/glotpress.php
@@ -40,6 +40,8 @@ require_once GP_PATH . 'gp-settings.php';
 
 /**
  * Perform necessary actions on activation
+ *
+ * @since 1.0.0
  */
 function gp_activate_plugin() {
     $admins = GP::$permission->find_one( array( 'action' => 'admin' ) );
@@ -48,6 +50,17 @@ function gp_activate_plugin() {
     }
 }
 register_activation_hook( GP_PLUGIN_FILE, 'gp_activate_plugin' );
+
+/**
+ * Run the plugin de-activation code.
+ *
+ * @since 1.0.0
+ */
+function gp_deactivate_plugin() {
+	// Flush the rewrite rule option so it will be re-generated next time the plugin is activated.
+	update_option( 'gp_rewrite_rule', '' );
+}
+register_deactivation_hook( GP_PLUGIN_FILE, 'gp_deactivate_plugin' );
 
 // Load the plugin's translated strings
 load_plugin_textdomain( 'glotpress', false, dirname( plugin_basename( GP_PLUGIN_FILE ) ) . '/languages/' );

--- a/glotpress.php
+++ b/glotpress.php
@@ -55,10 +55,28 @@ register_activation_hook( GP_PLUGIN_FILE, 'gp_activate_plugin' );
  * Run the plugin de-activation code.
  *
  * @since 1.0.0
+ *
+ * @param bool $network_wide Whether the plugin is deactivated for all sites in the network
+ *                           or just the current site.
  */
-function gp_deactivate_plugin() {
-	// Flush the rewrite rule option so it will be re-generated next time the plugin is activated.
-	update_option( 'gp_rewrite_rule', '' );
+function gp_deactivate_plugin( $network_wide ) {
+
+	/*
+	 * Flush the rewrite rule option so it will be re-generated next time the plugin is activated.
+	 * If network deactivating, ensure we flush the option on every site.
+	 */
+	if ( $network_wide ) {
+		$sites = wp_get_sites();
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+			update_option( 'gp_rewrite_rule', '' );
+			restore_current_blog();
+		}
+	} else {
+		update_option( 'gp_rewrite_rule', '' );
+	}
+
 }
 register_deactivation_hook( GP_PLUGIN_FILE, 'gp_deactivate_plugin' );
 

--- a/gp-includes/rewrite.php
+++ b/gp-includes/rewrite.php
@@ -51,7 +51,7 @@ function gp_rewrite_rules() {
 	 */
 	if ( $match_regex != get_option( 'gp_rewrite_rule' ) ) {
 		update_option( 'gp_rewrite_rule', $match_regex );
-		flush_rewrite_rules();
+		flush_rewrite_rules( false );
 	}
 }
 

--- a/gp-includes/rewrite.php
+++ b/gp-includes/rewrite.php
@@ -3,25 +3,56 @@
  * Defines WordPress rewrites and query vars
  */
 
+
 /**
- * Add WP rewrite rules to avoid WP thinking that GP pages are 404
+ * Generate the WP rewrite rules.
+ *
+ * @since 1.0.0
+ */
+function gp_generate_rewrite_rules( $gp_base = false ) {
+	if ( false === $gp_base ) {
+		$gp_base = trim( gp_url_base_path(), '/' );
+	}
+
+	if ( ! $gp_base ) {
+		$match_regex = '^(.*)$';
+	} else {
+		$match_regex = '^' . $gp_base . '/?(.*)$';
+	}
+
+	return $match_regex;
+}
+
+/**
+ * Add WP rewrite rules to avoid WP thinking that GP pages are 404.
  *
  * @since 1.0.0
  */
 function gp_rewrite_rules() {
-    $gp_base = trim( gp_url_base_path(), '/' );
+	$gp_base = trim( gp_url_base_path(), '/' );
 
-    if ( ! $gp_base ) {
-        // When GlotPress is set to take over the root of the site,
-        // add a special rule that WordPress uses to route requests to root.
-        add_rewrite_rule( '$', 'index.php?gp_route', 'top' );
+	if ( ! $gp_base ) {
+		/*
+		 * When GlotPress is set to take over the root of the site,
+		 * add a special rule that WordPress uses to route requests to root.
+		 */
+		add_rewrite_rule( '$', 'index.php?gp_route', 'top' );
+	}
 
-        $match_regex = '^(.*)$';
-    } else {
-        $match_regex = '^' . $gp_base . '/?(.*)$';
-    }
+	$match_regex = gp_generate_rewrite_rules();
 
-    add_rewrite_rule( $match_regex, 'index.php?gp_route=$matches[1]', 'top' );
+	add_rewrite_rule( $match_regex, 'index.php?gp_route=$matches[1]', 'top' );
+
+	/*
+	 * Check to see if the rewrite rule has changed, if so, update the option
+	 * and flush the rewrite rules.
+	 * Save the rewrite rule to an option so we have something to compare against later.
+	 * We don't need to worry about the root rewrite rule above as it is always the same.
+	 */
+	if ( $match_regex != get_option( 'gp_rewrite_rule' ) ) {
+		update_option( 'gp_rewrite_rule', $match_regex );
+		flush_rewrite_rules();
+	}
 }
 
 /**

--- a/gp-includes/rewrite.php
+++ b/gp-includes/rewrite.php
@@ -39,7 +39,7 @@ function gp_rewrite_rules() {
 		add_rewrite_rule( '$', 'index.php?gp_route', 'top' );
 	}
 
-	$match_regex = gp_generate_rewrite_rules();
+	$match_regex = gp_generate_rewrite_rules( $gp_base );
 
 	add_rewrite_rule( $match_regex, 'index.php?gp_route=$matches[1]', 'top' );
 


### PR DESCRIPTION
This also changes our init code to a lower priority so other plugins can add their rewrite rules before we execute the flush.

Resolves #21.
