### PR TITLE
196: Add GP Profile to the WP Profile.

### DIFF
--- a/gp-includes/routes/profile.php
+++ b/gp-includes/routes/profile.php
@@ -16,17 +16,26 @@ class GP_Route_Profile extends GP_Route_Main {
 		$this->tmpl( 'profile' );
 	}
 
-	public function profile_post() {
+	public function profile_post( $user_id = null ) {
 		if ( isset( $_POST['submit'] ) ) {
+			// Sometimes we get null, sometimes we get 0, depending on where it comes from.
+			// Let's make sure we have a consistent value to test against and that it's an integer.
+			$user_id = (int) $user_id;
+
+			if ( 0 === $user_id ) { 
+				$user_id = get_current_user_id(); 
+			}
+			
 			$per_page = (int) $_POST['per_page'];
-			update_user_option( get_current_user_id(), 'gp_per_page', $per_page );
+			update_user_option( $user_id, 'gp_per_page', $per_page );
 
 			$default_sort = array(
 				'by'  => 'priority',
 				'how' => 'desc'
 			);
+			
 			$user_sort = wp_parse_args( $_POST['default_sort'], $default_sort );
-			update_user_option( get_current_user_id(), 'gp_default_sort', $user_sort );
+			update_user_option( $user_id, 'gp_default_sort', $user_sort );
 		}
 
 		$this->redirect( gp_url( '/profile' ) );

--- a/gp-templates/profile-edit.php
+++ b/gp-templates/profile-edit.php
@@ -1,0 +1,44 @@
+<?php
+
+$per_page = get_user_option( 'gp_per_page' );
+if ( 0 == $per_page ) {
+	$per_page = 15;
+}
+
+$default_sort = get_user_option( 'gp_default_sort' );
+if ( ! is_array( $default_sort ) ) {
+	$default_sort = array(
+		'by'  => 'priority',
+		'how' => 'desc'
+	);
+}
+?>
+	<table class="form-table">
+		<tr>
+			<th><label for="per_page"><?php _e( 'Number of items per page:', 'glotpress' ); ?></label></th>
+			<td><input type="number" id="per_page" name="per_page" value="<?php echo $per_page ?>"/></td>
+		</tr>
+		<tr>
+			<th><label for="default_sort[by]"><?php _e( 'Default Sort By:', 'glotpress' ) ?></label></th>
+			<td><?php echo gp_radio_buttons('default_sort[by]',
+		array(
+			'original_date_added'    => __( 'Date added (original)', 'glotpress' ),
+			'translation_date_added' => __( 'Date added (translation)', 'glotpress' ),
+			'original'               => __( 'Original string', 'glotpress' ),
+			'translation'            => __( 'Translation', 'glotpress' ),
+			'priority'               => __( 'Priority', 'glotpress' ),
+			'references'             => __( 'Filename in source', 'glotpress' ),
+			'random'                 => __( 'Random', 'glotpress' ),
+		), gp_array_get( $default_sort, 'by', 'priority' ) ); ?></td>
+		</tr>
+		<tr>
+			<th><label for="default_sort[how]"><?php _e( 'Default Sort Order:', 'glotpress' ) ?></label></th>
+			<td><?php echo gp_radio_buttons('default_sort[how]',
+				array(
+					'asc' => __( 'Ascending', 'glotpress' ),
+					'desc' => __( 'Descending', 'glotpress' ),
+				), gp_array_get( $default_sort, 'how', 'desc' ) );
+			?></td>
+		</tr>
+	</table>
+

--- a/gp-templates/profile.php
+++ b/gp-templates/profile.php
@@ -18,34 +18,9 @@ if ( ! is_array( $default_sort ) ) {
 ?>
 <h2><?php _e( 'Profile', 'glotpress' ); ?></h2>
 <form action="" method="post">
-	<table class="form-table">
-		<tr>
-			<th><label for="per_page"><?php _e( 'Number of items per page:', 'glotpress' ); ?></label></th>
-			<td><input type="number" id="per_page" name="per_page" value="<?php echo $per_page ?>"/></td>
-		</tr>
-		<tr>
-			<th><label for="default_sort[by]"><?php _e( 'Default Sort By:', 'glotpress' ) ?></label></th>
-			<td><?php echo gp_radio_buttons('default_sort[by]',
-		array(
-			'original_date_added' => __( 'Date added (original)', 'glotpress' ),
-			'translation_date_added' => __( 'Date added (translation)', 'glotpress' ),
-			'original' => __( 'Original string', 'glotpress' ),
-			'translation' => __( 'Translation', 'glotpress' ),
-			'priority' => __( 'Priority', 'glotpress' ),
-			'references' => __( 'Filename in source', 'glotpress' ),
-			'random' => __( 'Random', 'glotpress' ),
-		), gp_array_get( $default_sort, 'by', 'priority' ) ); ?></td>
-		</tr>
-		<tr>
-			<th><label for="default_sort[how]"><?php _e( 'Default Sort Order:', 'glotpress' ) ?></label></th>
-			<td><?php echo gp_radio_buttons('default_sort[how]',
-				array(
-					'asc' => __( 'Ascending', 'glotpress' ),
-					'desc' => __( 'Descending', 'glotpress' ),
-				), gp_array_get( $default_sort, 'how', 'desc' ) );
-			?></td>
-		</tr>
-	</table>
+<?php 
+include_once( dirname( __FILE__ ) . '/profile-edit.php' );
+?>
 	<br>
 	<input type="submit" name="submit" value="<?php esc_attr_e( 'Change Settings', 'glotpress' ); ?>">
 </form>


### PR DESCRIPTION
Split the profile template file in to three, one part for the otter html, one part for the inner editing html and the last part for the inner viewing html.

Added filters and functions to display the GP profile in the WP profile page.

Resolves #196.

See #197 for history.
