### PR TITLE
238 esc_html() and deprecated code replacement.

### DIFF
--- a/gp-includes/strings.php
+++ b/gp-includes/strings.php
@@ -72,7 +72,7 @@ function gp_sanitize_for_url( $name ) {
  */
 function gp_esc_attr_with_entities( $text ) {
 	$safe_text = wp_check_invalid_utf8( $text );
-	$safe_text = _wp_specialchars( $safe_text, ENT_QUOTES, false, true );
+	$safe_text = esc_html( $safe_text );
 	return apply_filters( 'gp_attribute_escape', $safe_text, $text );
 
 }

--- a/gp-templates/header.php
+++ b/gp-templates/header.php
@@ -33,13 +33,13 @@
 
 		<?php if (gp_notice('error')): ?>
 			<div class="error">
-				<?php echo gp_notice( 'error' ); //TODO: run kses on notices ?>
+				<?php echo esc_html( gp_notice( 'error' ) ); //TODO: run kses on notices ?>
 			</div>
 		<?php endif; ?>
 
 		<?php if (gp_notice()): ?>
 			<div class="notice">
-				<?php echo gp_notice(); ?>
+				<?php echo esc_html( gp_notice() ); ?>
 			</div>
 		<?php endif; ?>
 

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -118,7 +118,7 @@ function textareas( $entry, $permissions, $index = 0 ) {
  * Similar to esc_html() but allows double-encoding.
  */
 function esc_translation( $text ) {
-	return _wp_specialchars( $text, ENT_NOQUOTES, false, true );
+	return esc_html( $text );
 }
 
 function display_status( $status ) {


### PR DESCRIPTION
Replace [_]wp_special_characters() as it's deprecated with esc_html().

Use esc_html() around the notices display.

Resolves #238.
