### PR TITLE
99: Merge similar translation strings and avoid using HTML tags in translation strings

### DIFF
--- a/gp-includes/routes/glossary.php
+++ b/gp-includes/routes/glossary.php
@@ -8,7 +8,7 @@ class GP_Route_Glossary extends GP_Route_Main {
 		$translation_set = $glossary->translation_set_id ? GP::$translation_set->get( $glossary->translation_set_id ) : null;
 
 		if ( ! $translation_set ) {
-			$this->redirect_with_error( __( 'Cannot find translation set with this ID.', 'glotpress' ) );
+			$this->redirect_with_error( __( 'Couldn&#8217;t find translation set with this ID.', 'glotpress' ) );
 			return;
 		}
 
@@ -34,7 +34,7 @@ class GP_Route_Glossary extends GP_Route_Main {
 		$translation_set = $new_glossary->translation_set_id ? GP::$translation_set->get( $new_glossary->translation_set_id ) : null;
 
 		if ( ! $translation_set ) {
-			$this->redirect_with_error( __( 'Cannot find translation set with this ID.', 'glotpress' ), gp_url( '/glossaries/-new', array( 'translation_set_id' => $new_glossary->translation_set_id ) ) );
+			$this->redirect_with_error( __( 'Couldn&#8217;t find translation set with this ID.', 'glotpress' ), gp_url( '/glossaries/-new', array( 'translation_set_id' => $new_glossary->translation_set_id ) ) );
 			return;
 		}
 

--- a/gp-includes/template.php
+++ b/gp-includes/template.php
@@ -434,7 +434,7 @@ function gp_project_options_form( $project ) {
 					<dd>
 						<input type="text" value="' . esc_html( $project->source_url_template() ) . '" name="source-url-template" id="source-url-template" />
 						<small>' . sprintf(
-							__( 'Public URL to a source file in the project. You can use %1$s and %2$s. Ex. %3$s', 'glotpress' ),
+							__( 'URL to a source file in the project. You can use %1$s and %2$s. Ex. %3$s', 'glotpress' ),
 							'<code>%file%</code>',
 							'<code>%line%</code>',
 							'<code>https://trac.example.org/browser/%file%#L%line%</code>'

--- a/gp-includes/template.php
+++ b/gp-includes/template.php
@@ -433,7 +433,12 @@ function gp_project_options_form( $project ) {
 					<dt><label for="source-url-template">' . __( 'Source file URL', 'glotpress' ) . '</label></dt>
 					<dd>
 						<input type="text" value="' . esc_html( $project->source_url_template() ) . '" name="source-url-template" id="source-url-template" />
-						<small>' . __( 'URL to a source file in the project. You can use <code>%file%</code> and <code>%line%</code>. Ex. <code>https://trac.example.org/browser/%file%#L%line%</code>', 'glotpress' ) .'</small>
+						<small>' . sprintf(
+							__( 'Public URL to a source file in the project. You can use %1$s and %2$s. Ex. %3$s', 'glotpress' ),
+							'<code>%file%</code>',
+							'<code>%line%</code>',
+							'<code>https://trac.example.org/browser/%file%#L%line%</code>'
+						) . '</small>
 					</dd>
 				</dl>
 				<p>

--- a/gp-includes/validation.php
+++ b/gp-includes/validation.php
@@ -90,9 +90,9 @@ class GP_Validation_Rules {
 		}
 
 		if ( 'positive' == $rule['kind'] )
-			return sprintf( __( 'The %s <strong>%s</strong> is invalid and should be %s!', 'glotpress' ), $type_field, $name_field, $name_rule );
+			return sprintf( __( 'The %1$s %2$s is invalid and should be %3$s!', 'glotpress' ), $type_field, '<strong>'.$name_field.'</strong>', $name_rule );
 		else //if ( 'negative' == $rule['kind'] )
-			return sprintf( __( 'The %s <strong>%s</strong> is invalid and should not be %s!', 'glotpress' ), $type_field, $name_field, $name_rule );
+			return sprintf( __( 'The %1$s %2$s is invalid and should not be %3$s!', 'glotpress' ), $type_field, '<strong>'.$name_field.'</strong>', $name_rule );
 	}
 }
 

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -87,7 +87,7 @@ function textareas( $entry, $permissions, $index = 0 ) {
 			$warning = each( $referenceable );
 			?>
 			<div class="warning secondary">
-				<?php printf( __( '<strong>Warning:</strong> %s', 'glotpress' ), esc_html( $warning['value'] ) ); ?>
+				<strong><?php _e( 'Warning:', 'glotpress' ); ?></strong> <?php echo esc_html( $warning['value'] ); ?>
 
 				<?php if( $can_approve ): ?>
 					<a href="#" class="discard-warning" key="<?php echo $warning['key'] ?>" index="<?php echo $index; ?>"><?php _e( 'Discard', 'glotpress' ); ?></a>

--- a/gp-templates/profile-public.php
+++ b/gp-templates/profile-public.php
@@ -16,9 +16,9 @@ gp_tmpl_header();
 				$locale_keys = array_keys( $locales );
 
 				if ( 1 < count( $locales ) ) {
-					vprintf( __( '%s is a polyglot who knows %s but also knows %s.', 'glotpress' ), array_merge( array( $user->display_name ), $locale_keys ) );
+					vprintf( __( '%1$s is a polyglot who knows %2$s but also knows %3$s.', 'glotpress' ), array_merge( array( $user->display_name ), $locale_keys ) );
 				} else if( ! empty ( $locale_keys ) ) {
-					printf( __( '%s is a polyglot who contributes to %s', 'glotpress' ), $user->display_name, $locale_keys[0] );
+					printf( __( '%1$s is a polyglot who contributes to %2$s', 'glotpress' ), $user->display_name, $locale_keys[0] );
 				}
 			?></dd>
 			<dt><?php _e( 'Member Since', 'glotpress' ); ?></dt>

--- a/gp-templates/project-branch.php
+++ b/gp-templates/project-branch.php
@@ -20,7 +20,12 @@ gp_tmpl_header();
 	<dt><label for="project[source_url_template]"><?php _e( 'Source file URL', 'glotpress' ); ?></label></dt>
 	<dd>
 		<input type="text" value="<?php echo esc_html( $project->source_url_template ); ?>" name="project[source_url_template]" id="project[source_url_template]" style="width: 30em;" />
-		<span class="ternary"><?php _e( 'Public URL to a source file in the project. You can use <code>%file%</code> and <code>%line%</code>. Ex. <code>https://trac.example.org/browser/%file%#L%line%</code>', 'glotpress' ); ?></span>
+		<span class="ternary"><?php printf(
+			__( 'Public URL to a source file in the project. You can use %1$s and %2$s. Ex. %3$s', 'glotpress' ),
+			'<code>%file%</code>',
+			'<code>%line%</code>',
+			'<code>https://trac.example.org/browser/%file%#L%line%</code>'
+		); ?></span>
 	</dd>
 	<div id="preview"></div>
 	<input type="hidden" value="<?php echo esc_html( $project->parent_project_id ); ?>" name="project[parent_project_id]" id="project[parent_project_id]" />

--- a/gp-templates/project-form.php
+++ b/gp-templates/project-form.php
@@ -15,7 +15,12 @@
 	<dt><label for="project[source_url_template]"><?php _e( 'Source file URL', 'glotpress' ); ?></label></dt>
 	<dd>
 		<input type="text" value="<?php echo esc_html( $project->source_url_template ); ?>" name="project[source_url_template]" id="project[source_url_template]" style="width: 30em;" />
-		<span class="ternary"><?php _e( 'Public URL to a source file in the project. You can use <code>%file%</code> and <code>%line%</code>. Ex. <code>https://trac.example.org/browser/%file%#L%line%</code>', 'glotpress' ); ?></span>
+		<span class="ternary"><?php printf(
+			__( 'Public URL to a source file in the project. You can use %1$s and %2$s. Ex. %3$s', 'glotpress' ),
+			'<code>%file%</code>',
+			'<code>%line%</code>',
+			'<code>https://trac.example.org/browser/%file%#L%line%</code>'
+		); ?></span>
 	</dd>
 
 	<dt><label for="project[parent_project_id]"><?php _e( 'Parent Project', 'glotpress' ); ?></label></dt>


### PR DESCRIPTION
Previously: #198

See #99.
