### PR TITLE
280: Replace _wp_specialchars() with htmlspecialchars()

### DIFF
--- a/gp-includes/strings.php
+++ b/gp-includes/strings.php
@@ -96,6 +96,21 @@ function gp_esc_attr_with_entities( $text ) {
 	return apply_filters( 'gp_attribute_escape', $safe_text, $text );
 }
 
+/**
+ * Escapes translations for HTML blocks.
+ *
+ * Similar to esc_html(), but double encode entities.
+ *
+ * @since 1.0.0
+ *
+ * @param string $text The text prior to being escaped.
+ * @return string The text after it has been escaped.
+ */
+function esc_translation( $text ) {
+	$safe_text = wp_check_invalid_utf8( $text );
+	return htmlspecialchars( $safe_text, ENT_NOQUOTES, false, true );
+}
+
 function gp_string_similarity( $str1, $str2 ) {
 
 	$length1 = gp_strlen( $str1 );

--- a/gp-includes/strings.php
+++ b/gp-includes/strings.php
@@ -68,13 +68,32 @@ function gp_sanitize_for_url( $name ) {
 }
 
 /**
- * Similar to {@link esc_attr()}, but double encode entities
+ * Escaping for HTML attributes.
+ *
+ * Similar to esc_attr(), but double encode entities.
+ *
+ * @since 1.0.0
+ *
+ * @param string $text The text prior to being escaped.
+ * @return string The text after it has been escaped.
  */
 function gp_esc_attr_with_entities( $text ) {
 	$safe_text = wp_check_invalid_utf8( $text );
 	$safe_text = htmlspecialchars( $safe_text, ENT_QUOTES, false, true );
-	return apply_filters( 'gp_attribute_escape', $safe_text, $text );
 
+	/**
+	 * Filter a string cleaned and escaped for output in an HTML attribute.
+	 *
+	 * Text passed to gp_esc_attr_with_entities() is stripped of invalid or
+	 * special characters before output. Unlike esc_attr() it double encodes
+	 * entities.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $safe_text The text after it has been escaped.
+	 * @param string $text      The text prior to being escaped.
+	 */
+	return apply_filters( 'gp_attribute_escape', $safe_text, $text );
 }
 
 function gp_string_similarity( $str1, $str2 ) {

--- a/gp-includes/strings.php
+++ b/gp-includes/strings.php
@@ -72,7 +72,7 @@ function gp_sanitize_for_url( $name ) {
  */
 function gp_esc_attr_with_entities( $text ) {
 	$safe_text = wp_check_invalid_utf8( $text );
-	$safe_text = _wp_specialchars( $safe_text, ENT_QUOTES, false, true );
+	$safe_text = htmlspecialchars( $safe_text, ENT_QUOTES, false, true );
 	return apply_filters( 'gp_attribute_escape', $safe_text, $text );
 
 }

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -114,13 +114,6 @@ function textareas( $entry, $permissions, $index = 0 ) {
 	<?php
 }
 
-/**
- * Similar to esc_html() but allows double-encoding.
- */
-function esc_translation( $text ) {
-	return htmlspecialchars( $text, ENT_NOQUOTES, false, true );
-}
-
 function display_status( $status ) {
 	$status = preg_replace( '/^[+-]/', '', $status);
 	return $status ? $status : __( 'untranslated', 'glotpress' );

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -118,7 +118,7 @@ function textareas( $entry, $permissions, $index = 0 ) {
  * Similar to esc_html() but allows double-encoding.
  */
 function esc_translation( $text ) {
-	return _wp_specialchars( $text, ENT_NOQUOTES, false, true );
+	return htmlspecialchars( $text, ENT_NOQUOTES, false, true );
 }
 
 function display_status( $status ) {

--- a/tests/test_strings.php
+++ b/tests/test_strings.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @group strings
+ */
 class GP_Test_Strings extends GP_UnitTestCase {
 	function test_gp_sanitize_for_url() {
 		$this->assertEquals( 'baba', gp_sanitize_for_url( 'baba') );
@@ -23,4 +26,18 @@ class GP_Test_Strings extends GP_UnitTestCase {
 		$this->assertEquals( $similarity_2, 1 );
 	}
 
+	/**
+	 * @dataProvider date_attributes_with_entities
+	 */
+	function test_gp_esc_attr_with_entities( $expected, $attribute ) {
+		$this->assertEquals( $expected, gp_esc_attr_with_entities( $attribute ) );
+	}
+
+	function date_attributes_with_entities() {
+		return array(
+			array( '&amp;#8212;', '&#8212;' ), // https://glotpress.trac.wordpress.org/ticket/12
+			array( 'Foo &amp; Bar', 'Foo & Bar' ),
+			array( '&quot;&amp;hellip;&quot;', '"&hellip;"' ),
+		);
+	}
 }

--- a/tests/test_strings.php
+++ b/tests/test_strings.php
@@ -27,17 +27,32 @@ class GP_Test_Strings extends GP_UnitTestCase {
 	}
 
 	/**
-	 * @dataProvider date_attributes_with_entities
+	 * @dataProvider data_attributes_with_entities
 	 */
 	function test_gp_esc_attr_with_entities( $expected, $attribute ) {
 		$this->assertEquals( $expected, gp_esc_attr_with_entities( $attribute ) );
 	}
 
-	function date_attributes_with_entities() {
+	function data_attributes_with_entities() {
 		return array(
 			array( '&amp;#8212;', '&#8212;' ), // https://glotpress.trac.wordpress.org/ticket/12
 			array( 'Foo &amp; Bar', 'Foo & Bar' ),
 			array( '&quot;&amp;hellip;&quot;', '"&hellip;"' ),
+		);
+	}
+
+	/**
+	 * @dataProvider data_translations_with_entities
+	 */
+	function test_esc_translation( $expected, $translation ) {
+		$this->assertEquals( $expected, esc_translation( $translation ) );
+	}
+
+	function data_translations_with_entities() {
+		return array(
+			array( 'Foo bar&amp;hellip;', 'Foo bar&hellip;' ),
+			array( 'Foo &lt;span class="count"&gt;(%s)&lt;/span&gt;', 'Foo <span class="count">(%s)</span>' ),
+			array( '"&amp;hellip;"', '"&hellip;"' ),
 		);
 	}
 }


### PR DESCRIPTION
Resolves #280.
