### PR TITLE
Add hooks for plugins

### DIFF
--- a/gp-includes/default-filters.php
+++ b/gp-includes/default-filters.php
@@ -1,7 +1,10 @@
 <?php
 /**
- * Filters and actions assigned by default
+ * Filters and actions assigned by default.
  */
+
+// Actions
+add_action( 'init', 'gp_init' );
 
 // Styles and scripts
 add_action( 'gp_head', 'wp_enqueue_scripts' );
@@ -10,5 +13,5 @@ add_action( 'gp_head', 'gp_print_scripts' );
 
 // Rewrite rules
 add_filter( 'query_vars', 'gp_query_vars' );
-add_action( 'init', 'gp_rewrite_rules' );
 add_action( 'template_redirect', 'gp_run_route' );
+

--- a/gp-includes/system.php
+++ b/gp-includes/system.php
@@ -13,3 +13,19 @@ function gp_set_globals( $vars ) {
 		$GLOBALS[ $name ] = $value;
 	}
 }
+
+/**
+ * Initializes rewrite rules and provides the 'gp_init' action.
+ *
+ * @since 1.0.0
+ */
+function gp_init() {
+	gp_rewrite_rules();
+
+	/**
+	 * Fires after GlotPress has finished loading but before any headers are sent.
+	 *
+	 * @since 1.0.0
+	 */
+	do_action( 'gp_init' );
+}


### PR DESCRIPTION
Add three hooks for plugins to use:
1. gp_loaded - fires after all GP functions have loaded but before the upgrade script.
2. gp_init - fires on the WP init hook but after the rewrite rules have been registered.
3. gp_plugins_loaded - fires on the WP plugins_loaded hook.

Resolves #107.
