### PR TITLE
236: Do not allow translations with empty plurals

### DIFF
--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -81,6 +81,11 @@ class GP_Translation extends GP_Thing {
 
 	public function restrict_fields( $translation ) {
 		$translation->translation_0_should_not_be( 'empty_string' );
+		$translation->translation_1_should_not_be( 'empty_string' );
+		$translation->translation_2_should_not_be( 'empty_string' );
+		$translation->translation_3_should_not_be( 'empty_string' );
+		$translation->translation_4_should_not_be( 'empty_string' );
+		$translation->translation_5_should_not_be( 'empty_string' );
 		$translation->status_should_not_be( 'empty' );
 		$translation->original_id_should_be( 'positive_int' );
 		$translation->translation_set_id_should_be( 'positive_int' );

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -169,12 +169,7 @@ class GP_Translation extends GP_Thing {
 		$statuses = explode( '_or_', $status );
 		if ( in_array( 'untranslated', $statuses ) ) {
 			if ( $statuses == array( 'untranslated' ) ) {
-				$empty_plural_translation = '(' . implode( ' OR ', array_map(
-					function( $x ) { return "$x = ''"; },
-					array( 't.translation_0', 't.translation_1', 't.translation_2', 't.translation_3', 't.translation_4', 't.translation_5', )
-				) ) . ')';
-
-				$where[] = "t.translation_0 IS NULL OR (o.plural IS NOT NULL AND $empty_plural_translation)";
+				$where[] = 't.translation_0 IS NULL';
 			}
 			$join_type = 'LEFT';
 			$join_where[] = 't.status != "rejected"';

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -164,7 +164,12 @@ class GP_Translation extends GP_Thing {
 		$statuses = explode( '_or_', $status );
 		if ( in_array( 'untranslated', $statuses ) ) {
 			if ( $statuses == array( 'untranslated' ) ) {
-				$where[] = 't.translation_0 IS NULL';
+				$empty_plural_translation = '(' . implode( ' OR ', array_map(
+					function( $x ) { return "$x = ''"; },
+					array( 't.translation_0', 't.translation_1', 't.translation_2', 't.translation_3', 't.translation_4', 't.translation_5', )
+				) ) . ')';
+
+				$where[] = "t.translation_0 IS NULL OR (o.plural IS NOT NULL AND $empty_plural_translation)";
 			}
 			$join_type = 'LEFT';
 			$join_where[] = 't.status != "rejected"';

--- a/tests/tests_things/test_thing_translation.php
+++ b/tests/tests_things/test_thing_translation.php
@@ -33,6 +33,17 @@ class GP_Test_Thing_Translation extends GP_UnitTestCase {
 		$this->assertEqualFields( $translation, $plurals );
 	}
 
+	/**
+	 * @ticket 149
+	 * @ticket gh-236
+	 */
+	function test_translation_should_not_validate_with_empty_plurals() {
+		$plurals = array( 'translation_0' => 'Zero', 'translation_1' => '', 'translation_2' => '' );
+		$translation = $this->factory->translation->create( $plurals );
+
+		$this->assertFalse( $translation->validate() );
+	}
+
 	function test_for_translation_shouldnt_exclude_originals_with_rejected_translation_if_status_has_untranslated() {
 		$set = $this->factory->translation_set->create_with_project_and_locale();
 		$translation = $this->factory->translation->create_with_original_for_translation_set( $set );

--- a/tests/tests_things/test_thing_translation.php
+++ b/tests/tests_things/test_thing_translation.php
@@ -38,10 +38,26 @@ class GP_Test_Thing_Translation extends GP_UnitTestCase {
 	 * @ticket gh-236
 	 */
 	function test_translation_should_not_validate_with_empty_plurals() {
-		$plurals = array( 'translation_0' => 'Zero', 'translation_1' => '', 'translation_2' => '' );
-		$translation = $this->factory->translation->create( $plurals );
+		$data = array(
+			'user_id'            => 1,
+			'original_id'        => 1,
+			'translation_set_id' => 1,
+			'status'             => 'current',
+		);
+		$plurals = array(
+			'translation_0' => 'Zero',
+			'translation_1' => '',
+			'translation_2' => '',
+			'translation_3' => '',
+			'translation_4' => '',
+			'translation_5' => '',
+		);
 
+		$data = array_merge( $data, $plurals );
+
+		$translation = $this->factory->translation->create( $data );
 		$this->assertFalse( $translation->validate() );
+		$this->assertCount( 5, $translation->errors );
 	}
 
 	function test_for_translation_shouldnt_exclude_originals_with_rejected_translation_if_status_has_untranslated() {

--- a/tests/tests_things/test_thing_translation.php
+++ b/tests/tests_things/test_thing_translation.php
@@ -36,6 +36,8 @@ class GP_Test_Thing_Translation extends GP_UnitTestCase {
 	/**
 	 * @ticket 149
 	 * @ticket gh-236
+	 *
+	 * @covers GP_Translation::restrict_fields
 	 */
 	function test_translation_should_not_validate_with_empty_plurals() {
 		$data = array(


### PR DESCRIPTION
- Show strings with missing plurals in 'Untranslated' view.
- Do not allow translations with empty plurals.

See #236.
