### PR TITLE
237 Harmonize GP_Format child and parent class

### DIFF
--- a/gp-includes/format.php
+++ b/gp-includes/format.php
@@ -29,8 +29,13 @@ abstract class GP_Format {
 		foreach( $translations->entries as $key => $entry ) {
 			// we have been using read_originals_from_file to parse the file
 			// so we need to swap singular and translation
-			$entry->translations = array( $entry->singular );
-			$entry->singular     = null;
+			if ( $entry->context == $entry->singular ) {
+				$entry->translations = array();
+			} else {
+				$entry->translations = array( $entry->singular );
+			}
+
+			$entry->singular = null;
 
 			foreach( $originals as $original ) {
 				if ( $original->context == $entry->context ) {
@@ -40,7 +45,7 @@ abstract class GP_Format {
 			}
 
 			if ( ! $entry->singular ) {
-				error_log( sprintf( __( "Missing context %s in project #%d", 'glotpress' ), $entry->context, $project->id ) );
+				error_log( sprintf( __( 'Missing context %s in project #%d', 'glotpress' ), $entry->context, $project->id ) );
 				continue;
 			}
 

--- a/gp-includes/formats/format_strings.php
+++ b/gp-includes/formats/format_strings.php
@@ -32,49 +32,6 @@ class GP_Format_Strings extends GP_Format {
 		return $prefix . mb_convert_encoding( $result, 'UTF-16LE' );
 	}
 
-	public function read_translations_from_file( $file_name, $project = null ) {
-		if ( is_null( $project ) ) {
-			return false;
-		}
-
-		$translations = $this->read_originals_from_file( $file_name );
-
-		if ( ! $translations ) {
-			return false;
-		}
-
-		$originals        = GP::$original->by_project_id( $project->id );
-		$new_translations = new Translations;
-
-		foreach( $translations->entries as $key => $entry ) {
-			// we have been using read_originals_from_file to parse the file
-			// so we need to swap singular and translation
-			if ( $entry->context == $entry->singular ) {
-				$entry->translations = array();
-			} else {
-				$entry->translations = array( $entry->singular );
-			}
-
-			$entry->singular = null;
-
-			foreach( $originals as $original ) {
-				if ( $original->context == $entry->context ) {
-					$entry->singular = $original->singular;
-					break;
-				}
-			}
-
-			if ( ! $entry->singular ) {
-				error_log( sprintf( __( 'Missing context %s in project #%d', 'glotpress' ), $entry->context, $project->id ) );
-				continue;
-			}
-
-			$new_translations->add_entry( $entry );
-		}
-
-		return $new_translations;
-	}
-
 	public function read_originals_from_file( $file_name ) {
 		$entries = new Translations;
 		$file = file_get_contents( $file_name );


### PR DESCRIPTION
The GP_Format_Strings calss and the GP_Format class both have a nearly identical read_originals_from_file() method, the primary difference being the GP_Format_Strings class has a slightly more robust handling when swapping singular and translation.

Since the GP_Format class is the parent class for GP_Format_Strings, the change updates GP_Format class to match the code in the GP_Format_Strings class and then removes read_originals_from_file() from the GP_Format_Strings class.

Part of #237.
