### PR TITLE
Remove meta handling from `GP_User`.

### DIFF
--- a/gp-includes/routes/profile.php
+++ b/gp-includes/routes/profile.php
@@ -13,15 +13,14 @@ class GP_Route_Profile extends GP_Route_Main {
 	function profile_post() {
 		if ( isset( $_POST['submit'] ) ) {
 			$per_page = (int) $_POST['per_page'];
-			GP::$user->current()->set_meta( 'per_page', $per_page );
+			update_user_option( get_current_user_id(), 'gp_per_page', $per_page );
 
 			$default_sort = array(
 				'by'  => 'priority',
 				'how' => 'desc'
 			);
 			$user_sort = wp_parse_args( $_POST['default_sort'], $default_sort );
-
-			GP::$user->current()->set_meta( 'default_sort', $user_sort );
+			update_user_option( get_current_user_id(), 'gp_default_sort', $user_sort );
 		}
 
 		$this->redirect( gp_url( '/profile' ) );

--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -55,13 +55,14 @@ class GP_Route_Project extends GP_Route_Main {
 		}
 
 		$user = GP::$user->current();
-		$source_url_templates = $user->get_meta( 'source_url_templates' );
+		$source_url_templates = get_user_meta( get_current_user_id(), 'gp_source_url_templates', true );
 		if ( !is_array( $source_url_templates ) ) $source_url_templates = array();
 		$source_url_templates[$project->id] = gp_post( 'source-url-template' );
-		if ( $user->set_meta( 'source_url_templates', $source_url_templates ) )
+		if ( update_user_meta( get_current_user_id(), 'gp_source_url_templates', $source_url_templates ) ) {
 			$this->notices[] = 'Source URL template was successfully updated.';
-		else
+		} else {
 			$this->errors[] = 'Error in updating source URL template.';
+		}
 		$this->redirect( gp_url_project( $project ) );
 	}
 

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -127,7 +127,7 @@ class GP_Route_Translation extends GP_Route_Main {
 			add_filter( 'gp_pagination', '__return_null' );
 		}
 
-		$per_page = GP::$user->current()->get_meta('per_page');
+		$per_page = get_user_option( 'gp_per_page' );
 		if ( 0 == $per_page )
 			$per_page = GP::$translation->per_page;
 		else

--- a/gp-includes/things/project.php
+++ b/gp-includes/things/project.php
@@ -123,7 +123,7 @@ class GP_Project extends GP_Thing {
 		if ( isset( $this->user_source_url_template ) )
 			return $this->user_source_url_template;
 		else {
-			if ( $this->id && is_user_logged_in() && ($templates = GP::$user->current()->get_meta( 'source_url_templates' ))
+			if ( $this->id && is_user_logged_in() && ( $templates = get_user_meta( get_current_user_id(), 'gp_source_url_templates', true ) )
 					 && isset( $templates[$this->id] ) ) {
 				$this->user_source_url_template = $templates[$this->id];
 				return $this->user_source_url_template;

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -86,7 +86,13 @@ class GP_Translation extends GP_Thing {
 			'random' => 'o.priority DESC, RAND()', 'translation_date_added' => 't.date_added %s', 'original_date_added' => 'o.date_added %s',
 			'references' => 'o.references' );
 
-		$default_sort = GP::$user->current()->sort_defaults();
+		$default_sort = get_user_option( 'gp_default_sort' );
+		if ( ! is_array( $default_sort ) ) {
+			$default_sort = array(
+				'by'  => 'priority',
+				'how' => 'desc'
+			);
+		}
 
 		$sort_by = gp_array_get( $sort_bys, gp_array_get( $sort, 'by' ),  gp_array_get( $sort_bys, $default_sort['by'] ) );
 		$sort_hows = array('asc' => 'ASC', 'desc' => 'DESC', );

--- a/gp-includes/things/user.php
+++ b/gp-includes/things/user.php
@@ -82,38 +82,6 @@ class GP_User extends GP_Thing {
 		return apply_filters( 'gp_can_user', $verdict, $filter_args );
 	}
 
-	function get_meta( $key ) {
-		if ( !$user = get_userdata( $this->id ) ) {
-			return;
-		}
-
-		if ( !isset( $user->$key ) ) {
-			return;
-		}
-		return $user->$key;
-	}
-
-	function set_meta( $key, $value ) {
-		return gp_update_meta( $this->id, $key, $value, 'user' );
-	}
-
-	function delete_meta( $key ) {
-		return gp_delete_meta( $this->id, $key, '', 'user' );
-	}
-
-	public function sort_defaults() {
-		$defaults = $this->get_meta('default_sort');
-
-		if ( ! is_array( $defaults ) ) {
-			$defaults = array(
-				'by' => 'priority',
-				'how' => 'desc'
-			);
-		}
-
-		return $defaults;
-	}
-
 	public function get_recent_translation_sets( $amount = 5 ) {
 		global $wpdb;
 

--- a/gp-templates/profile.php
+++ b/gp-templates/profile.php
@@ -3,11 +3,18 @@ gp_title( __( 'Profile &lt; GlotPress', 'glotpress' ) );
 gp_breadcrumb( array( __( 'Profile', 'glotpress' ) ) );
 gp_tmpl_header();
 
-$per_page = GP::$user->current()->get_meta('per_page');
-if ( 0 == $per_page )
+$per_page = get_user_option( 'gp_per_page' );
+if ( 0 == $per_page ) {
 	$per_page = 15;
+}
 
-$default_sort = GP::$user->current()->sort_defaults();
+$default_sort = get_user_option( 'gp_default_sort' );
+if ( ! is_array( $default_sort ) ) {
+	$default_sort = array(
+		'by'  => 'priority',
+		'how' => 'desc'
+	);
+}
 ?>
 <h2><?php _e( 'Profile', 'glotpress' ); ?></h2>
 <form action="" method="post">

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -114,7 +114,13 @@ $i = 0;
 		<dt><?php _x( 'By:', 'sort by', 'glotpress' ); ?></dt>
 		<dd>
 		<?php
-		$default_sort = GP::$user->current()->sort_defaults();
+		$default_sort = get_user_option( 'gp_default_sort' );
+		if ( ! is_array( $default_sort ) ) {
+			$default_sort = array(
+				'by'  => 'priority',
+				'how' => 'desc'
+			);
+		}
 
 		echo gp_radio_buttons('sort[by]',
 			array(

--- a/tests/test_user.php
+++ b/tests/test_user.php
@@ -33,23 +33,4 @@ class GP_Test_User extends GP_UnitTestCase {
 		$this->assertFalse( $nonadmin_user->can( 'milk', 'a cow' ) );
 		$this->assertFalse( $nonadmin_user->can( 'milk', 'a cow', 5 ) );
 	}
-
-	function test_set_meta_should_set_meta() {
-		$user = $this->factory->user->create();
-		$user->set_meta( 'int', 5 );
-		$this->assertEquals( 5, $user->get_meta( 'int') );
-	}
-
-	function test_delete_meta_should_delete_the_meta() {
-		$user = $this->factory->user->create();
-		$user->set_meta( 'int', 5 );
-		$user->delete_meta( 'int' );
-		$this->assertEquals( null, $user->get_meta( 'int') );
-	}
-
-	function test_setting_array_value_as_meta_should_come_out_as_an_array() {
-		$user = $this->factory->user->create();
-		$user->set_meta( 'mixed', array(1, 2, 3) );
-		$this->assertEquals( array(1, 2, 3), $user->get_meta( 'mixed' ) );
-	}
 }


### PR DESCRIPTION
Instead use `get_user_option()` and `update_user_option()` to support also per Network settings.

`gp_source_url_templates` is an exception because it keys the setting by project IDs which aren't unique in a Network.

See #5.
