### PR TITLE
Idea: Use `current_user_can()` and custom capabilities

### DIFF
--- a/gp-includes/advanced-permissions.php
+++ b/gp-includes/advanced-permissions.php
@@ -1,6 +1,161 @@
 <?php
 
 /**
+ *
+ * @param array  $caps    Returns the user's actual capabilities.
+ * @param string $cap     Capability name.
+ * @param int    $user_id The user ID.
+ * @param array  $args    Adds the context to the cap. Typically the object ID.
+ * @return array Actual capabilities for meta capability.
+ */
+function gp_map_meta_cap( $caps, $cap, $user_id, $args ) {
+	switch ( $cap ) {
+		case 'gp_create_projects':
+		case 'gp_delete_projects':
+		case 'gp_delete_project':
+		case 'gp_edit_projects':
+		case 'gp_edit_project':
+			array_pop( $caps );
+
+			$caps[] = 'manage_options';
+			break;
+
+		case 'gp_suggest_translations':
+			array_pop( $caps );
+
+			if ( $user_id ) {
+				$caps[] = 'gp_suggest_translations';
+			} else {
+				$caps[] = 'do_not_allow';
+			}
+			break;
+
+		case 'gp_approve_translations':
+			array_pop( $caps );
+
+			if ( ! isset( $args[0] ) ) { // ID of a translation set.
+				$caps[] = 'do_not_allow';
+				break;
+			}
+
+			$translation_set = GP::$translation_set->get( $args[0] );
+			if ( ! $translation_set ) {
+				$caps[] = 'do_not_allow';
+				break;
+			}
+
+			$permission_args = array(
+				'user_id'     => $user_id,
+				'action'      => 'approve',
+				'object_type' => GP::$validator_permission->object_type,
+				'object_id'   => GP::$validator_permission->object_id( $translation_set->project_id, $translation_set->locale, $translation_set->slug )
+			);
+
+			$has_permission =
+				GP::$permission->find_one( array( 'action' => 'admin', 'user_id' => $user_id ) ) ||
+				GP::$permission->find_one( $permission_args );
+
+			if ( $has_permission ) {
+				$caps[] = 'gp_approve_translations';
+			} else {
+				$caps[] = 'do_not_allow';
+			}
+			break;
+
+		case 'gp_create_glossary_entry':
+		case 'gp_edit_glossary':
+			array_pop( $caps );
+
+			if ( ! isset( $args[0] ) ) { // ID of a glossary
+				$caps[] = 'do_not_allow';
+				break;
+			}
+
+			$glossary = GP::$glossary->get( $args[0] );
+			if ( ! $glossary ) {
+				$caps[] = 'do_not_allow';
+				break;
+			}
+
+			$translation_set = GP::$translation_set->get( $glossary->translation_set_id );
+			if ( ! $translation_set ) {
+				$caps[] = 'do_not_allow';
+				break;
+			}
+
+			$permission_args = array(
+				'user_id'     => $user_id,
+				'action'      => 'approve',
+				'object_type' => GP::$validator_permission->object_type,
+				'object_id'   => GP::$validator_permission->object_id( $translation_set->project_id, $translation_set->locale, $translation_set->slug )
+			);
+
+			$has_permission =
+				GP::$permission->find_one( array( 'action' => 'admin', 'user_id' => $user_id ) ) ||
+				GP::$permission->find_one( $permission_args );
+
+			if ( $has_permission ) {
+				$caps[] = 'gp_edit_glossaries';
+			} else {
+				$caps[] = 'do_not_allow';
+			}
+			break;
+	}
+
+	return $caps;
+}
+add_filter( 'map_meta_cap', 'gp_map_meta_cap', 10, 4 );
+
+/**
+ *
+ * @return array An array of primary capabilities for GlotPress.
+ */
+function gp_get_primary_capabilities() {
+	return array(
+		'gp_create_projects',
+		'gp_delete_projects',
+		'gp_edit_projects',
+
+		'gp_suggest_translations',
+		'gp_approve_translations',
+	//	'gp_import_translations', => gp_approve_translations
+
+	//	'gp_import_originals', => 'gp_edit_projects'
+
+		'gp_create_glossaries',
+		'gp_edit_glossaries',
+		'gp_delete_glossaries',
+
+		'gp_create_glossary_entries',
+		'gp_edit_glossary_entries',
+		'gp_delete_glossary_entries',
+		'gp_import_glossary_entries',
+	);
+}
+
+/**
+ *
+ * @param array   $allcaps An array of all the user's capabilities.
+ * @param array   $caps    Actual capabilities for meta capability.
+ * @param array   $args    Optional parameters passed to has_cap(), typically object ID.
+ * @param WP_User $user    The user object.
+ * @return array An array of all the user's capabilities.
+ */
+function gp_user_has_cap( $allcaps, $caps, $args, $user ) {
+
+	$caps_keyed = array_flip( $caps );
+	$primary_capabilities = gp_get_primary_capabilities();
+	foreach ( $primary_capabilities as $primary_capability ) {
+		if ( array_key_exists( $primary_capability, $caps_keyed ) ) {
+			$allcaps[ $primary_capability ] = true;
+		}
+	}
+
+	return $allcaps;
+}
+add_filter( 'user_has_cap', 'gp_user_has_cap', 10 ,4 );
+
+/**
  * Filter for can_user, which tries if the user
  * has permissions on project parents
  */

--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -76,8 +76,8 @@ class GP_Route {
 		return false;
 	}
 
-	function can( $action, $object_type = null, $object_id = null ) {
-		return GP::$user->current()->can( $action, $object_type, $object_id );
+	function can( $cap, $object_id = null ) {
+		return current_user_can( $cap, $object_id );
 	}
 
 	/**
@@ -88,8 +88,8 @@ class GP_Route {
 	 * @param string $object_id
 	 * @param string $url	The URL to redirect. Default value: referrer or index page, if referrer is missing
 	 */
-	function cannot_and_redirect( $action, $object_type = null, $object_id = null, $url = null ) {
-		$can = $this->can( $action, $object_type, $object_id );
+	function cannot_and_redirect( $cap, $object_id = null, $url = null ) {
+		$can = $this->can( $cap, $object_id );
 		if ( !$can ) {
 			$this->redirect_with_error( __( 'You are not allowed to do that!', 'glotpress' ), $url );
 			return true;
@@ -97,8 +97,8 @@ class GP_Route {
 		return false;
 	}
 
-	function can_or_forbidden( $action, $object_type = null, $object_id = null, $message = 'You are not allowed to do that!' ) {
-		$can = $this->can( $action, $object_type, $object_id );
+	function can_or_forbidden( $cap, $object_id = null, $message = 'You are not allowed to do that!' ) {
+		$can = $this->can( $cap, $object_id );
 		if ( !$can ) {
 			$this->die_with_error( $message, 403 );
 		}

--- a/gp-includes/routes/glossary-entry.php
+++ b/gp-includes/routes/glossary-entry.php
@@ -32,7 +32,7 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 			}
 		}
 
-		$can_edit = $this->can( 'approve', 'translation-set', $translation_set->id );
+		$can_edit = current_user_can( 'gp_create_glossary_entry', $glossary->id );
 		$url      = gp_url_join( gp_url_project_locale( $project_path, $locale_slug, $translation_set_slug ), array('glossary') );
 
 		$this->tmpl( 'glossary-view', get_defined_vars() );
@@ -52,7 +52,7 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
-		if ( $this->cannot_and_redirect( 'approve', 'translation-set', $translation_set->id ) ) {
+		if ( $this->cannot_and_redirect( 'gp_create_glossary_entries', $glossary->id ) ) { // @todo $glossary
 			return;
 		}
 
@@ -87,7 +87,7 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 
 		$glossary        = GP::$glossary->get( $glossary_entry->glossary_id );
 		$translation_set = GP::$translation_set->get( $glossary->translation_set_id );
-		$can_edit        = $this->can( 'approve', 'translation-set', $translation_set->id );
+		$can_edit        = current_user_can( 'gp_edit_glossary_entry', $glossary_entry->id );
 
 		if ( ! $can_edit ) {
 			return $this->die_with_error( __( 'Forbidden', 'glotpress' ), 403 );
@@ -137,7 +137,7 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 
 		$glossary        = GP::$glossary->get( $glossary_entry->glossary_id );
 		$translation_set = GP::$translation_set->get( $glossary->translation_set_id );
-		$can_edit        = $this->can( 'approve', 'translation-set', $translation_set->id );
+		$can_edit        = current_user_can( 'gp_delete_glossary_entry', $glossary_entry->id );
 
 		if ( ! $can_edit ) {
 			return $this->die_with_error( __( 'Forbidden', 'glotpress' ), 403 );
@@ -202,7 +202,7 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
-		if ( $this->cannot_and_redirect( 'approve', 'translation-set', $translation_set->id ) ) {
+		if ( $this->cannot_and_redirect( 'gp_import_glossary_entries', $glossary->id ) ) { // @todo $glossary
 			return;
 		}
 
@@ -229,7 +229,7 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
-		if ( $this->cannot_and_redirect( 'approve', 'translation-set', $translation_set->id ) ) {
+		if ( $this->cannot_and_redirect( 'gp_import_glossary_entries', $glossary->id ) ) { // @todo $glossary
 			return;
 		}
 

--- a/gp-includes/routes/glossary.php
+++ b/gp-includes/routes/glossary.php
@@ -20,7 +20,7 @@ class GP_Route_Glossary extends GP_Route_Main {
 			return;
 		}
 
-		if ( $this->cannot_edit_glossary_and_redirect( $glossary ) ) {
+		if ( ! $this->cannot_and_redirect( 'gp_create_glossary', $glossary->translation_set_id ) ) {
 			return;
 		}
 
@@ -43,7 +43,7 @@ class GP_Route_Glossary extends GP_Route_Main {
 			return;
 		}
 
-		if ( $this->cannot_edit_glossary_and_redirect( $new_glossary ) ) {
+		if ( $this->cannot_and_redirect( 'gp_create_glossary', $new_glossary->translation_set_id ) ) {
 			return;
 		}
 
@@ -68,6 +68,10 @@ class GP_Route_Glossary extends GP_Route_Main {
 			$this->redirect_with_error( __( 'Cannot find glossary.', 'glotpress' ) );
 		}
 
+		if ( $this->cannot_and_redirect( 'gp_edit_glossary', $glossary->id ) ) {
+			return;
+		}
+
 		$translation_set = GP::$translation_set->get( $glossary->translation_set_id );
 		$locale          = GP_Locales::by_slug( $translation_set->locale );
 		$project         = GP::$project->get( $translation_set->project_id );
@@ -79,7 +83,7 @@ class GP_Route_Glossary extends GP_Route_Main {
 		$glossary     = GP::$glossary->get( $glossary_id );
 		$new_glossary = new GP_Glossary( gp_post('glossary') );
 
-		if ( $this->cannot_edit_glossary_and_redirect( $glossary ) ) {
+		if ( $this->cannot_and_redirect( 'gp_edit_glossary', $glossary->id ) ) {
 			return;
 		}
 
@@ -95,9 +99,4 @@ class GP_Route_Glossary extends GP_Route_Main {
 
 		$this->redirect( gp_url_join( gp_url_project( $set_project, array( $translation_set->locale, $translation_set->slug ) ), array('glossary') ) );
 	}
-
-	private function cannot_edit_glossary_and_redirect( $glossary ) {
-		return $this->cannot_and_redirect( 'approve', 'translation-set', $glossary->translation_set_id );
-	}
-
 }

--- a/gp-includes/routes/original.php
+++ b/gp-includes/routes/original.php
@@ -15,7 +15,8 @@ class GP_Route_Original extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
-		$this->can_or_forbidden( 'write', 'project', $project->id );
+		$this->can_or_forbidden( 'gp_edit_project', $project->id );
+
 		$original->priority = gp_post( 'priority' );
 
 		if ( ! $original->validate() ) {

--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -39,7 +39,7 @@ class GP_Route_Project extends GP_Route_Main {
 		$translation_sets = apply_filters( 'gp_translation_sets_sort', $translation_sets );
 
 		$title = sprintf( __( '%s project ', 'glotpress' ), esc_html( $project->name ) );
-		$can_write = $this->can( 'write', 'project', $project->id );
+		$can_write = current_user_can( 'gp_edit_project', $project->id );
 		$this->tmpl( 'project', get_defined_vars() );
 	}
 
@@ -50,7 +50,7 @@ class GP_Route_Project extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
-		if ( $this->cannot_and_redirect( 'write', 'project', $project->id ) ) {
+		if ( $this->cannot_and_redirect( 'gp_edit_project', $project->id ) ) {
 			return;
 		}
 
@@ -72,7 +72,7 @@ class GP_Route_Project extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
-		if ( $this->cannot_and_redirect( 'write', 'project', $project->id ) ) {
+		if ( $this->cannot_and_redirect( 'gp_import_originals', $project->id ) ) {
 			return;
 		}
 
@@ -87,7 +87,7 @@ class GP_Route_Project extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
-		if ( $this->cannot_and_redirect( 'write', 'project', $project->id ) ) {
+		if ( $this->cannot_and_redirect( 'gp_import_originals', $project->id ) ) {
 			return;
 		}
 
@@ -131,7 +131,7 @@ class GP_Route_Project extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
-		if ( $this->cannot_and_redirect( 'write', 'project', $project->id ) ) {
+		if ( $this->cannot_and_redirect( 'gp_edit_project', $project->id ) ) {
 			return;
 		}
 
@@ -145,7 +145,7 @@ class GP_Route_Project extends GP_Route_Main {
 			$this->die_with_404();
 		}
 
-		if ( $this->cannot_and_redirect( 'write', 'project', $project->id ) ) {
+		if ( $this->cannot_and_redirect( 'gp_edit_project', $project->id ) ) {
 			return;
 		}
 
@@ -180,7 +180,7 @@ class GP_Route_Project extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
-		if ( $this->cannot_and_redirect( 'write', 'project', $project->id ) ) {
+		if ( $this->cannot_and_redirect( 'gp_delete_project', $project->id ) ) {
 			return;
 		}
 
@@ -199,7 +199,7 @@ class GP_Route_Project extends GP_Route_Main {
 		$project = new GP_Project();
 		$project->parent_project_id = gp_get( 'parent_project_id', null );
 
-		if ( $this->cannot_and_redirect( 'write', 'project', $project->parent_project_id ) ) {
+		if ( $this->cannot_and_redirect( 'gp_create_projects', $project->parent_project_id ) ) {
 			return;
 		}
 
@@ -210,7 +210,7 @@ class GP_Route_Project extends GP_Route_Main {
 		$post = gp_post( 'project' );
 		$parent_project_id = gp_array_get( $post, 'parent_project_id', null );
 
-		if ( $this->cannot_and_redirect( 'write', 'project', $parent_project_id ) ) {
+		if ( $this->cannot_and_redirect( 'gp_create_projects', $parent_project_id ) ) {
 			return;
 		}
 
@@ -239,7 +239,7 @@ class GP_Route_Project extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
-		if ( $this->cannot_and_redirect( 'write', 'project', $project->id ) ) {
+		if ( $this->cannot_and_redirect( 'gp_edit_project', $project->id ) ) {
 			return;
 		}
 
@@ -273,7 +273,7 @@ class GP_Route_Project extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
-		if ( $this->cannot_and_redirect( 'write', 'project', $project->id ) ) {
+		if ( $this->cannot_and_redirect( 'gp_edit_project', $project->id ) ) {
 			return;
 		}
 
@@ -305,7 +305,7 @@ class GP_Route_Project extends GP_Route_Main {
 			$this->die_with_404();
 		}
 
-		if ( $this->cannot_and_redirect( 'write', 'project', $project->id ) ) {
+		if ( $this->cannot_and_redirect( 'gp_edit_project', $project->id ) ) {
 			return;
 		}
 
@@ -329,7 +329,7 @@ class GP_Route_Project extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
-		if ( $this->cannot_and_redirect( 'write', 'project', $project->id ) ) {
+		if ( $this->cannot_and_redirect( 'gp_edit_project', $project->id ) ) {
 			return;
 		}
 
@@ -342,7 +342,7 @@ class GP_Route_Project extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
-		if ( $this->cannot_and_redirect( 'write', 'project', $project->id ) ) {
+		if ( $this->cannot_and_redirect( 'gp_edit_project', $project->id ) ) {
 			return;
 		}
 
@@ -375,7 +375,7 @@ class GP_Route_Project extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
-		if ( $this->cannot_and_redirect( 'write', 'project', $project->id ) ) {
+		if ( $this->cannot_and_redirect( 'gp_edit_project', $project->id ) ) {
 			return;
 		}
 
@@ -396,7 +396,7 @@ class GP_Route_Project extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
-		if ( $this->cannot_and_redirect( 'write', 'project', $project->id ) ) {
+		if ( $this->cannot_and_redirect( 'gp_edit_project', $project->id ) ) {
 			return;
 		}
 
@@ -414,7 +414,7 @@ class GP_Route_Project extends GP_Route_Main {
 
 		$parent_project_id = gp_array_get( $post, 'parent_project_id', null );
 
-		if ( $this->cannot_and_redirect( 'write', 'project', $parent_project_id ) ) {
+		if ( $this->cannot_and_redirect( 'gp_edit_project', $parent_project_id ) ) {
 			return;
 		}
 

--- a/gp-includes/routes/translation-set.php
+++ b/gp-includes/routes/translation-set.php
@@ -4,13 +4,22 @@ class GP_Route_Translation_Set extends GP_Route_Main {
 		$set = new GP_Translation_Set;
 		$set->project_id = gp_get( 'project_id' );
 		$project = $set->project_id? GP::$project->get( $set->project_id ) : null;
+
+		if ( ! $this->cannot_and_redirect( 'gp_create_translation_sets', $set->project_id ) ) {
+			return;
+		}
+
 		if ( $this->cannot_edit_set_and_redirect( $set ) ) return;
 		$this->tmpl( 'translation-set-new', get_defined_vars() );
 	}
 
 	function new_post() {
 		$new_set = new GP_Translation_Set( gp_post( 'set', array() ) );
-		if ( $this->cannot_edit_set_and_redirect( $new_set ) ) return;
+
+		if ( ! $this->cannot_and_redirect( 'gp_create_translation_sets', $new_set->project_id ) ) {
+			return;
+		}
+
 		if ( $this->invalid_and_redirect( $new_set ) ) return;
 		$created_set = GP::$translation_set->create_and_select( $new_set );
 		if ( $created_set ) $project = GP::$project->get( $created_set->project_id );
@@ -34,7 +43,11 @@ class GP_Route_Translation_Set extends GP_Route_Main {
 		$items = $this->get_set_project_and_locale_from_set_id_or_404( $set_id );
 		if ( !$items ) return;
 		list( $set, $project, $locale ) = $items;
-		if ( $this->cannot_and_redirect( 'write', 'project', $set->project_id, gp_url_project( $project ) ) ) return;
+
+		if ( ! $this->cannot_and_redirect( 'gp_edit_translation_set', $set->id, gp_url_project( $project ) ) ) {
+			return;
+		}
+
 		$url = gp_url_project( $project, gp_url_join( $set->locale, $set->slug ) );
 		$this->tmpl( 'translation-set-edit', get_defined_vars() );
 	}
@@ -43,8 +56,12 @@ class GP_Route_Translation_Set extends GP_Route_Main {
 		$items = $this->get_set_project_and_locale_from_set_id_or_404( $set_id );
 		if ( !$items ) return;
 		list( $set, $project, $locale ) = $items;
+
+		if ( ! $this->cannot_and_redirect( 'gp_edit_translation_set', $set->id ) ) {
+			return;
+		}
+
 		$new_set = new GP_Translation_Set( gp_post( 'set', array() ) );
-		if ( $this->cannot_edit_set_and_redirect( $new_set ) ) return;
 		if ( $this->invalid_and_redirect( $new_set, gp_url( '/sets/-new' ) ) ) return;
 		if ( !$set->update( $new_set ) ) {
 			$this->errors[] = __( 'Error in updating translation set!', 'glotpress' );
@@ -56,9 +73,6 @@ class GP_Route_Translation_Set extends GP_Route_Main {
 		$this->redirect( gp_url_project_locale( $project, $new_set->locale, $new_set->slug ) );
 	}
 
-	private function cannot_edit_set_and_redirect( $set ) {
-		return $this->cannot_and_redirect( 'write', 'project', $set->project_id );
-	}
 
 	private function get_set_project_and_locale_from_set_id_or_404( $set_id ) {
 		$set = GP::$translation_set->get( $set_id );

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -15,7 +15,7 @@ class GP_Route_Translation extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
-		if ( $this->cannot_and_redirect( 'approve', 'translation-set', $translation_set->id ) ) {
+		if ( $this->cannot_and_redirect( 'gp_import_translations', $translation_set->id ) ) {
 			return;
 		}
 
@@ -37,7 +37,7 @@ class GP_Route_Translation extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
-		if ( $this->cannot_and_redirect( 'approve', 'translation-set', $translation_set->id ) ) {
+		if ( $this->cannot_and_redirect( 'gp_import_translations', $translation_set->id ) ) {
 			return;
 		}
 
@@ -136,9 +136,9 @@ class GP_Route_Translation extends GP_Route_Main {
 		$translations = GP::$translation->for_translation( $project, $translation_set, $page, $filters, $sort );
 		$total_translations_count = GP::$translation->found_rows;
 
-		$can_edit = $this->can( 'edit', 'translation-set', $translation_set->id );
-		$can_write = $this->can( 'write', 'project', $project->id );
-		$can_approve = $this->can( 'approve', 'translation-set', $translation_set->id );
+		$can_edit = current_user_can( 'gp_suggest_translations', $translation_set->id );
+		$can_write = current_user_can( 'gp_edit_project', $project->id );
+		$can_approve = current_user_can( 'gp_approve_translations', $translation_set->id );
 		$url = gp_url_project( $project, gp_url_join( $locale->slug, $translation_set->slug ) );
 		$set_priority_url = gp_url( '/originals/%original-id%/set_priority');
 		$discard_warning_url = gp_url_project( $project, gp_url_join( $locale->slug, $translation_set->slug, '-discard-warning' ) );
@@ -163,7 +163,7 @@ class GP_Route_Translation extends GP_Route_Main {
 
 		$translation_set = GP::$translation_set->by_project_id_slug_and_locale( $project->id, $translation_set_slug, $locale_slug );
 
-		$this->can_or_forbidden( 'edit', 'translation-set', $translation_set->id );
+		$this->can_or_forbidden( 'gp_suggest_translations', $translation_set->id );
 
 		if ( ! $translation_set ) {
 			return $this->die_with_404();
@@ -179,10 +179,11 @@ class GP_Route_Translation extends GP_Route_Main {
 				if ( isset( $translations[$i] ) ) $data["translation_$i"] = $translations[$i];
 			}
 
-			if ( $this->can( 'approve', 'translation-set', $translation_set->id ) || $this->can( 'write', 'project', $project->id ) )
+			if ( current_user_can( 'gp_approve_translations', $translation_set->id ) ) {
 				$data['status'] = 'current';
-			else
+			} else {
 				$data['status'] = 'waiting';
+			}
 
 			$original = GP::$original->get( $original_id );
 			$data['warnings'] = GP::$translation_warnings->check( $original->singular, $original->plural, $translations, $locale );
@@ -216,9 +217,9 @@ class GP_Route_Translation extends GP_Route_Main {
 				if ( $translations ) {
 					$t = $translations[0];
 
-					$can_edit = $this->can( 'edit', 'translation-set', $translation_set->id );
-					$can_write = $this->can( 'write', 'project', $project->id );
-					$can_approve = $this->can( 'approve', 'translation-set', $translation_set->id );
+					$can_edit = current_user_can( 'gp_suggest_translations', $translation_set->id );
+					$can_write = current_user_can( 'gp_edit_project', $project->id );
+					$can_approve = current_user_can( 'gp_approve_translations', $translation_set->id );
 					$output[$original_id] = gp_tmpl_get_output( 'translation-row', get_defined_vars() );
 				}
 				else {
@@ -243,7 +244,9 @@ class GP_Route_Translation extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
-		if ( $this->cannot_and_redirect( 'approve', 'translation-set', $translation_set->id ) ) return;
+		if ( $this->cannot_and_redirect( 'gp_approve_translations', $translation_set->id ) ) {
+			return;
+		}
 
 		$bulk = gp_post('bulk');
 		$bulk['row-ids'] = array_filter( explode( ',', $bulk['row-ids'] ) );
@@ -316,7 +319,7 @@ class GP_Route_Translation extends GP_Route_Main {
 
 	function _bulk_set_priority( $project, $locale, $translation_set, $bulk ) {
 
-		if ( $this->cannot_and_redirect( 'write', 'project', $project->id ) ){
+		if ( $this->cannot_and_redirect( 'gp_edit_project', $project->id ) ){
 			return;
 		}
 
@@ -393,9 +396,9 @@ class GP_Route_Translation extends GP_Route_Main {
 		if ( $translations ) {
 			$t = $translations[0];
 
-			$can_edit = $this->can( 'edit', 'translation-set', $translation_set->id );
-			$can_write = $this->can( 'write', 'project', $project->id );
-			$can_approve = $this->can( 'approve', 'translation-set', $translation_set->id );
+			$can_edit = current_user_can( 'gp_suggest_translations', $translation_set->id );
+			$can_write = current_user_can( 'gp_edit_project', $project->id );
+			$can_approve = current_user_can( 'gp_approve_translations', $translation_set->id );
 			$this->tmpl( 'translation-row', get_defined_vars() );
 		} else {
 			return $this->die_with_error( 'Error in retrieving translation!' );
@@ -446,6 +449,6 @@ class GP_Route_Translation extends GP_Route_Main {
 		if ( $can_reject_self ) {
 			return;
 		}
-		$this->can_or_forbidden( 'approve', 'translation-set', $translation->translation_set_id );
+		$this->can_or_forbidden( 'gp_approve_translations', $translation->translation_set_id );
 	}
 }

--- a/gp-includes/template-links.php
+++ b/gp-includes/template-links.php
@@ -42,7 +42,7 @@ function gp_link_project() {
 }
 
 function gp_link_project_edit_get( $project, $text = null, $attrs = array() ) {
-	if ( ! current_user_can( 'manage_options' ) ) {
+	if ( ! current_user_can( 'gp_edit_project', $project->id ) ) {
 		return '';
 	}
 	$text = $text? $text : __( 'Edit', 'glotpress' );
@@ -55,7 +55,7 @@ function gp_link_project_edit() {
 }
 
 function gp_link_project_delete_get( $project, $text = false, $attrs = array() ) {
-	if ( ! current_user_can( 'manage_options' ) ) {
+	if ( ! current_user_can( 'gp_edit_project', $project->id ) ) {
 		return '';
 	}
 	$text = $text? $text : __( 'Delete', 'glotpress' );
@@ -77,9 +77,10 @@ function gp_link_home() {
 }
 
 function gp_link_set_edit_get( $set, $project, $text = false, $attrs = array() ) {
-	if ( ! current_user_can( 'manage_options' ) ) {
+	if ( ! current_user_can( 'gp_edit_translation_set', $set->id ) ) {
 		return '';
 	}
+
 	$text = $text? $text : __( 'Edit', 'glotpress' );
 	return gp_link_get( gp_url( gp_url_join( '/sets', $set->id, '-edit' ) ), $text, gp_attrs_add_class( $attrs, 'action edit' ) );
 }
@@ -90,7 +91,7 @@ function gp_link_set_edit() {
 }
 
 function gp_link_glossary_edit_get( $glossary, $set, $text = false, $attrs = array() ) {
-	if ( ! GP::$user->current()->can( 'approve', 'translation-set', $set->id ) ) {
+	if ( ! current_user_can( 'gp_edit_glossary', $glossary->id ) ) {
 		return '';
 	}
 

--- a/gp-templates/projects.php
+++ b/gp-templates/projects.php
@@ -13,7 +13,7 @@ gp_tmpl_header();
 	</ul>
 
 	<p class="actionlist secondary">
-		<?php if ( current_user_can( 'manage_options' ) ): ?>
+		<?php if ( current_user_can( 'gp_create_projects' ) ): ?>
 			<?php gp_link( gp_url_project( '-new' ), __( 'Create a New Project', 'glotpress' ) ); ?>  &bull;&nbsp;
 		<?php endif; ?>
 


### PR DESCRIPTION
An idea for replacing `GP_User->can()`, see #5, #19.

The idea is to use the WP function [current_user_can()](https://developer.wordpress.org/reference/functions/current_user_can/) and the filters [map_meta_cap](https://developer.wordpress.org/reference/hooks/map_meta_cap/) and [user_has_cap](https://developer.wordpress.org/reference/hooks/user_has_cap/)  to provide an API for different permission systems like custom roles or the current permissions table from GP.

**tldr;** I thought WordPress has proper support for such a case, but it has not.
## Capabilities
### Primary Capabilities

I have identified some primary capabilities. Some of them are used in this PR.
#### Projects
- gp_create_projects
- gp_edit_projects
- gp_delete_projects
#### Originals
- (gp_import_originals => gp_edit_projects)
#### Translation Sets
- gp_create_translation_sets
- gp_edit_translation_sets
- gp_delete_translation_sets
#### Translations
- gp_suggest_translations
- gp_approve_translations
- (gp_import_translations => gp_approve_translations)
#### Glossaries
- gp_create_glossaries
- gp_edit_glossaries
- gp_delete_glossaries
#### Glossary Entries
- gp_create_glossary_entries
- gp_edit_glossary_entries
- gp_delete_glossary_entries
- gp_import_glossary_entries

(The *_import caps are likely meta capabilities.)
### Meta Capabilities

The meta capabilities are used to check permissions on a specific object, like a project, a translation set or a glossary.
#### Projects
- gp_edit_project ($project)
- gp_delete_project ($project)
- gp_import_originals ($project)
#### Translation Sets
- gp_edit_translation_set ($set)
- gp_delete_translation_set ($set)
- gp_import_translations ($set)
#### Glossaries
- gp_create_glossary ($set)
- gp_edit_glossary ($glossary)
- gp_delete_glossary ($glossary)
#### Glossary Entries
- gp_create_glossary_entry ($glossary)
- gp_edit_glossary_entry ($glossary_entry)
- gp_delete_glossary_entry ($glossary_entry)
- gp_import_glossary_entries ($glossary)
## current_user_can()

Each  `$user->can()` can be replaced with `current_user_can()` and one of the capabilities from above. The capability name is more or less the action and the object type combined. The helper methods `GP_Route->can()`, `GP_Route->cannot_and_redirect()`, and `GP_Route->can_or_forbidden()` are changed to only support two arguments, the capability and the object ID.
Because we don't want to ship GP with custom roles which have these capabilities assigned we have to add them dynamically.
That's the fun part:
### map_meta_cap

With the `map_meta_cap` filter we can map our meta capabilities with the primary capabilities. But we can also map our primary caps with primary caps from WP, like `manage_options`. The PR does this for all capabilities for the _project_ object.
For `gp_approve_translations` or `gp_edit_glossary` I'm using the existing permissions system. This can be done for all the other capabilities too.

Note: You'll see a line `array_pop( $caps );`, that's because WP adds the original cap to the `$caps` array if there was no meta caps match, see https://github.com/WordPress/WordPress/blob/4.3/wp-includes/capabilities.php#L1415-L1416.
### user_has_cap

Now we have the required capabilities but the user still has non of the capabilities assigned. Via `user_has_cap` I'm going to add the capability to `$allcaps` if one of GP's capabilities exists in the meta `$cap` array. 
Yes, that's an dirty hack. It requires that _all_ capabilities _must_ be checked in `gp_map_meta_cap()`. If the user hasn't the correct permission you have to add `do_not_allow` to `$caps`.  (Also don't forget `array_pop( $caps );` per above). That's also important because `has_cap()` returns true if the list of caps is empty, see [#core-31518](https://core.trac.wordpress.org/ticket/31518).

---

That's all I have for now. I'd like to know what you think about this approach. Is there something I've missed? What can be done different to improve this idea?

(Note: The PR isn't finished, so please ignore the failing tests and such.)
