### PR TITLE
267: Enable deletion via UI for projects/originals/sets/translations

### DIFF
--- a/gp-includes/router.php
+++ b/gp-includes/router.php
@@ -130,6 +130,8 @@ class GP_Router {
 			"get:/sets/$id" => array('GP_Route_Translation_Set', 'single'),
 			"get:/sets/$id/-edit" => array('GP_Route_Translation_Set', 'edit_get'),
 			"post:/sets/$id/-edit" => array('GP_Route_Translation_Set', 'edit_post'),
+			"get:/sets/$id/-delete" => array('GP_Route_Translation_Set', 'delete_get'),
+			"post:/sets/$id/-delete" => array('GP_Route_Translation_Set', 'delete_post'),
 
 			"get:/glossaries/-new" => array('GP_Route_Glossary', 'new_get'),
 			"post:/glossaries/-new" => array('GP_Route_Glossary', 'new_post'),

--- a/gp-includes/router.php
+++ b/gp-includes/router.php
@@ -92,11 +92,8 @@ class GP_Router {
 			"get:/$project/-edit" => array('GP_Route_Project', 'edit_get'),
 			"post:/$project/-edit" => array('GP_Route_Project', 'edit_post'),
 
-			/*
-			// Currently the deletion of a project is not well defined so don't add routes to let it happen.
 			"get:/$project/-delete" => array('GP_Route_Project', 'delete_get'),
 			"post:/$project/-delete" => array('GP_Route_Project', 'delete_post'),
-			*/
 
 			"post:/$project/-personal" => array('GP_Route_Project', 'personal_options_post'),
 

--- a/gp-includes/router.php
+++ b/gp-includes/router.php
@@ -66,81 +66,81 @@ class GP_Router {
 
 		// overall structure
 		return array(
-			'/' => array('GP_Route_Index', 'index'),
+			'/' => array( 'GP_Route_Index', 'index' ),
 
 			'get:/profile' => array( 'GP_Route_Profile', 'profile_view' ),
-			"get:/profile/$path" => array('GP_Route_Profile', 'profile_view'),
+			"get:/profile/$path" => array( 'GP_Route_Profile', 'profile_view' ),
 
 			'get:/settings' => array( 'GP_Route_Settings', 'settings_get' ),
 			'post:/settings' => array( 'GP_Route_Settings', 'settings_post' ),
 
-			'get:/languages' => array('GP_Route_Locale', 'locales_get'),
-			"get:/languages/$locale/$path" => array('GP_Route_Locale', 'single'),
-			"get:/languages/$locale" => array('GP_Route_Locale', 'single'),
+			'get:/languages' => array( 'GP_Route_Locale', 'locales_get' ),
+			"get:/languages/$locale/$path" => array( 'GP_Route_Locale', 'single' ),
+			"get:/languages/$locale" => array( 'GP_Route_Locale', 'single' ),
 
-			"get:/$set/glossary" => array('GP_Route_Glossary_Entry', 'glossary_entries_get'),
-			"post:/$set/glossary" => array('GP_Route_Glossary_Entry', 'glossary_entries_post'),
-			"post:/$set/glossary/-new" => array('GP_Route_Glossary_Entry', 'glossary_entry_add_post'),
-			"post:/$set/glossary/-delete" => array('GP_Route_Glossary_Entry', 'glossary_entry_delete_post'),
-			"get:/$set/glossary/-export" => array('GP_Route_Glossary_Entry', 'export_glossary_entries_get'),
-			"get:/$set/glossary/-import" => array('GP_Route_Glossary_Entry', 'import_glossary_entries_get'),
-			"post:/$set/glossary/-import" => array('GP_Route_Glossary_Entry', 'import_glossary_entries_post'),
+			"get:/$set/glossary" => array( 'GP_Route_Glossary_Entry', 'glossary_entries_get' ),
+			"post:/$set/glossary" => array( 'GP_Route_Glossary_Entry', 'glossary_entries_post' ),
+			"post:/$set/glossary/-new" => array( 'GP_Route_Glossary_Entry', 'glossary_entry_add_post' ),
+			"post:/$set/glossary/-delete" => array( 'GP_Route_Glossary_Entry', 'glossary_entry_delete_post' ),
+			"get:/$set/glossary/-export" => array( 'GP_Route_Glossary_Entry', 'export_glossary_entries_get' ),
+			"get:/$set/glossary/-import" => array( 'GP_Route_Glossary_Entry', 'import_glossary_entries_get' ),
+			"post:/$set/glossary/-import" => array( 'GP_Route_Glossary_Entry', 'import_glossary_entries_post' ),
 
-			"get:/$project/import-originals" => array('GP_Route_Project', 'import_originals_get'),
-			"post:/$project/import-originals" => array('GP_Route_Project', 'import_originals_post'),
+			"get:/$project/import-originals" => array( 'GP_Route_Project', 'import_originals_get' ),
+			"post:/$project/import-originals" => array( 'GP_Route_Project', 'import_originals_post' ),
 
-			"get:/$project/-edit" => array('GP_Route_Project', 'edit_get'),
-			"post:/$project/-edit" => array('GP_Route_Project', 'edit_post'),
+			"get:/$project/-edit" => array( 'GP_Route_Project', 'edit_get' ),
+			"post:/$project/-edit" => array( 'GP_Route_Project', 'edit_post' ),
 
-			"get:/$project/-delete" => array('GP_Route_Project', 'delete_get'),
-			"post:/$project/-delete" => array('GP_Route_Project', 'delete_post'),
+			"get:/$project/-delete" => array( 'GP_Route_Project', 'delete_get' ),
+			"post:/$project/-delete" => array( 'GP_Route_Project', 'delete_post' ),
 
-			"post:/$project/-personal" => array('GP_Route_Project', 'personal_options_post'),
+			"post:/$project/-personal" => array( 'GP_Route_Project', 'personal_options_post' ),
 
-			"get:/$project/-permissions" => array('GP_Route_Project', 'permissions_get'),
-			"post:/$project/-permissions" => array('GP_Route_Project', 'permissions_post'),
-			"get:/$project/-permissions/-delete/$dir" => array('GP_Route_Project', 'permissions_delete'),
+			"get:/$project/-permissions" => array( 'GP_Route_Project', 'permissions_get' ),
+			"post:/$project/-permissions" => array( 'GP_Route_Project', 'permissions_post' ),
+			"get:/$project/-permissions/-delete/$dir" => array( 'GP_Route_Project', 'permissions_delete' ),
 
-			"get:/$project/-mass-create-sets" => array('GP_Route_Project', 'mass_create_sets_get'),
-			"post:/$project/-mass-create-sets" => array('GP_Route_Project', 'mass_create_sets_post'),
-			"post:/$project/-mass-create-sets/preview" => array('GP_Route_Project', 'mass_create_sets_preview_post'),
+			"get:/$project/-mass-create-sets" => array( 'GP_Route_Project', 'mass_create_sets_get' ),
+			"post:/$project/-mass-create-sets" => array( 'GP_Route_Project', 'mass_create_sets_post' ),
+			"post:/$project/-mass-create-sets/preview" => array( 'GP_Route_Project', 'mass_create_sets_preview_post' ),
 
-			"get:/$project/-branch" => array('GP_Route_Project', 'branch_project_get'),
-			"post:/$project/-branch" => array('GP_Route_Project', 'branch_project_post'),
+			"get:/$project/-branch" => array( 'GP_Route_Project', 'branch_project_get' ),
+			"post:/$project/-branch" => array( 'GP_Route_Project', 'branch_project_post' ),
 
-			"get:/$projects" => array('GP_Route_Project', 'index'),
-			"get:/$projects/-new" => array('GP_Route_Project', 'new_get'),
-			"post:/$projects/-new" => array('GP_Route_Project', 'new_post'),
+			"get:/$projects" => array( 'GP_Route_Project', 'index' ),
+			"get:/$projects/-new" => array( 'GP_Route_Project', 'new_get' ),
+			"post:/$projects/-new" => array( 'GP_Route_Project', 'new_post' ),
 
-			"post:/$set/-bulk" => array('GP_Route_Translation', 'bulk_post'),
-			"get:/$set/import-translations" => array('GP_Route_Translation', 'import_translations_get'),
-			"post:/$set/import-translations" => array('GP_Route_Translation', 'import_translations_post'),
-			"post:/$set/-discard-warning" => array('GP_Route_Translation', 'discard_warning'),
-			"post:/$set/-set-status" => array('GP_Route_Translation', 'set_status'),
-			"/$set/export-translations" => array('GP_Route_Translation', 'export_translations_get'),
-			// keep this below all URLs ending with a literal string, because it may catch one of them
-			"get:/$set" => array('GP_Route_Translation', 'translations_get'),
-			"post:/$set" => array('GP_Route_Translation', 'translations_post'),
+			"post:/$set/-bulk" => array( 'GP_Route_Translation', 'bulk_post' ),
+			"get:/$set/import-translations" => array( 'GP_Route_Translation', 'import_translations_get' ),
+			"post:/$set/import-translations" => array( 'GP_Route_Translation', 'import_translations_post' ),
+			"post:/$set/-discard-warning" => array( 'GP_Route_Translation', 'discard_warning' ),
+			"post:/$set/-set-status" => array( 'GP_Route_Translation', 'set_status' ),
+			"/$set/export-translations" => array( 'GP_Route_Translation', 'export_translations_get' ),
+			// Keep this below all URLs ending with a literal string, because it may catch one of them.
+			"get:/$set" => array( 'GP_Route_Translation', 'translations_get' ),
+			"post:/$set" => array( 'GP_Route_Translation', 'translations_post' ),
 
-			// keep this one at the bottom of the project, because it will catch anything starting with project
-			"/$project" => array('GP_Route_Project', 'single'),
+			// Keep this one at the bottom of the project, because it will catch anything starting with project.
+			"/$project" => array( 'GP_Route_Project', 'single' ),
 
-			"get:/sets/-new" => array('GP_Route_Translation_Set', 'new_get'),
-			"post:/sets/-new" => array('GP_Route_Translation_Set', 'new_post'),
-			"get:/sets/$id" => array('GP_Route_Translation_Set', 'single'),
-			"get:/sets/$id/-edit" => array('GP_Route_Translation_Set', 'edit_get'),
-			"post:/sets/$id/-edit" => array('GP_Route_Translation_Set', 'edit_post'),
-			"get:/sets/$id/-delete" => array('GP_Route_Translation_Set', 'delete_get'),
-			"post:/sets/$id/-delete" => array('GP_Route_Translation_Set', 'delete_post'),
+			'get:/sets/-new' => array( 'GP_Route_Translation_Set', 'new_get' ),
+			'post:/sets/-new' => array( 'GP_Route_Translation_Set', 'new_post' ),
+			"get:/sets/$id" => array( 'GP_Route_Translation_Set', 'single' ),
+			"get:/sets/$id/-edit" => array( 'GP_Route_Translation_Set', 'edit_get' ),
+			"post:/sets/$id/-edit" => array( 'GP_Route_Translation_Set', 'edit_post' ),
+			"get:/sets/$id/-delete" => array( 'GP_Route_Translation_Set', 'delete_get' ),
+			"post:/sets/$id/-delete" => array( 'GP_Route_Translation_Set', 'delete_post' ),
 
-			"get:/glossaries/-new" => array('GP_Route_Glossary', 'new_get'),
-			"post:/glossaries/-new" => array('GP_Route_Glossary', 'new_post'),
-			"get:/glossaries/$id/-edit" => array('GP_Route_Glossary', 'edit_get'),
-			"post:/glossaries/$id/-edit" => array('GP_Route_Glossary', 'edit_post'),
-			"get:/glossaries/$id/-delete" => array('GP_Route_Glossary', 'delete_get'),
-			"post:/glossaries/$id/-delete" => array('GP_Route_Glossary', 'delete_post'),
+			'get:/glossaries/-new' => array( 'GP_Route_Glossary', 'new_get' ),
+			'post:/glossaries/-new' => array( 'GP_Route_Glossary', 'new_post' ),
+			"get:/glossaries/$id/-edit" => array( 'GP_Route_Glossary', 'edit_get' ),
+			"post:/glossaries/$id/-edit" => array( 'GP_Route_Glossary', 'edit_post' ),
+			"get:/glossaries/$id/-delete" => array( 'GP_Route_Glossary', 'delete_get' ),
+			"post:/glossaries/$id/-delete" => array( 'GP_Route_Glossary', 'delete_post' ),
 
-			"post:/originals/$id/set_priority" => array('GP_Route_Original', 'set_priority'),
+			"post:/originals/$id/set_priority" => array( 'GP_Route_Original', 'set_priority' ),
 		);
 	}
 

--- a/gp-includes/router.php
+++ b/gp-includes/router.php
@@ -137,6 +137,8 @@ class GP_Router {
 			"post:/glossaries/-new" => array('GP_Route_Glossary', 'new_post'),
 			"get:/glossaries/$id/-edit" => array('GP_Route_Glossary', 'edit_get'),
 			"post:/glossaries/$id/-edit" => array('GP_Route_Glossary', 'edit_post'),
+			"get:/glossaries/$id/-delete" => array('GP_Route_Glossary', 'delete_get'),
+			"post:/glossaries/$id/-delete" => array('GP_Route_Glossary', 'delete_post'),
 
 			"post:/originals/$id/set_priority" => array('GP_Route_Original', 'set_priority'),
 		);

--- a/gp-includes/routes/glossary.php
+++ b/gp-includes/routes/glossary.php
@@ -116,6 +116,10 @@ class GP_Route_Glossary extends GP_Route_Main {
 			$this->redirect_with_error( __( 'Cannot find glossary.', 'glotpress' ) );
 		}
 
+		if ( $this->cannot_delete_glossary_and_redirect( $glossary ) ) {
+			return;
+		}
+		
 		$translation_set = GP::$translation_set->get( $glossary->translation_set_id );
 		$locale          = GP_Locales::by_slug( $translation_set->locale );
 		$project         = GP::$project->get( $translation_set->project_id );
@@ -126,7 +130,7 @@ class GP_Route_Glossary extends GP_Route_Main {
 	public function delete_post( $glossary_id ) {
 		$glossary     = GP::$glossary->get( $glossary_id );
 
-		if ( $this->cannot_edit_glossary_and_redirect( $glossary ) ) {
+		if ( $this->cannot_delete_glossary_and_redirect( $glossary ) ) {
 			return;
 		}
 
@@ -148,4 +152,7 @@ class GP_Route_Glossary extends GP_Route_Main {
 		return $this->cannot_and_redirect( 'approve', 'translation-set', $glossary->translation_set_id );
 	}
 
+	private function cannot_delete_glossary_and_redirect( $glossary ) {
+		return $this->cannot_and_redirect( 'delete', 'translation-set', $glossary->translation_set_id );
+	}
 }

--- a/gp-includes/routes/glossary.php
+++ b/gp-includes/routes/glossary.php
@@ -168,6 +168,8 @@ class GP_Route_Glossary extends GP_Route_Main {
 	 * @since 1.0.0
 	 *
 	 * @param GP_Glossary $glossary The glossary object to check.
+	 *
+	 * @return bool
 	 */
 	private function cannot_edit_glossary_and_redirect( $glossary ) {
 		return $this->cannot_and_redirect( 'approve', 'translation-set', $glossary->translation_set_id );
@@ -179,6 +181,8 @@ class GP_Route_Glossary extends GP_Route_Main {
 	 * @since 1.1.0
 	 *
 	 * @param GP_Glossary $glossary The glossary object to check.
+	 *
+	 * @return bool
 	 */
 	private function cannot_delete_glossary_and_redirect( $glossary ) {
 		return $this->cannot_and_redirect( 'delete', 'translation-set', $glossary->translation_set_id );

--- a/gp-includes/routes/glossary.php
+++ b/gp-includes/routes/glossary.php
@@ -109,6 +109,41 @@ class GP_Route_Glossary extends GP_Route_Main {
 		$this->redirect( gp_url_join( gp_url_project( $set_project, array( $translation_set->locale, $translation_set->slug ) ), array('glossary') ) );
 	}
 
+	public function delete_get( $glossary_id ) {
+		$glossary = GP::$glossary->get( $glossary_id );
+
+		if ( ! $glossary ) {
+			$this->redirect_with_error( __( 'Cannot find glossary.', 'glotpress' ) );
+		}
+
+		$translation_set = GP::$translation_set->get( $glossary->translation_set_id );
+		$locale          = GP_Locales::by_slug( $translation_set->locale );
+		$project         = GP::$project->get( $translation_set->project_id );
+
+		$this->tmpl( 'glossary-delete', get_defined_vars() );
+	}
+
+	public function delete_post( $glossary_id ) {
+		$glossary     = GP::$glossary->get( $glossary_id );
+
+		if ( $this->cannot_edit_glossary_and_redirect( $glossary ) ) {
+			return;
+		}
+
+		$translation_set = GP::$translation_set->get( $glossary->translation_set_id );
+		$project         = GP::$project->get( $translation_set->project_id );
+
+		if ( ! $glossary->delete() ) {
+			$this->errors[] = __( 'Error deleting glossary!', 'glotpress' );
+			$this->redirect();
+			return;
+		}
+
+		$this->notices[] = __( 'The glossary was deleted!', 'glotpress' );
+
+		$this->redirect( gp_url_join( gp_url_project( $project ), array( $translation_set->locale, $translation_set->slug ) ) );
+	}
+
 	private function cannot_edit_glossary_and_redirect( $glossary ) {
 		return $this->cannot_and_redirect( 'approve', 'translation-set', $glossary->translation_set_id );
 	}

--- a/gp-includes/routes/glossary.php
+++ b/gp-includes/routes/glossary.php
@@ -126,7 +126,7 @@ class GP_Route_Glossary extends GP_Route_Main {
 		if ( $this->cannot_delete_glossary_and_redirect( $glossary ) ) {
 			return;
 		}
-		
+
 		$translation_set = GP::$translation_set->get( $glossary->translation_set_id );
 		$locale          = GP_Locales::by_slug( $translation_set->locale );
 		$project         = GP::$project->get( $translation_set->project_id );

--- a/gp-includes/routes/glossary.php
+++ b/gp-includes/routes/glossary.php
@@ -109,6 +109,13 @@ class GP_Route_Glossary extends GP_Route_Main {
 		$this->redirect( gp_url_join( gp_url_project( $set_project, array( $translation_set->locale, $translation_set->slug ) ), array('glossary') ) );
 	}
 
+	/**
+	 * Displays the delete page for glossaries.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $glossary_id The id of the glossary to delete.
+	 */
 	public function delete_get( $glossary_id ) {
 		$glossary = GP::$glossary->get( $glossary_id );
 
@@ -127,6 +134,13 @@ class GP_Route_Glossary extends GP_Route_Main {
 		$this->tmpl( 'glossary-delete', get_defined_vars() );
 	}
 
+	/**
+	 * Delete a glossary.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $glossary_id The id of the glossary to delete.
+	 */
 	public function delete_post( $glossary_id ) {
 		$glossary     = GP::$glossary->get( $glossary_id );
 
@@ -148,10 +162,24 @@ class GP_Route_Glossary extends GP_Route_Main {
 		$this->redirect( gp_url_join( gp_url_project( $project ), array( $translation_set->locale, $translation_set->slug ) ) );
 	}
 
+	/**
+	 * Checks to see if the current user can edit a glossary or not.  If they cannot it redirects back to the project page.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param GP_Glossary $glossary The glossary object to check.
+	 */
 	private function cannot_edit_glossary_and_redirect( $glossary ) {
 		return $this->cannot_and_redirect( 'approve', 'translation-set', $glossary->translation_set_id );
 	}
 
+	/**
+	 * Checks to see if the current user can delete a glossary or not.  If they cannot it redirects back to the project page.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param GP_Glossary $glossary The glossary object to check.
+	 */
 	private function cannot_delete_glossary_and_redirect( $glossary ) {
 		return $this->cannot_and_redirect( 'delete', 'translation-set', $glossary->translation_set_id );
 	}

--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -192,10 +192,7 @@ class GP_Route_Project extends GP_Route_Main {
 		$this->redirect( gp_url_project( $project ) );
 	}
 
-	function delete_post() {
-		// TODO: do not delete using a GET request but POST
-		// TODO: decide what to do with child projects and translation sets
-		// TODO: just deactivate, do not actually delete
+	public function delete_post() {
 		$project_id = gp_post( 'project' );
 		$project_name = gp_post( 'project_name' );
 		$project = GP::$project->find_one( array( 'id' => $project_id ) );
@@ -222,7 +219,7 @@ class GP_Route_Project extends GP_Route_Main {
 		$this->redirect( gp_url_public_root() );
 	}
 	
-	function delete_get( $project_path ) {
+	public function delete_get( $project_path ) {
 		$project = GP::$project->by_path( $project_path );
 
 		if ( $this->cannot_and_redirect( 'write', 'project', $project->id ) ) {

--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -192,6 +192,13 @@ class GP_Route_Project extends GP_Route_Main {
 		$this->redirect( gp_url_project( $project ) );
 	}
 
+	/**
+	 * Deletes a project, including sub projects, glossaries, originals, translations sets and translations.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $project_id The id of the project to delete.
+	 */
 	public function delete_post( $project_id ) {
 		$project = GP::$project->find_one( array( 'id' => $project_id ) );
 		
@@ -217,6 +224,13 @@ class GP_Route_Project extends GP_Route_Main {
 		$this->redirect( gp_url_public_root() );
 	}
 	
+	/**
+	 * Displays the delete page for projects.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $glossary_id The id of the project to delete.
+	 */
 	public function delete_get( $project_path ) {
 		$project = GP::$project->by_path( $project_path );
 

--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -203,7 +203,7 @@ class GP_Route_Project extends GP_Route_Main {
 			return;
 		}
 
-		if ( $this->cannot_and_redirect( 'write', 'project', $project->id ) ) {
+		if ( $this->cannot_and_redirect( 'delete', 'project', $project->id ) ) {
 			return;
 		}
 
@@ -220,7 +220,7 @@ class GP_Route_Project extends GP_Route_Main {
 	public function delete_get( $project_path ) {
 		$project = GP::$project->by_path( $project_path );
 
-		if ( $this->cannot_and_redirect( 'write', 'project', $project->id ) ) {
+		if ( $this->cannot_and_redirect( 'delete', 'project', $project->id ) ) {
 			return;
 		}
 

--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -229,7 +229,7 @@ class GP_Route_Project extends GP_Route_Main {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @param int $glossary_id The id of the project to delete.
+	 * @param string $project_path The path of the project to delete.
 	 */
 	public function delete_get( $project_path ) {
 		$project = GP::$project->by_path( $project_path );

--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -203,10 +203,10 @@ class GP_Route_Project extends GP_Route_Main {
 		$project = GP::$project->by_path( $project_path );
 
 		if ( ! is_object( $project ) ) {
-			
+
 			$this->redirect( gp_url_public_root() );
 			$this->errors[] = __( 'Error in deleting project!', 'glotpress' );
-			
+
 			return;
 		}
 
@@ -223,7 +223,7 @@ class GP_Route_Project extends GP_Route_Main {
 
 		$this->redirect( gp_url_public_root() );
 	}
-	
+
 	/**
 	 * Displays the delete page for projects.
 	 *

--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -192,12 +192,10 @@ class GP_Route_Project extends GP_Route_Main {
 		$this->redirect( gp_url_project( $project ) );
 	}
 
-	public function delete_post() {
-		$project_id = gp_post( 'project' );
-		$project_name = gp_post( 'project_name' );
+	public function delete_post( $project_id ) {
 		$project = GP::$project->find_one( array( 'id' => $project_id ) );
 		
-		if ( $project_name != $project->name || null == $project_id ) {
+		if ( ! empty( $project_id ) ) {
 			
 			$this->redirect( gp_url_public_root() );
 			$this->errors[] = __( 'Error in deleting project!', 'glotpress' );

--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -197,11 +197,11 @@ class GP_Route_Project extends GP_Route_Main {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @param int $project_id The id of the project to delete.
+	 * @param int $project_path The path of the project to delete.
 	 */
-	public function delete_post( $project_id ) {
-		$project = GP::$project->find_one( array( 'id' => $project_id ) );
-		
+	public function delete_post( $project_path ) {
+		$project = GP::$project->by_path( $project_path );
+
 		if ( ! empty( $project_id ) ) {
 			
 			$this->redirect( gp_url_public_root() );

--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -202,7 +202,7 @@ class GP_Route_Project extends GP_Route_Main {
 	public function delete_post( $project_path ) {
 		$project = GP::$project->by_path( $project_path );
 
-		if ( ! empty( $project_id ) ) {
+		if ( ! is_object( $project ) ) {
 			
 			$this->redirect( gp_url_public_root() );
 			$this->errors[] = __( 'Error in deleting project!', 'glotpress' );

--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -192,14 +192,20 @@ class GP_Route_Project extends GP_Route_Main {
 		$this->redirect( gp_url_project( $project ) );
 	}
 
-	public function delete_get( $project_path ) {
+	function delete_post() {
 		// TODO: do not delete using a GET request but POST
 		// TODO: decide what to do with child projects and translation sets
 		// TODO: just deactivate, do not actually delete
-		$project = GP::$project->by_path( $project_path );
-
-		if ( !$project ) {
-			return $this->die_with_404();
+		$project_id = gp_post( 'project' );
+		$project_name = gp_post( 'project_name' );
+		$project = GP::$project->find_one( array( 'id' => $project_id ) );
+		
+		if ( $project_name != $project->name || null == $project_id ) {
+			
+			$this->redirect( gp_url_public_root() );
+			$this->errors[] = __( 'Error in deleting project!', 'glotpress' );
+			
+			return;
 		}
 
 		if ( $this->cannot_and_redirect( 'write', 'project', $project->id ) ) {
@@ -207,13 +213,23 @@ class GP_Route_Project extends GP_Route_Main {
 		}
 
 		if ( $project->delete() ) {
-			$this->notices[] = __( 'The project was deleted.', 'glotpress' );
+			$this->notices[] = sprintf( __( 'The project "%s" was deleted.', 'glotpress' ), $project->name );
 		}
 		else {
-			$this->errors[] = __( 'Error in deleting project!', 'glotpress' );
+			$this->errors[] = sprintf( __( 'Error deleting project "%s"!', 'glotpress' ), $project->name );
 		}
 
-		$this->redirect( gp_url_project( '' ) );
+		$this->redirect( gp_url_public_root() );
+	}
+	
+	function delete_get( $project_path ) {
+		$project = GP::$project->by_path( $project_path );
+
+		if ( $this->cannot_and_redirect( 'write', 'project', $project->id ) ) {
+			return;
+		}
+
+		$this->tmpl( 'project-delete', get_defined_vars() );
 	}
 
 

--- a/gp-includes/routes/translation-set.php
+++ b/gp-includes/routes/translation-set.php
@@ -69,6 +69,30 @@ class GP_Route_Translation_Set extends GP_Route_Main {
 		$this->redirect( gp_url_project_locale( $project, $new_set->locale, $new_set->slug ) );
 	}
 
+	public function delete_post() {
+		$set_id = gp_post( 'translation_set' );
+		$items = $this->get_set_project_and_locale_from_set_id_or_404( $set_id );
+		if ( !$items ) return;
+		list( $set, $project, $locale ) = $items;
+		if ( $this->cannot_edit_set_and_redirect( $set ) ) return;
+		if ( !$set->delete() ) {
+			$this->errors[] = __( 'Error deleting translation set!', 'glotpress' );
+			$this->redirect();
+			return;
+		}
+		$this->notices[] = __( 'The translation set was deleted!', 'glotpress' );
+		$this->redirect( gp_url_project( $project ) );
+	}
+	
+	public function delete_get( $set_id ) {
+		$items = $this->get_set_project_and_locale_from_set_id_or_404( $set_id );
+		if ( !$items ) return;
+		list( $set, $project, $locale ) = $items;
+		if ( $this->cannot_and_redirect( 'write', 'project', $set->project_id, gp_url_project( $project ) ) ) return;
+		$url = gp_url_project( $project, gp_url_join( $set->locale, $set->slug ) );
+		$this->tmpl( 'translation-set-delete', get_defined_vars() );
+	}
+	
 	private function cannot_edit_set_and_redirect( $set ) {
 		return $this->cannot_and_redirect( 'write', 'project', $set->project_id );
 	}

--- a/gp-includes/routes/translation-set.php
+++ b/gp-includes/routes/translation-set.php
@@ -69,6 +69,13 @@ class GP_Route_Translation_Set extends GP_Route_Main {
 		$this->redirect( gp_url_project_locale( $project, $new_set->locale, $new_set->slug ) );
 	}
 
+	/**
+	 * Deletes a translation set.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $set_id The id of the translation set to delete.
+	 */
 	public function delete_post( $set_id ) {
 		$items = $this->get_set_project_and_locale_from_set_id_or_404( $set_id );
 		if ( !$items ) return;
@@ -83,6 +90,13 @@ class GP_Route_Translation_Set extends GP_Route_Main {
 		$this->redirect( gp_url_project( $project ) );
 	}
 	
+	/**
+	 * Displays the delete page for translations sets.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $set_id The id of the translation set to delete.
+	 */
 	public function delete_get( $set_id ) {
 		$items = $this->get_set_project_and_locale_from_set_id_or_404( $set_id );
 		if ( !$items ) return;

--- a/gp-includes/routes/translation-set.php
+++ b/gp-includes/routes/translation-set.php
@@ -87,7 +87,7 @@ class GP_Route_Translation_Set extends GP_Route_Main {
 		$items = $this->get_set_project_and_locale_from_set_id_or_404( $set_id );
 		if ( !$items ) return;
 		list( $set, $project, $locale ) = $items;
-		if ( $this->cannot_and_redirect( 'write', 'project', $set->project_id, gp_url_project( $project ) ) ) return;
+		if ( $this->cannot_and_redirect( 'delete', 'project', $set->project_id, gp_url_project( $project ) ) ) return;
 		$url = gp_url_project( $project, gp_url_join( $set->locale, $set->slug ) );
 		$this->tmpl( 'translation-set-delete', get_defined_vars() );
 	}

--- a/gp-includes/routes/translation-set.php
+++ b/gp-includes/routes/translation-set.php
@@ -78,18 +78,25 @@ class GP_Route_Translation_Set extends GP_Route_Main {
 	 */
 	public function delete_post( $set_id ) {
 		$items = $this->get_set_project_and_locale_from_set_id_or_404( $set_id );
-		if ( !$items ) return;
+		if ( ! $items ) {
+			return;
+		}
+
 		list( $set, $project, $locale ) = $items;
-		if ( $this->cannot_edit_set_and_redirect( $set ) ) return;
-		if ( !$set->delete() ) {
+		if ( $this->cannot_edit_set_and_redirect( $set ) ) {
+			return;
+		}
+
+		if ( ! $set->delete() ) {
 			$this->errors[] = __( 'Error deleting translation set!', 'glotpress' );
 			$this->redirect();
 			return;
 		}
+
 		$this->notices[] = __( 'The translation set was deleted!', 'glotpress' );
 		$this->redirect( gp_url_project( $project ) );
 	}
-	
+
 	/**
 	 * Displays the delete page for translations sets.
 	 *
@@ -99,13 +106,24 @@ class GP_Route_Translation_Set extends GP_Route_Main {
 	 */
 	public function delete_get( $set_id ) {
 		$items = $this->get_set_project_and_locale_from_set_id_or_404( $set_id );
-		if ( !$items ) return;
+		if ( ! $items ) {
+			return;
+		}
+
 		list( $set, $project, $locale ) = $items;
-		if ( $this->cannot_and_redirect( 'delete', 'project', $set->project_id, gp_url_project( $project ) ) ) return;
+		if ( $this->cannot_and_redirect( 'delete', 'project', $set->project_id, gp_url_project( $project ) ) ) {
+			return;
+		}
+
 		$url = gp_url_project( $project, gp_url_join( $set->locale, $set->slug ) );
 		$this->tmpl( 'translation-set-delete', get_defined_vars() );
 	}
-	
+
+	/**
+	 * Determines whether the current user can edit a translation set.
+	 *
+	 * @param GP_Translation_Set $set The translation set to edit.
+	 */
 	private function cannot_edit_set_and_redirect( $set ) {
 		return $this->cannot_and_redirect( 'write', 'project', $set->project_id );
 	}

--- a/gp-includes/routes/translation-set.php
+++ b/gp-includes/routes/translation-set.php
@@ -69,8 +69,7 @@ class GP_Route_Translation_Set extends GP_Route_Main {
 		$this->redirect( gp_url_project_locale( $project, $new_set->locale, $new_set->slug ) );
 	}
 
-	public function delete_post() {
-		$set_id = gp_post( 'translation_set' );
+	public function delete_post( $set_id ) {
 		$items = $this->get_set_project_and_locale_from_set_id_or_404( $set_id );
 		if ( !$items ) return;
 		list( $set, $project, $locale ) = $items;

--- a/gp-includes/template-links.php
+++ b/gp-includes/template-links.php
@@ -89,17 +89,43 @@ function gp_link_set_edit() {
 	echo call_user_func_array('gp_link_set_edit_get', $args);
 }
 
+/**
+ * Creates a html link to the delete page for translations sets.  Does the heavy lifting for gp_link_set_delete.
+ *
+ * @since 1.1.0
+ *
+ * @param GP_Translation_Set $set The translation set to link to.
+ * @param GP_Project $project The project the translation set belongs to.
+ * @param string $text The text to use for the link.
+ * @param array $attrs Additional attributes to use to determine the classes for the link.
+ *
+ * @return string $link
+ */
 function gp_link_set_delete_get( $set, $project, $text = false, $attrs = array() ) {
 	if ( ! GP::$permission->current_user_can( 'write', 'project', $project->id ) ) {
 		return '';
 	}
-	$text = $text? $text : __( 'Delete', 'glotpress' );
+	
+	if ( false === $text ) {
+		$text = __( 'Delete', 'glotpress' );
+	}
+	
 	return gp_link_get( gp_url( gp_url_join( '/sets', $set->id, '-delete' ) ), $text, gp_attrs_add_class( $attrs, 'action edit' ) );
 }
 
-function gp_link_set_delete() {
-	$args = func_get_args();
-	echo call_user_func_array('gp_link_set_delete_get', $args);
+/*
+ * Outputs a html link to the delete page for translations sets.  Does the heavy lifting for gp_link_set_delete.
+ *
+ * @since 1.1.0
+ *
+ * @param GP_Translation_Set $set The translation set to link to.
+ * @param GP_Project $project The project the translation set belongs to.
+ * @param string $text The text to use for the link.
+ * @param array $attrs Additional attributes to use to determine the classes for the link.
+ *
+ */
+function gp_link_set_delete( $set, $project, $text = false, $attrs = array() ) {
+	echo gp_link_set_delete_get( $set, $project, $text, $attrs );
 }
 
 function gp_link_glossary_edit_get( $glossary, $set, $text = false, $attrs = array() ) {
@@ -116,6 +142,18 @@ function gp_link_glossary_edit() {
 	echo call_user_func_array('gp_link_glossary_edit_get', $args);
 }
 
+/**
+ * Creates a html link to the delete page for translations sets.  Does the heavy lifting for gp_link_glossary_delete.
+ *
+ * @since 1.1.0
+ *
+ * @param GP_Glossary $glossary The glossary to link to.
+ * @param GP_Translation_Set $set The translation set the glossary is for.
+ * @param string $text The text to use for the link.
+ * @param array $attrs Additional attributes to use to determine the classes for the link.
+ *
+ * @return string $link
+ */
 function gp_link_glossary_delete_get( $glossary, $set, $text = false, $attrs = array() ) {
 	if ( ! GP::$permission->current_user_can( 'approve', 'translation-set', $set->id ) ) {
 		return '';
@@ -125,7 +163,17 @@ function gp_link_glossary_delete_get( $glossary, $set, $text = false, $attrs = a
 	return gp_link_get( gp_url( gp_url_join( '/glossaries', $glossary->id, '-delete' ) ), $text, gp_attrs_add_class( $attrs, 'action edit' ) );
 }
 
-function gp_link_glossary_delete() {
-	$args = func_get_args();
-	echo call_user_func_array('gp_link_glossary_delete_get', $args);
+/*
+ * Outputs a html link to the delete page for glossaries.
+ *
+ * @since 1.1.0
+ *
+ * @param GP_Glossary $glossary The glossary to link to.
+ * @param GP_Translation_Set $set The translation set the glossary is for.
+ * @param string $text The text to use for the link.
+ * @param array $attrs Additional attributes to use to determine the classes for the link.
+ *
+ */
+function gp_link_glossary_delete( $glossary, $set, $text = false, $attrs = array() ) {
+	echo gp_link_glossary_delete_get( $glossary, $set, $text, $attrs ); 
 }

--- a/gp-includes/template-links.php
+++ b/gp-includes/template-links.php
@@ -115,3 +115,17 @@ function gp_link_glossary_edit() {
 	$args = func_get_args();
 	echo call_user_func_array('gp_link_glossary_edit_get', $args);
 }
+
+function gp_link_glossary_delete_get( $glossary, $set, $text = false, $attrs = array() ) {
+	if ( ! GP::$permission->current_user_can( 'approve', 'translation-set', $set->id ) ) {
+		return '';
+	}
+
+	$text = $text? $text : __( 'Delete', 'glotpress' );
+	return gp_link_get( gp_url( gp_url_join( '/glossaries', $glossary->id, '-delete' ) ), $text, gp_attrs_add_class( $attrs, 'action edit' ) );
+}
+
+function gp_link_glossary_delete() {
+	$args = func_get_args();
+	echo call_user_func_array('gp_link_glossary_delete_get', $args);
+}

--- a/gp-includes/template-links.php
+++ b/gp-includes/template-links.php
@@ -59,7 +59,7 @@ function gp_link_project_delete_get( $project, $text = false, $attrs = array() )
 		return '';
 	}
 	$text = $text? $text : __( 'Delete', 'glotpress' );
-	return gp_link_get( gp_url_project( $project, '-delete' ), $text, gp_attrs_add_class( $attrs, 'action delete' ) );
+	return gp_link_get( gp_url_project( $project, '-delete' ), $text, gp_attrs_add_class( $attrs, 'action edit' ) );
 }
 
 function gp_link_project_delete() {
@@ -87,6 +87,19 @@ function gp_link_set_edit_get( $set, $project, $text = false, $attrs = array() )
 function gp_link_set_edit() {
 	$args = func_get_args();
 	echo call_user_func_array('gp_link_set_edit_get', $args);
+}
+
+function gp_link_set_delete_get( $set, $project, $text = false, $attrs = array() ) {
+	if ( ! GP::$permission->current_user_can( 'write', 'project', $project->id ) ) {
+		return '';
+	}
+	$text = $text? $text : __( 'Delete', 'glotpress' );
+	return gp_link_get( gp_url( gp_url_join( '/sets', $set->id, '-delete' ) ), $text, gp_attrs_add_class( $attrs, 'action edit' ) );
+}
+
+function gp_link_set_delete() {
+	$args = func_get_args();
+	echo call_user_func_array('gp_link_set_delete_get', $args);
 }
 
 function gp_link_glossary_edit_get( $glossary, $set, $text = false, $attrs = array() ) {

--- a/gp-includes/template-links.php
+++ b/gp-includes/template-links.php
@@ -55,7 +55,7 @@ function gp_link_project_edit() {
 }
 
 function gp_link_project_delete_get( $project, $text = false, $attrs = array() ) {
-	if ( ! GP::$permission->current_user_can( 'write', 'project', $project->id ) ) {
+	if ( ! GP::$permission->current_user_can( 'delete', 'project', $project->id ) ) {
 		return '';
 	}
 	$text = $text? $text : __( 'Delete', 'glotpress' );

--- a/gp-includes/template-links.php
+++ b/gp-includes/template-links.php
@@ -90,14 +90,16 @@ function gp_link_set_edit() {
 }
 
 /**
- * Creates a html link to the delete page for translations sets.  Does the heavy lifting for gp_link_set_delete.
+ * Creates a HTML link to the delete page for translations sets.
+ *
+ * Does the heavy lifting for gp_link_set_delete().
  *
  * @since 1.1.0
  *
- * @param GP_Translation_Set $set The translation set to link to.
- * @param GP_Project $project The project the translation set belongs to.
- * @param string $text The text to use for the link.
- * @param array $attrs Additional attributes to use to determine the classes for the link.
+ * @param GP_Translation_Set $set     The translation set to link to.
+ * @param GP_Project         $project The project the translation set belongs to.
+ * @param string             $text    The text to use for the link.
+ * @param array              $attrs   Additional attributes to use to determine the classes for the link.
  *
  * @return string $link
  */
@@ -105,29 +107,43 @@ function gp_link_set_delete_get( $set, $project, $text = false, $attrs = array()
 	if ( ! GP::$permission->current_user_can( 'write', 'project', $project->id ) ) {
 		return '';
 	}
-	
+
 	if ( false === $text ) {
 		$text = __( 'Delete', 'glotpress' );
 	}
-	
+
 	return gp_link_get( gp_url( gp_url_join( '/sets', $set->id, '-delete' ) ), $text, gp_attrs_add_class( $attrs, 'action edit' ) );
 }
 
-/*
- * Outputs a html link to the delete page for translations sets.  Does the heavy lifting for gp_link_set_delete.
+/**
+ * Outputs a HTML link to the delete page for translations sets.
+ *
+ * Does the heavy lifting for gp_link_set_delete().
  *
  * @since 1.1.0
  *
- * @param GP_Translation_Set $set The translation set to link to.
- * @param GP_Project $project The project the translation set belongs to.
- * @param string $text The text to use for the link.
- * @param array $attrs Additional attributes to use to determine the classes for the link.
- *
+ * @param GP_Translation_Set $set     The translation set to link to.
+ * @param GP_Project         $project The project the translation set belongs to.
+ * @param string             $text    The text to use for the link.
+ * @param array              $attrs   Additional attributes to use to determine the classes for the link.
  */
 function gp_link_set_delete( $set, $project, $text = false, $attrs = array() ) {
 	echo gp_link_set_delete_get( $set, $project, $text, $attrs );
 }
 
+/**
+ * Creates a HTML link to the delete page for translations sets.
+ *
+ * Does the heavy lifting for gp_link_glossary_delete.
+ *
+ * @since 1.0.0
+ *
+ * @param GP_Glossary        $glossary The glossary to link to.
+ * @param GP_Translation_Set $set      The translation set the glossary is for.
+ * @param string             $text     The text to use for the link.
+ * @param array              $attrs    Additional attributes to use to determine the classes for the link.
+ * @return string The HTML link.
+ */
 function gp_link_glossary_edit_get( $glossary, $set, $text = false, $attrs = array() ) {
 	if ( ! GP::$permission->current_user_can( 'approve', 'translation-set', $set->id ) ) {
 		return '';
@@ -143,16 +159,17 @@ function gp_link_glossary_edit() {
 }
 
 /**
- * Creates a html link to the delete page for translations sets.  Does the heavy lifting for gp_link_glossary_delete.
+ * Creates a HTML link to the delete page for translations sets.
+ *
+ * Does the heavy lifting for gp_link_glossary_delete.
  *
  * @since 1.1.0
  *
- * @param GP_Glossary $glossary The glossary to link to.
- * @param GP_Translation_Set $set The translation set the glossary is for.
- * @param string $text The text to use for the link.
- * @param array $attrs Additional attributes to use to determine the classes for the link.
- *
- * @return string $link
+ * @param GP_Glossary        $glossary The glossary to link to.
+ * @param GP_Translation_Set $set      The translation set the glossary is for.
+ * @param string             $text     The text to use for the link.
+ * @param array              $attrs    Additional attributes to use to determine the classes for the link.
+ * @return string The HTML link.
  */
 function gp_link_glossary_delete_get( $glossary, $set, $text = false, $attrs = array() ) {
 	if ( ! GP::$permission->current_user_can( 'approve', 'translation-set', $set->id ) ) {
@@ -163,17 +180,16 @@ function gp_link_glossary_delete_get( $glossary, $set, $text = false, $attrs = a
 	return gp_link_get( gp_url( gp_url_join( '/glossaries', $glossary->id, '-delete' ) ), $text, gp_attrs_add_class( $attrs, 'action edit' ) );
 }
 
-/*
- * Outputs a html link to the delete page for glossaries.
+/**
+ * Outputs a HTML link to the delete page for glossaries.
  *
  * @since 1.1.0
  *
- * @param GP_Glossary $glossary The glossary to link to.
- * @param GP_Translation_Set $set The translation set the glossary is for.
- * @param string $text The text to use for the link.
- * @param array $attrs Additional attributes to use to determine the classes for the link.
- *
+ * @param GP_Glossary        $glossary The glossary to link to.
+ * @param GP_Translation_Set $set      The translation set the glossary is for.
+ * @param string             $text     The text to use for the link.
+ * @param array              $attrs    Additional attributes to use to determine the classes for the link.
  */
 function gp_link_glossary_delete( $glossary, $set, $text = false, $attrs = array() ) {
-	echo gp_link_glossary_delete_get( $glossary, $set, $text, $attrs ); 
+	echo gp_link_glossary_delete_get( $glossary, $set, $text, $attrs );
 }

--- a/gp-includes/template.php
+++ b/gp-includes/template.php
@@ -507,8 +507,8 @@ function gp_project_actions( $project, $translation_sets ) {
 		gp_link_get( gp_url_project( '', '-new', array('parent_project_id' => $project->id) ), __( 'New Sub-Project', 'glotpress' ) ),
 		gp_link_get( gp_url( '/sets/-new', array( 'project_id' => $project->id ) ), __( 'New Translation Set', 'glotpress' ) ),
 		gp_link_get( gp_url_project( $project, array( '-mass-create-sets' ) ), __( 'Mass-create Translation Sets', 'glotpress' ) ),
-		gp_link_get( gp_url_project( $project, '-branch'), __( 'Branch Project', 'glotpress' ) ),
-		gp_link_get( gp_url_project( $project, '-delete'), __( 'Delete Project', 'glotpress' ) ),
+		gp_link_get( gp_url_project( $project, '-branch' ), __( 'Branch Project', 'glotpress' ) ),
+		gp_link_get( gp_url_project( $project, '-delete' ), __( 'Delete Project', 'glotpress' ) ),
 	);
 
 	/**

--- a/gp-includes/template.php
+++ b/gp-includes/template.php
@@ -508,7 +508,7 @@ function gp_project_actions( $project, $translation_sets ) {
 		gp_link_get( gp_url( '/sets/-new', array( 'project_id' => $project->id ) ), __( 'New Translation Set', 'glotpress' ) ),
 		gp_link_get( gp_url_project( $project, array( '-mass-create-sets' ) ), __( 'Mass-create Translation Sets', 'glotpress' ) ),
 		gp_link_get( gp_url_project( $project, '-branch'), __( 'Branch Project', 'glotpress' ) ),
-		gp_link_with_ays_get( gp_url_project( $project, '-delete'), __( 'Delete Project', 'glotpress' ), array( 'ays-text' => __( 'Do you really want to delete this project?', 'glotpress' ) ) )
+		gp_link_get( gp_url_project( $project, '-delete'), __( 'Delete Project', 'glotpress' ) ),
 	);
 
 	/**

--- a/gp-includes/thing.php
+++ b/gp-includes/thing.php
@@ -383,7 +383,7 @@ class GP_Thing {
 	 *
 	 * @param $where array An array of conditions to use to for a SQL "where" clause, if not passed, no rows will be deleted.
 	 */
-	function delete_many( $where = null ) {
+	public function delete_many( $where = null ) {
 		if ( null != $where ) {
 			return $this->delete_all( $where );
 		}

--- a/gp-includes/thing.php
+++ b/gp-includes/thing.php
@@ -351,10 +351,22 @@ class GP_Thing {
 		return $update_res;
 	}
 
+	/**
+	 * Deletes a single row
+	 *
+	 * @since 1.0.0
+	 */
 	public function delete() {
 		return $this->delete_all( array( 'id' => $this->id ) );
 	}
 
+	/**
+	 * Deletes all or multiple rows
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param $where array An array of conditions to use to for a SQL "where" clause, if null, not used and all matching rows will be deleted.
+	 */
 	public function delete_all( $where = null  ) {
 		$query = "DELETE FROM $this->table";
 		$conditions_sql = $this->sql_from_conditions( $where );
@@ -364,6 +376,21 @@ class GP_Thing {
 		return $result;
 	}
 
+	/**
+	 * Deletes multiple rows
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param $where array An array of conditions to use to for a SQL "where" clause, if not passed, no rows will be deleted.
+	 */
+	function delete_many( $where = null ) {
+		if ( null != $where ) {
+			return $this->delete_all( $where );
+		}
+		
+		return false;
+	}
+	
 	// Fields handling
 
 	public function set_fields( $db_object ) {

--- a/gp-includes/thing.php
+++ b/gp-includes/thing.php
@@ -365,9 +365,9 @@ class GP_Thing {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param $where array An array of conditions to use to for a SQL "where" clause, if null, not used and all matching rows will be deleted.
+	 * @param array $where An array of conditions to use to for a SQL "where" clause, if null, not used and all matching rows will be deleted.
 	 */
-	public function delete_all( $where = null  ) {
+	public function delete_all( $where = null ) {
 		$query = "DELETE FROM $this->table";
 		$conditions_sql = $this->sql_from_conditions( $where );
 		if ( $conditions_sql ) $query .= " WHERE $conditions_sql";
@@ -381,17 +381,15 @@ class GP_Thing {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @param $where array An array of conditions to use to for a SQL "where" clause, if not passed, no rows will be deleted.
+	 * @param array $where An array of conditions to use to for a SQL "where" clause, if not passed, no rows will be deleted.
 	 */
 	public function delete_many( $where = null ) {
-		if ( null != $where ) {
+		if ( null !== $where ) {
 			return $this->delete_all( $where );
 		}
-		
+
 		return false;
 	}
-	
-	// Fields handling
 
 	public function set_fields( $db_object ) {
 		$db_object = $this->normalize_fields( $db_object );

--- a/gp-includes/things/glossary.php
+++ b/gp-includes/things/glossary.php
@@ -105,6 +105,13 @@ class GP_Glossary extends GP_Thing {
 		);
 	}
 
+	/**
+	 * Deletes a glossary and all of it's entries.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool
+	 */
 	public function delete() {
 		GP::$glossary_entry->delete_many( array( 'glossary_id', $this->id ) );
 		

--- a/gp-includes/things/glossary.php
+++ b/gp-includes/things/glossary.php
@@ -106,15 +106,7 @@ class GP_Glossary extends GP_Thing {
 	}
 
 	public function delete() {
-		$glossary_entries = GP::$glossary_entry->find_many( array( 'glossary_id', $this->id ) );
-		
-		if ( ! empty( $glossary_entries ) ) {
-			foreach ( $glossary_entries as $entry ) {
-				if ( ! $entry->delete() ) {
-					return false;
-				}
-			}
-		}
+		GP::$glossary_entry->delete_many( array( 'glossary_id', $this->id ) );
 		
 		return parent::delete();
 	}

--- a/gp-includes/things/glossary.php
+++ b/gp-includes/things/glossary.php
@@ -114,7 +114,7 @@ class GP_Glossary extends GP_Thing {
 	 */
 	public function delete() {
 		GP::$glossary_entry->delete_many( array( 'glossary_id', $this->id ) );
-		
+
 		return parent::delete();
 	}
 }

--- a/gp-includes/things/glossary.php
+++ b/gp-includes/things/glossary.php
@@ -106,7 +106,7 @@ class GP_Glossary extends GP_Thing {
 	}
 
 	public function delete() {
-		$glossary_entries = GP::$glossary_entries->find_many( array( 'glossary_id', $this->id ) );
+		$glossary_entries = GP::$glossary_entry->find_many( array( 'glossary_id', $this->id ) );
 		
 		if ( ! empty( $glossary_entries ) ) {
 			foreach ( $glossary_entries as $entry ) {

--- a/gp-includes/things/glossary.php
+++ b/gp-includes/things/glossary.php
@@ -105,6 +105,19 @@ class GP_Glossary extends GP_Thing {
 		);
 	}
 
+	public function delete() {
+		$glossary_entries = GP::$glossary_entries->find_many( array( 'glossary_id', $this->id ) );
+		
+		if ( ! empty( $glossary_entries ) ) {
+			foreach ( $glossary_entries as $entry ) {
+				if ( ! $entry->delete() ) {
+					return false;
+				}
+			}
+		}
+		
+		return parent::delete();
+	}
 }
 
 GP::$glossary = new GP_Glossary();

--- a/gp-includes/things/project.php
+++ b/gp-includes/things/project.php
@@ -372,7 +372,7 @@ class GP_Project extends GP_Thing {
 	public function delete() {
 		$child_projects = GP::$project->find_many( array( 'parent_project_id' => $this->id ) );
 
-		if ( $child_projects ) {
+		if ( ! empty( $child_projects ) ) {
 			foreach ( $child_projects as $project ) {
 				if ( ! $project->delete() ) {
 					return false;
@@ -381,9 +381,9 @@ class GP_Project extends GP_Thing {
 		}
 		
 		$translation_sets = GP::$translation_set->find_many( array( 'project_id' => $this->id ) );
-		
-		if ( $translation_sets ) {
-			foreach ( $tranlsation_sets as $set ) {
+
+		if ( ! empty( $translation_sets ) ) {
+			foreach ( $translation_sets as $set ) {
 				if ( ! $set->delete() ) {
 					return false;
 				}
@@ -392,7 +392,7 @@ class GP_Project extends GP_Thing {
 		
 		$originals = GP::$original->find_many( array( 'project_id' => $this->id ) );
 		
-		if ( $originals ) {
+		if ( ! empty( $originals ) ) {
 			foreach ( $originals as $original ) {
 				if ( ! $original->delete() ) {
 					return false;

--- a/gp-includes/things/project.php
+++ b/gp-includes/things/project.php
@@ -369,5 +369,39 @@ class GP_Project extends GP_Thing {
 		}
 	}
 
+	public function delete() {
+		$child_projects = GP::$project->find_many( array( 'parent_project_id' => $this->id ) );
+
+		if ( $child_projects ) {
+			foreach ( $child_projects as $project ) {
+				if ( ! $project->delete() ) {
+					return false;
+				}
+			}
+		}
+		
+		$translation_sets = GP::$translation_set->find_many( array( 'project_id' => $this->id ) );
+		
+		if ( $translation_sets ) {
+			foreach ( $tranlsation_sets as $set ) {
+				if ( ! $set->delete() ) {
+					return false;
+				}
+			}
+		}
+		
+		$originals = GP::$original->find_many( array( 'project_id' => $this->id ) );
+		
+		if ( $originals ) {
+			foreach ( $originals as $original ) {
+				if ( ! $original->delete() ) {
+					return false;
+				}
+			}
+		}
+
+		return parent::delete();
+	}
+	
 }
 GP::$project = new GP_Project();

--- a/gp-includes/things/project.php
+++ b/gp-includes/things/project.php
@@ -378,13 +378,12 @@ class GP_Project extends GP_Thing {
 	 */
 	public function delete() {
 		GP::$project->delete_many( array( 'parent_project_id' => $this->id ) );
-		
+
 		GP::$translation_set->delete_many( array( 'project_id' => $this->id ) );
 
 		GP::$original->delete_many( array( 'project_id' => $this->id ) );
-		
+
 		return parent::delete();
 	}
-	
 }
 GP::$project = new GP_Project();

--- a/gp-includes/things/project.php
+++ b/gp-includes/things/project.php
@@ -369,6 +369,13 @@ class GP_Project extends GP_Thing {
 		}
 	}
 
+	/**
+	 * Deletes a project and all of sub projects, translations, translation sets, originals and glossaries.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool
+	 */
 	public function delete() {
 		GP::$project->delete_many( array( 'parent_project_id' => $this->id ) );
 		

--- a/gp-includes/things/project.php
+++ b/gp-includes/things/project.php
@@ -370,36 +370,12 @@ class GP_Project extends GP_Thing {
 	}
 
 	public function delete() {
-		$child_projects = GP::$project->find_many( array( 'parent_project_id' => $this->id ) );
-
-		if ( ! empty( $child_projects ) ) {
-			foreach ( $child_projects as $project ) {
-				if ( ! $project->delete() ) {
-					return false;
-				}
-			}
-		}
+		GP::$project->delete_many( array( 'parent_project_id' => $this->id ) );
 		
-		$translation_sets = GP::$translation_set->find_many( array( 'project_id' => $this->id ) );
+		GP::$translation_set->delete_many( array( 'project_id' => $this->id ) );
 
-		if ( ! empty( $translation_sets ) ) {
-			foreach ( $translation_sets as $set ) {
-				if ( ! $set->delete() ) {
-					return false;
-				}
-			}
-		}
+		GP::$original->delete_many( array( 'project_id' => $this->id ) );
 		
-		$originals = GP::$original->find_many( array( 'project_id' => $this->id ) );
-		
-		if ( ! empty( $originals ) ) {
-			foreach ( $originals as $original ) {
-				if ( ! $original->delete() ) {
-					return false;
-				}
-			}
-		}
-
 		return parent::delete();
 	}
 	

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -338,7 +338,7 @@ class GP_Translation_Set extends GP_Thing {
 		return GP::$translation->last_modified( $this );
 	}
 	
-	function delete() {
+	public function delete() {
 		$translations = GP::$translation->find_many( array( 'translation_set_id' => $this->id ) );
 
 		if ( $translations ) {

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -337,7 +337,7 @@ class GP_Translation_Set extends GP_Thing {
 	public function last_modified() {
 		return GP::$translation->last_modified( $this );
 	}
-	
+
 	/**
 	 * Deletes a translation set and all of it's translations and glossaries.
 	 *
@@ -349,7 +349,7 @@ class GP_Translation_Set extends GP_Thing {
 		GP::$translation->delete_many( array( 'translation_set_id' => $this->id ) );
 
 		GP::$glossary->delete_many( array( 'translation_set_id', $this->id ) );
-		
+
 		return parent::delete();
 	}
 }

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -341,14 +341,24 @@ class GP_Translation_Set extends GP_Thing {
 	public function delete() {
 		$translations = GP::$translation->find_many( array( 'translation_set_id' => $this->id ) );
 
-		if ( $translations ) {
+		if ( ! empty( $translations ) ) {
 			foreach ( $tranlsations as $translation ) {
 				if ( ! $translation->delete() ) {
 					return false;
 				}
 			}
 		}
-	
+
+		$glossaries = GP::$glossary->find_many( array( 'translation_set_id', $this->id ) );
+		
+		if ( ! empty( $glossaries ) ) {
+			foreach ( $glossaries as $glossary ) {
+				if ( ! $glossary->delete() ) {
+					return false;
+				}
+			}
+		}
+		
 		return parent::delete();
 	}
 }

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -342,7 +342,7 @@ class GP_Translation_Set extends GP_Thing {
 		$translations = GP::$translation->find_many( array( 'translation_set_id' => $this->id ) );
 
 		if ( ! empty( $translations ) ) {
-			foreach ( $tranlsations as $translation ) {
+			foreach ( $translations as $translation ) {
 				if ( ! $translation->delete() ) {
 					return false;
 				}

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -337,5 +337,19 @@ class GP_Translation_Set extends GP_Thing {
 	public function last_modified() {
 		return GP::$translation->last_modified( $this );
 	}
+	
+	function delete() {
+		$translations = GP::$translations->find_many( array( 'translation_set_id' => $this->id ) );
+
+		if ( $translations ) {
+			foreach ( $tranlsations as $translation ) {
+				if ( ! $translation->delete() ) {
+					return false;
+				}
+			}
+		}
+	
+		return parent::delete();
+	}
 }
 GP::$translation_set = new GP_Translation_Set();

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -339,7 +339,7 @@ class GP_Translation_Set extends GP_Thing {
 	}
 	
 	function delete() {
-		$translations = GP::$translations->find_many( array( 'translation_set_id' => $this->id ) );
+		$translations = GP::$translation->find_many( array( 'translation_set_id' => $this->id ) );
 
 		if ( $translations ) {
 			foreach ( $tranlsations as $translation ) {

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -338,6 +338,13 @@ class GP_Translation_Set extends GP_Thing {
 		return GP::$translation->last_modified( $this );
 	}
 	
+	/**
+	 * Deletes a translation set and all of it's translations and glossaries.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool
+	 */
 	public function delete() {
 		GP::$translation->delete_many( array( 'translation_set_id' => $this->id ) );
 

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -339,25 +339,9 @@ class GP_Translation_Set extends GP_Thing {
 	}
 	
 	public function delete() {
-		$translations = GP::$translation->find_many( array( 'translation_set_id' => $this->id ) );
+		GP::$translation->delete_many( array( 'translation_set_id' => $this->id ) );
 
-		if ( ! empty( $translations ) ) {
-			foreach ( $translations as $translation ) {
-				if ( ! $translation->delete() ) {
-					return false;
-				}
-			}
-		}
-
-		$glossaries = GP::$glossary->find_many( array( 'translation_set_id', $this->id ) );
-		
-		if ( ! empty( $glossaries ) ) {
-			foreach ( $glossaries as $glossary ) {
-				if ( ! $glossary->delete() ) {
-					return false;
-				}
-			}
-		}
+		GP::$glossary->delete_many( array( 'translation_set_id', $this->id ) );
 		
 		return parent::delete();
 	}

--- a/gp-templates/glossary-delete.php
+++ b/gp-templates/glossary-delete.php
@@ -14,7 +14,6 @@ gp_tmpl_header();
 <form action="" method="post">
 	<p>
 		<?php _e( 'Note this will delete all entries associated with this glossary!', 'glotpress' ); ?>
-		<input type="hidden" name="glossary" value="<?php echo $glossary->id; ?>" id="glossary" />
 	</p>
 
 	<p>

--- a/gp-templates/glossary-delete.php
+++ b/gp-templates/glossary-delete.php
@@ -1,0 +1,26 @@
+<?php
+gp_title( __( 'Delete Glossary &lt; GlotPress', 'glotpress' ) );
+gp_breadcrumb( array(
+	gp_project_links_from_root( $project ),
+	gp_link_get( gp_url_project_locale( $project->path, $locale->slug, $translation_set->slug ), $translation_set->name ),
+	gp_link_get( gp_url_project_locale( $project->path, $locale->slug, $translation_set->slug ) . '/glossary', __( 'Glossary', 'glotpress' ) ),
+	__( 'delete', 'glotpress' )
+) );
+gp_tmpl_header();
+?>
+
+<h2><?php _e( 'Delete Glossary', 'glotpress' ); ?></h2>
+
+<form action="" method="post">
+	<p>
+		<?php _e( 'Note this will delete all entries associated with this glossary!', 'glotpress' ); ?>
+		<input type="hidden" name="glossary" value="<?php echo $glossary->id; ?>" id="glossary" />
+	</p>
+
+	<p>
+		<input type="submit" name="submit" value="<?php esc_attr_e( 'Delete', 'glotpress' ); ?>" id="submit" />
+		<span class="or-cancel"><?php _e( 'or', 'glotpress' ); ?> <a href="javascript:history.back();"><?php _e( 'Cancel', 'glotpress' ); ?></a></span>
+	</p>
+</form>
+
+<?php gp_tmpl_footer();

--- a/gp-templates/glossary-delete.php
+++ b/gp-templates/glossary-delete.php
@@ -3,7 +3,7 @@ gp_title( __( 'Delete Glossary &lt; GlotPress', 'glotpress' ) );
 gp_breadcrumb( array(
 	gp_project_links_from_root( $project ),
 	gp_link_get( gp_url_project_locale( $project->path, $locale->slug, $translation_set->slug ), $translation_set->name ),
-	gp_link_get( gp_url_project_locale( $project->path, $locale->slug, $translation_set->slug ) . '/glossary', __( 'Glossary', 'glotpress' ) ),
+	gp_link_get( gp_url_join( gp_url_project_locale( $project->path, $locale->slug, $translation_set->slug ), '/glossary' ), __( 'Glossary', 'glotpress' ) ),
 	__( 'delete', 'glotpress' )
 ) );
 gp_tmpl_header();
@@ -18,7 +18,7 @@ gp_tmpl_header();
 
 	<p>
 		<input type="submit" name="submit" value="<?php esc_attr_e( 'Delete', 'glotpress' ); ?>" id="submit" />
-		<span class="or-cancel"><?php _e( 'or', 'glotpress' ); ?> <a href="javascript:history.back();"><?php _e( 'Cancel', 'glotpress' ); ?></a></span>
+		<span class="or-cancel"><?php _e( 'or', 'glotpress' ); ?> <a href="<?php echo gp_url_join( gp_url_project_locale( $project->path, $locale->slug, $translation_set->slug ),  '/glossary' ); ?>"><?php _e( 'Cancel', 'glotpress' ); ?></a></span>
 	</p>
 </form>
 

--- a/gp-templates/glossary-delete.php
+++ b/gp-templates/glossary-delete.php
@@ -1,10 +1,18 @@
 <?php
+/**
+ * Templates: Delete Glossary
+ *
+ * @package GlotPress
+ * @subpackage Templates
+ * @since 1.1.0
+ */
+
 gp_title( __( 'Delete Glossary &lt; GlotPress', 'glotpress' ) );
 gp_breadcrumb( array(
 	gp_project_links_from_root( $project ),
 	gp_link_get( gp_url_project_locale( $project->path, $locale->slug, $translation_set->slug ), $translation_set->name ),
 	gp_link_get( gp_url_join( gp_url_project_locale( $project->path, $locale->slug, $translation_set->slug ), '/glossary' ), __( 'Glossary', 'glotpress' ) ),
-	__( 'delete', 'glotpress' )
+	__( 'delete', 'glotpress' ),
 ) );
 gp_tmpl_header();
 ?>
@@ -18,7 +26,7 @@ gp_tmpl_header();
 
 	<p>
 		<input type="submit" name="submit" value="<?php esc_attr_e( 'Delete', 'glotpress' ); ?>" id="submit" />
-		<span class="or-cancel"><?php _e( 'or', 'glotpress' ); ?> <a href="<?php echo gp_url_join( gp_url_project_locale( $project->path, $locale->slug, $translation_set->slug ),  '/glossary' ); ?>"><?php _e( 'Cancel', 'glotpress' ); ?></a></span>
+		<span class="or-cancel"><?php _e( 'or', 'glotpress' ); ?> <a href="<?php echo esc_url( gp_url_join( gp_url_project_locale( $project->path, $locale->slug, $translation_set->slug ),  '/glossary' ) ); ?>"><?php _e( 'Cancel', 'glotpress' ); ?></a></span>
 	</p>
 </form>
 

--- a/gp-templates/glossary-view.php
+++ b/gp-templates/glossary-view.php
@@ -18,6 +18,7 @@ gp_tmpl_header();
 
 <h2><?php printf( _x( 'Glossary for %1$s translation of %2$s', '{language} / { project name}', 'glotpress' ), esc_html( $translation_set->name ), esc_html( $project->name ) ); ?>
 	<?php gp_link_glossary_edit( $glossary, $translation_set, __( '(edit)', 'glotpress' ) ); ?>
+	<?php gp_link_glossary_delete( $glossary, $translation_set, __( '(delete)', 'glotpress' ) ); ?>
 </h2>
 
 <?php

--- a/gp-templates/project-delete.php
+++ b/gp-templates/project-delete.php
@@ -10,7 +10,7 @@ gp_tmpl_header();
 	</p>
 	<p>
 		<input type="submit" name="submit" value="<?php esc_attr_e( 'Delete', 'glotpress' ); ?>" id="submit" />
-		<span class="or-cancel"><?php _e( 'or', 'glotpress' ); ?> <a href="javascript:history.back();"><?php _e( 'Cancel', 'glotpress' ); ?></a></span>
+		<span class="or-cancel"><?php _e( 'or', 'glotpress' ); ?> <a href="<?php echo gp_url_project( $project ); ?>"><?php _e( 'Cancel', 'glotpress' ); ?></a></span>
 	</p>
 </form>
 <?php gp_tmpl_footer();

--- a/gp-templates/project-delete.php
+++ b/gp-templates/project-delete.php
@@ -7,8 +7,6 @@ gp_tmpl_header();
 <form action="" method="post">
 	<p>
 		<?php _e( 'Note this will delete all translations, translation sets and child projects!', 'glotpress' ); ?>
-		<input type="hidden" name="project" value="<?php echo $project->id; ?>" id="project" />
-		<input type="hidden" name="project_name" value="<?php echo $project->name; ?>" id="project_name" />
 	</p>
 	<p>
 		<input type="submit" name="submit" value="<?php esc_attr_e( 'Delete', 'glotpress' ); ?>" id="submit" />

--- a/gp-templates/project-delete.php
+++ b/gp-templates/project-delete.php
@@ -3,7 +3,7 @@ gp_title( sprintf( __( 'Delete Project %s &lt; GlotPress', 'glotpress' ),  $proj
 gp_breadcrumb_project( $project );
 gp_tmpl_header();
 ?>
-<h2><?php echo wptexturize( sprintf( __( 'Delete project "%s"', 'glotpress' ), esc_html( $project->name ) ) ); ?></h2>
+<h2><?php echo sprintf( __( 'Delete project &#8220;%s&#8221;', 'glotpress' ), esc_html( $project->name ) ); ?></h2>
 <form action="" method="post">
 	<p>
 		<?php _e( 'Note this will delete all translations, translation sets and child projects!', 'glotpress' ); ?>

--- a/gp-templates/project-delete.php
+++ b/gp-templates/project-delete.php
@@ -1,0 +1,18 @@
+<?php
+gp_title( sprintf( __( 'Delete Project %s &lt; GlotPress', 'glotpress' ),  $project->name ) );
+gp_breadcrumb_project( $project );
+gp_tmpl_header();
+?>
+<h2><?php echo wptexturize( sprintf( __( 'Delete project "%s"', 'glotpress' ), esc_html( $project->name ) ) ); ?></h2>
+<form action="" method="post">
+	<p>
+		<?php _e( 'Note this will delete all translations, translation sets and child projects!', 'glotpress' ); ?>
+		<input type="hidden" name="project" value="<?php echo $project->id; ?>" id="project" />
+		<input type="hidden" name="project_name" value="<?php echo $project->name; ?>" id="project_name" />
+	</p>
+	<p>
+		<input type="submit" name="submit" value="<?php esc_attr_e( 'Delete', 'glotpress' ); ?>" id="submit" />
+		<span class="or-cancel"><?php _e( 'or', 'glotpress' ); ?> <a href="javascript:history.back();"><?php _e( 'Cancel', 'glotpress' ); ?></a></span>
+	</p>
+</form>
+<?php gp_tmpl_footer();

--- a/gp-templates/project-delete.php
+++ b/gp-templates/project-delete.php
@@ -1,16 +1,24 @@
 <?php
+/**
+ * Templates: Delete Project
+ *
+ * @package GlotPress
+ * @subpackage Templates
+ * @since 1.1.0
+ */
+
 gp_title( sprintf( __( 'Delete Project %s &lt; GlotPress', 'glotpress' ),  $project->name ) );
 gp_breadcrumb_project( $project );
 gp_tmpl_header();
 ?>
-<h2><?php echo sprintf( __( 'Delete project &#8220;%s&#8221;', 'glotpress' ), esc_html( $project->name ) ); ?></h2>
+<h2><?php printf( __( 'Delete project &#8220;%s&#8221;', 'glotpress' ), esc_html( $project->name ) ); ?></h2>
 <form action="" method="post">
 	<p>
 		<?php _e( 'Note this will delete all translations, translation sets and child projects!', 'glotpress' ); ?>
 	</p>
 	<p>
 		<input type="submit" name="submit" value="<?php esc_attr_e( 'Delete', 'glotpress' ); ?>" id="submit" />
-		<span class="or-cancel"><?php _e( 'or', 'glotpress' ); ?> <a href="<?php echo gp_url_project( $project ); ?>"><?php _e( 'Cancel', 'glotpress' ); ?></a></span>
+		<span class="or-cancel"><?php _e( 'or', 'glotpress' ); ?> <a href="<?php echo esc_url( gp_url_project( $project ) ); ?>"><?php _e( 'Cancel', 'glotpress' ); ?></a></span>
 	</p>
 </form>
 <?php gp_tmpl_footer();

--- a/gp-templates/translation-set-delete.php
+++ b/gp-templates/translation-set-delete.php
@@ -10,7 +10,6 @@ gp_tmpl_header();
 <form action="" method="post">
 	<p>
 		<?php _e( 'Note this will delete all translations associated with this set!', 'glotpress' ); ?>
-		<input type="hidden" name="translation_set" value="<?php echo $set->id; ?>" id="translation_set" />
 	</p>
 	<p>
 		<input type="submit" name="submit" value="<?php esc_attr_e( 'Delete', 'glotpress' ); ?>" id="submit" />

--- a/gp-templates/translation-set-delete.php
+++ b/gp-templates/translation-set-delete.php
@@ -1,0 +1,20 @@
+<?php
+gp_title( sprintf( __( 'Delete Translation Set &lt; %s &lt; %s &lt; GlotPress', 'glotpress' ), $set->name, $project->name ) );
+gp_breadcrumb( array(
+	gp_project_links_from_root( $project ),
+	gp_link_get( $url, $locale->english_name . 'default' != $set->slug? ' '.$set->name : '' ),
+) );
+gp_tmpl_header();
+?>
+<h2><?php _e( 'Delete Translation Set', 'glotpress' ); ?></h2>
+<form action="" method="post">
+	<p>
+		<?php _e( 'Note this will delete all translations associated with this set!', 'glotpress' ); ?>
+		<input type="hidden" name="translation_set" value="<?php echo $project->id; ?>" id="translation_set" />
+	</p>
+	<p>
+		<input type="submit" name="submit" value="<?php esc_attr_e( 'Delete', 'glotpress' ); ?>" id="submit" />
+		<span class="or-cancel">or <a href="javascript:history.back();"><?php esc_attr_e( 'Cancel', 'glotpress' ); ?></a></span>
+	</p>
+</form>
+<?php gp_tmpl_footer();

--- a/gp-templates/translation-set-delete.php
+++ b/gp-templates/translation-set-delete.php
@@ -13,7 +13,7 @@ gp_tmpl_header();
 	</p>
 	<p>
 		<input type="submit" name="submit" value="<?php esc_attr_e( 'Delete', 'glotpress' ); ?>" id="submit" />
-		<span class="or-cancel">or <a href="javascript:history.back();"><?php esc_attr_e( 'Cancel', 'glotpress' ); ?></a></span>
+		<span class="or-cancel">or <a href="<?php echo gp_url_project_locale( $project, $locale->slug, $set->slug ); ?>"><?php esc_attr_e( 'Cancel', 'glotpress' ); ?></a></span>
 	</p>
 </form>
 <?php gp_tmpl_footer();

--- a/gp-templates/translation-set-delete.php
+++ b/gp-templates/translation-set-delete.php
@@ -10,7 +10,7 @@ gp_tmpl_header();
 <form action="" method="post">
 	<p>
 		<?php _e( 'Note this will delete all translations associated with this set!', 'glotpress' ); ?>
-		<input type="hidden" name="translation_set" value="<?php echo $project->id; ?>" id="translation_set" />
+		<input type="hidden" name="translation_set" value="<?php echo $set->id; ?>" id="translation_set" />
 	</p>
 	<p>
 		<input type="submit" name="submit" value="<?php esc_attr_e( 'Delete', 'glotpress' ); ?>" id="submit" />

--- a/gp-templates/translation-set-delete.php
+++ b/gp-templates/translation-set-delete.php
@@ -1,8 +1,16 @@
 <?php
+/**
+ * Templates: Delete Translation Set
+ *
+ * @package GlotPress
+ * @subpackage Templates
+ * @since 1.1.0
+ */
+
 gp_title( sprintf( __( 'Delete Translation Set &lt; %s &lt; %s &lt; GlotPress', 'glotpress' ), $set->name, $project->name ) );
 gp_breadcrumb( array(
 	gp_project_links_from_root( $project ),
-	gp_link_get( $url, $locale->english_name . 'default' != $set->slug? ' '.$set->name : '' ),
+	gp_link_get( $url, $locale->english_name . ( 'default' !== $set->slug ? ' ' . $set->name : '' ) ),
 ) );
 gp_tmpl_header();
 ?>
@@ -13,7 +21,7 @@ gp_tmpl_header();
 	</p>
 	<p>
 		<input type="submit" name="submit" value="<?php esc_attr_e( 'Delete', 'glotpress' ); ?>" id="submit" />
-		<span class="or-cancel">or <a href="<?php echo gp_url_project_locale( $project, $locale->slug, $set->slug ); ?>"><?php esc_attr_e( 'Cancel', 'glotpress' ); ?></a></span>
+		<span class="or-cancel">or <a href="<?php echo esc_url( gp_url_project_locale( $project, $locale->slug, $set->slug ) ); ?>"><?php _e( 'Cancel', 'glotpress' ); ?></a></span>
 	</p>
 </form>
 <?php gp_tmpl_footer();

--- a/gp-templates/translation-set-edit.php
+++ b/gp-templates/translation-set-edit.php
@@ -1,7 +1,7 @@
 <?php
 gp_title( sprintf( __( 'Edit Translation Set &lt; %s &lt; %s &lt; GlotPress', 'glotpress' ), $set->name, $project->name ) );
 gp_breadcrumb( array(
-	gp_link_project_get( $project, $project->name ),
+	gp_project_links_from_root( $project ),
 	gp_link_get( $url, $locale->english_name . 'default' != $set->slug? ' '.$set->name : '' ),
 ) );
 gp_tmpl_header();

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -20,6 +20,7 @@ $i = 0;
 <h2>
 	<?php printf( __( 'Translation of %s', 'glotpress' ), esc_html( $project->name )); ?>: <?php echo esc_html( $translation_set->name ); ?>
 	<?php gp_link_set_edit( $translation_set, $project, __( '(edit)', 'glotpress' ) ); ?>
+	<?php gp_link_set_delete( $translation_set, $project, __( '(delete)', 'glotpress' ) ); ?>
 	<?php if ( $glossary ): ?>
 	<?php echo gp_link( $glossary->path(), __( 'glossary', 'glotpress' ), array('class'=>'glossary-link') ); ?>
 	<?php elseif ( $can_approve ): ?>

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -13,9 +13,7 @@
 
 	<rule ref="WordPress.XSS.EscapeOutput">
 		<properties>
-			<property name="customAutoEscapedFunctions" value="gp_radio_buttons" type="array" />
-			<property name="customAutoEscapedFunctions" value="gp_select" type="array" />
-			<property name="customAutoEscapedFunctions" value="gp_projects_dropdown" type="array" />
+			<property name="customAutoEscapedFunctions" value="gp_radio_buttons=>gp_radio_buttons,gp_select=>gp_select,gp_projects_dropdown=>gp_projects_dropdown,gp_link_glossary_delete_get=>gp_link_glossary_delete_get,gp_link_set_delete_get=>gp_link_set_delete_get,__=>__" type="array" />
 		</properties>
 	</rule>
 

--- a/tests/tests_routes/test_route_translation_set.php
+++ b/tests/tests_routes/test_route_translation_set.php
@@ -139,4 +139,20 @@ class GP_Test_Route_Translation_Set extends GP_UnitTestCase_Route {
 		$this->set->reload();
 		$this->assertEquals( $_POST['set']['name'], $this->set->name );
 	}
+
+	function test_delete_post_with_a_non_existent_set_gives_404() {
+		$this->route->delete_post( 11 );
+	}
+
+	function test_delete_post_forbidden_redirect_if_not_logged_in() {
+		$this->route->delete_post( $this->set->id );
+		$this->assertNotAllowedRedirect();
+	}
+
+	function test_delete_post_forbidden_redirect_if_logged_in_but_without_sufficient_permissions() {
+		$this->set_normal_user_as_current();
+		$this->route->delete_post( $this->set->id );
+		$this->assertNotAllowedRedirect();
+	}
+
 }

--- a/tests/tests_things/test_thing_glossary.php
+++ b/tests/tests_things/test_thing_glossary.php
@@ -39,4 +39,12 @@ class GP_Test_Glossary extends GP_UnitTestCase {
 		$this->assertEquals( $glossary, $subsub_glossary );
 		$this->assertEquals( $glossary->path(), $subsub_glossary->path() );
 	}
+	
+	function test_delete() {
+		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => '1' ) );
+		$glossary->delete();
+		$new = GP::$glossary->by_set_id( '1' );
+		$this->assertNotEquals( $glossary, $new );
+		
+	}
 }

--- a/tests/tests_things/test_thing_glossary_entry.php
+++ b/tests/tests_things/test_thing_glossary_entry.php
@@ -49,5 +49,18 @@ class GP_Test_Glossary_Entry extends GP_UnitTestCase {
 		$this->assertCount( 9, GP::$glossary_entry->parts_of_speech );
 		$this->assertArrayHasKey( 'noun', GP::$glossary_entry->parts_of_speech );
 	}
+	
+	function test_delete() {
+		$entry = GP::$glossary_entry->create( array( 'glossary_id' => '1', 'term' => 'term', 'part_of_speech' => 'verb', 'last_edited_by' =>'1' ) );
+		
+		$pre_delete = GP::$glossary_entry->find_one( array( 'id' => $entry->id ) );
+
+		$entry->delete();
+		
+		$post_delete = GP::$glossary_entry->find_one( array( 'id' => $entry->id ) );
+
+		$this->assertFalse( empty( $pre_delete ) );
+		$this->assertNotEquals( $pre_delete, $post_delete );
+	}
 
 }

--- a/tests/tests_things/test_thing_original.php
+++ b/tests/tests_things/test_thing_original.php
@@ -249,7 +249,22 @@ class GP_Test_Thing_Original extends GP_UnitTestCase {
 		$this->assertEquals( 1, count( $set4_current_translations ) );
 		$this->assertEquals( $translation3->translation_0, $set4_current_translations[0]->translations[0] );
 	}
+	
+	function test_delete() {
+		$set = $this->factory->translation_set->create_with_project_and_locale( array(), array( 'name' => 'project_one' ) );
 
+		$original = $this->factory->original->create( array( 'project_id' => $set->project_id, 'status' => '+active', 'singular' => '%s baba', 'plural' => '%s babas' ) );
+		
+		$pre_delete = GP::$original->find_one( array( 'id' => $original->id ) );
+		
+		$original->delete();
+		
+		$post_delete = GP::$original->find_one( array( 'id' => $original->id ) );
+		
+		$this->assertFalse( empty( $pre_delete ) );
+		$this->assertNotEquals( $pre_delete, $post_delete );
+	}
+	
 	/**
 	 * @ticket gh-332
 	 */

--- a/tests/tests_things/test_thing_project.php
+++ b/tests/tests_things/test_thing_project.php
@@ -275,4 +275,17 @@ class GP_Test_Project extends GP_UnitTestCase {
 		$this->assertNotEquals( false, $branch_other_sub );
 	}
 
+	function test_delete() {
+		$project = GP::$project->create( array( 'name' => 'Root', 'slug' => 'root' ) );
+		
+		$pre_delete = GP::$project->find_one( array( 'id' => $project->id ) );
+
+		$project->delete();
+		
+		$post_delete = GP::$project->find_one( array( 'id' => $project->id ) );
+		
+		$this->assertFalse( empty( $pre_delete ) );
+		$this->assertNotEquals( $pre_delete, $post_delete );
+	}
+
 }

--- a/tests/tests_things/test_thing_translation.php
+++ b/tests/tests_things/test_thing_translation.php
@@ -321,4 +321,18 @@ class GP_Test_Thing_Translation extends GP_UnitTestCase {
 		$set2_current_translations = GP::$translation->for_export( $project2, $set2, array( 'status' => 'waiting' ) );
 		$this->assertEquals( 0, count( $set2_current_translations ) );
 	}
+	
+	function test_delete() {
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$translation = $this->factory->translation->create_with_original_for_translation_set( $set );
+		
+		$pre_delete = GP::$translation->find_one( array( 'id' => $translation->id ) );
+		
+		$translation->delete();
+		
+		$post_delete = GP::$translation->find_one( array( 'id' => $translation->id ) );
+		
+		$this->assertFalse( empty( $pre_delete ) );
+		$this->assertNotEquals( $pre_delete, $post_delete );
+	}
 }

--- a/tests/tests_things/test_thing_translation_set.php
+++ b/tests/tests_things/test_thing_translation_set.php
@@ -122,4 +122,17 @@ class GP_Test_Thing_Translation_set extends GP_UnitTestCase {
 		// Expect only 3 imported translations, fuzzy translations are ignored.
 		$this->assertEquals( $translations_added, 3 );
 	}
+
+	function test_delete() {
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+
+		$pre_delete = GP::$translation_set->find_one( array( 'id' => $set->id ) );
+		
+		$set->delete();
+		
+		$post_delete = GP::$translation_set->find_one( array( 'id' => $set->id ) );
+		
+		$this->assertFalse( empty( $pre_delete ) );
+		$this->assertNotEquals( $pre_delete, $post_delete );
+	}
 }


### PR DESCRIPTION
This PR allows an admin to delete any of the various GlotPress items:
- Projects - will delete all content in the project (originals, translation sets, translations, glossaries, sub projects, etc.).
- Glossaries - will delete the glossary and all entries.
- Translation set - will delete the set and all translations.

Test cases are included.

New "delete" pages are included.

Resolves #267.
