### PR TITLE
Add info to the Readme about how to access GlotPress

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ $ cd /your/wordpress/folder/wp-content/plugins/
 $ git clone git@github.com:deliciousbrains/GlotPress.git glotpress
 ```
 
+After activating the plugin, GlotPress can be accessed via `<home_url>/glotpress/`
+
+To access GlotPress under a different path, modify the `GP_URL_BASE` constant in `wp-config.php`, for example to run it in /, you'd add
+
+```
+define( 'GP_URL_BASE', '/' );
+```
+
 ## Communication
 
 * [WordPress Slack](https://chat.wordpress.org/): #glotpress

--- a/readme.txt
+++ b/readme.txt
@@ -28,10 +28,17 @@ This plugin wouldn't be possible without all the hard work that has gone in to t
 
 Search for "GlotPress" and install it.
 
+After activating the plugin, GlotPress can be accessed via `<home_url>/glotpress/`
+
 = Manual Installation =
 
 1. Upload the entire `/glotpress` directory to the `/wp-content/plugins/` directory.
 2. Activate GlotPress through the 'Plugins' menu in WordPress.
+3. GlotPress can then be accessed via `<home_url>/glotpress/`
+
+To access GlotPress under a different path, modify the `GP_URL_BASE` constant in `wp-config.php`, for example to run it in /, you'd add
+
+`define( 'GP_URL_BASE', '/' );`
 
 == Frequently Asked Questions ==
 = How can I contribute to GlotPress? =


### PR DESCRIPTION
Currently the docs leave new users in the dark where to access GlotPress after activating the plugin.

This PR adds this information, and also mentions the `GP_URL_BASE` constant to be used, if for example the plugin is installed in order to replace the WordPress site.
