### PR TITLE
Remove references to `clean_url()`.

### DIFF
--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -263,8 +263,7 @@ class GP_Route_Translation extends GP_Route_Main {
 			$this->errors[] = 'No translations were supplied.';
 		}
 
-		// hack, until we make clean_url() to allow [ and ]
-		$bulk['redirect_to'] = str_replace( array('[', ']'), array_map('urlencode', array('[', ']')), $bulk['redirect_to']);
+		$bulk['redirect_to'] = esc_url_raw( $bulk['redirect_to'] );
 		$this->redirect( $bulk['redirect_to'] );
 	}
 

--- a/gp-includes/template-links.php
+++ b/gp-includes/template-links.php
@@ -10,8 +10,8 @@ function gp_link_get( $url, $text, $attrs = array() ) {
 	}
 	$attributes = gp_html_attributes( $attrs );
 	$attributes = $attributes? " $attributes" : '';
-	// TODO: clean_url(), but make it allow [ and ]
-	return sprintf('%1$s<a href="%2$s"%3$s>%4$s</a>%5$s', $before, esc_attr( $url ), $attributes, $text, $after );
+
+	return sprintf('%1$s<a href="%2$s"%3$s>%4$s</a>%5$s', $before, esc_url( $url ), $attributes, $text, $after );
 }
 
 function gp_link() {

--- a/tests/test_links.php
+++ b/tests/test_links.php
@@ -25,8 +25,7 @@ class GP_Test_Links extends GP_UnitTestCase {
 
 	function test_gp_link_get_escape() {
 		$this->assertEquals( '<a href="http://dir.bg/">Baba & Dyado</a>', gp_link_get( 'http://dir.bg/', 'Baba & Dyado' ) );
-		// clean_url() is too restrictive, so it isn't called
-		//$this->assertEquals( '<a href="http://dir.bg/?x=5&#038;y=11">Baba</a>', gp_link_get( 'http://dir.bg/?x=5&y=11', 'Baba' ) );
+		$this->assertEquals( '<a href="http://dir.bg/?x=5&#038;y=11">Baba</a>', gp_link_get( 'http://dir.bg/?x=5&y=11', 'Baba' ) );
 		$this->assertEquals( '<a href="http://dir.bg/" a="&quot;">Baba</a>', gp_link_get( 'http://dir.bg/', 'Baba', array( 'a' => '"') ) );
 	}
 }


### PR DESCRIPTION
`clean_url()` is now `esc_url()` (or `esc_url_raw()`) which can handle more characters, like square brackets.

Fixes #147.
