### PR TITLE
237: Remove the thing's magic method.

### DIFF
--- a/gp-includes/thing.php
+++ b/gp-includes/thing.php
@@ -51,18 +51,6 @@ class GP_Thing {
 		self::$static_by_class[$this->class][$name] = $value;
 	}
 
-	function __call( $name, $args ) {
-		$suffix = '_no_map';
-		if ( gp_endswith( $name, $suffix ) ) {
-			$name = substr( $name, 0, strlen( $name ) - strlen( $suffix ) );
-			$this->map_results = false;
-			$result = call_user_func_array( array( &$this, $name ), $args );
-			$this->map_results = true;
-			return $result;
-		}
-		trigger_error(sprintf('Call to undefined function: %s::%s().', get_class($this), $name), E_USER_ERROR);
-	}
-
 	// CRUD
 
 	/**
@@ -115,28 +103,114 @@ class GP_Thing {
 		}
 	}
 
+
 	/**
 	 * Retrieves multiple rows from this table
 	 *
-	 * For parameters description see BPDB::prepare()
-	 * @return mixed an object, containing the selected row or false on error
+	 * For parameters description see `$wpdb->prepare()`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return mixed An object, containing the selected row or false on error.
 	 */
-	function many() {
+	public function many() {
 		global $wpdb;
 		$args = func_get_args();
 		return $this->map( $wpdb->get_results( $this->prepare( $args ) ) );
 	}
 
-	function find_many( $conditions, $order = null ) {
+	/**
+	 * [many_no_map description]
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return mixed
+	 */
+	public function many_no_map() {
+		$args = func_get_args();
+		return $this->_no_map( 'many', $args );
+	}
+
+	/**
+	 * [find_many description]
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string|array $conditions
+	 * @param string|array $order Optional.
+	 * @return mixed
+	 */
+	public function find_many( $conditions, $order = null ) {
 		return $this->many( $this->select_all_from_conditions_and_order( $conditions, $order ) );
 	}
 
-	function find_one( $conditions, $order = null ) {
+	/**
+	 * [find_many_no_map description]
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string|array $conditions
+	 * @param string|array $order Optional.
+	 * @return mixed
+	 */
+	public function find_many_no_map( $conditions, $order = null ) {
+		return $this->_no_map( 'find_many', array( $conditions, $order ) );
+	}
+
+	/**
+	 * [find_one description]
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string|array $conditions
+	 * @param string|array $order Optional.
+	 * @return mixed
+	 */
+	public function find_one( $conditions, $order = null ) {
 		return $this->one( $this->select_all_from_conditions_and_order( $conditions, $order ) );
 	}
 
-	function find( $conditions, $order = null ) {
+	/**
+	 * [find description]
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string|array $conditions
+	 * @param string|array $order Optional.
+	 * @return mixed
+	 */
+	public function find( $conditions, $order = null ) {
 		return $this->find_many( $conditions, $order );
+	}
+
+	/**
+	 * [find_no_map description]
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string|array $conditions
+	 * @param string|array $order Optional.
+	 * @return mixed
+	 */
+	public function find_no_map( $conditions, $order = null ) {
+		return $this->_no_map( 'find', array( $conditions, $order ) );
+	}
+
+	/**
+	 * [_no_map description]
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $name Method name.
+	 * @param mixed  $args Method-dependent arguments.
+	 * @return mixed
+	 */
+	private function _no_map( $name, $args ) {
+		$this->map_results = false;
+		$result = call_user_func_array( array( $this, $name ), $args );
+		$this->map_results = true;
+
+		return $result;
 	}
 
 	function query() {
@@ -305,6 +379,10 @@ class GP_Thing {
 		return $mapped;
 	}
 
+	function map_no_map( $results ) {
+		return $this->_no_map( 'map', $results );
+	}
+
 	// Triggers
 
 	function after_create() {
@@ -389,7 +467,7 @@ class GP_Thing {
 
 	function fields() {
 		$result = array();
-		foreach( array_merge( $this->field_names, $this->non_db_field_names ) as $field_name ) { 
+		foreach( array_merge( $this->field_names, $this->non_db_field_names ) as $field_name ) {
 			if ( isset( $this->$field_name ) ) {
 				$result[$field_name] = $this->$field_name;
 			}

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -159,7 +159,7 @@ class GP_Translation_Set extends GP_Thing {
 			$counts = GP::$translation->many_no_map("
 				SELECT t.status as translation_status, COUNT(*) as n
 				FROM $t AS t INNER JOIN $o AS o ON t.original_id = o.id WHERE t.translation_set_id = %d AND o.status LIKE '+%%' GROUP BY t.status", $this->id);
-			$warnings_count = GP::$translation->value_no_map("
+			$warnings_count = GP::$translation->value("
 				SELECT COUNT(*) FROM $t AS t INNER JOIN $o AS o ON t.original_id = o.id
 				WHERE t.translation_set_id = %d AND o.status LIKE '+%%' AND (t.status = 'current' OR t.status = 'waiting') AND warnings IS NOT NULL", $this->id);
 			$counts[] = (object)array( 'translation_status' => 'warnings', 'n' => $warnings_count );


### PR DESCRIPTION
The _no_map magic method is only valid for a few methods in the class, but is callable via __call() on all methods.  This change removes the __call() magic method and adds the required [func]_no_map() methods to the class.

It also replaces a single instance of value_no_map() with value() as _no_map has no effect on the value() function.

This makes the code more readable, solve solves several scrutinizer issues and allows for better doc blocks.

Part of #237.
