### PR TITLE
Add the breadcrumbs to the projects and locales pages 

### DIFF
--- a/gp-templates/locales.php
+++ b/gp-templates/locales.php
@@ -3,6 +3,7 @@ gp_title( __( 'Locales &lt; GlotPress', 'glotpress' ) );
 
 gp_enqueue_script( 'gp-common' );
 gp_enqueue_script( 'tablesorter' );
+gp_breadcrumb( array( __( 'Locales', 'glotpress' ) ) );
 gp_tmpl_header();
 ?>
 

--- a/gp-templates/projects.php
+++ b/gp-templates/projects.php
@@ -1,5 +1,6 @@
 <?php
 gp_title( __( 'Projects &lt; GlotPress', 'glotpress' ) );
+gp_breadcrumb( array( __( 'Projects', 'glotpress' ) ) );
 gp_tmpl_header();
 ?>
 


### PR DESCRIPTION
to be consistent and display the gp_notices correctly.

Resolves #96.
