### PR TITLE
294: Standardize triggers in projects, translations and originals.

### DIFF
--- a/gp-includes/things/original.php
+++ b/gp-includes/things/original.php
@@ -402,6 +402,15 @@ class GP_Original extends GP_Thing {
 		}
 	}
 
+	// Triggers
+
+	/**
+	 * Executes after creating an original.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool
+	 */
 	public function after_create() {
 		/**
 		 * Fires after a new original is created.
@@ -411,6 +420,47 @@ class GP_Original extends GP_Thing {
 		 * @param GP_original $original The original that was created.
 		 */
 		do_action( 'gp_original_created', $this );
+		
+		return true;
+	}
+
+	/**
+	 * Executes after saving an original.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool
+	 */
+	public function after_save() {
+		/**
+		 * Fires after an original is saved.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param GP_original $original The original that was saved.
+		 */
+		do_action( 'gp_original_saved', $this );
+		
+		return true;
+	}
+
+	/**
+	 * Executes after deleting an original.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool
+	 */
+	public function after_delete() {
+		/**
+		 * Fires after an original is deleted.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param GP_original $original The original that was deleted.
+		 */
+		do_action( 'gp_original_deleted', $this );
+		
 		return true;
 	}
 }

--- a/gp-includes/things/project.php
+++ b/gp-includes/things/project.php
@@ -54,21 +54,13 @@ class GP_Project extends GP_Thing {
 
 	// Triggers
 
-	public function after_save() {
-		/**
-		 * Fires after saving a project.
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param GP_Project $project The project that was saved.
-		 */
-		do_action( 'gp_project_saved', $this );
-		// TODO: pass the update args to after/pre_save?
-		// TODO: only call it if the slug or parent project were changed
-		return !is_null( $this->update_path() );
-	}
-
-
+	/**
+	 * Executes after creating a project.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool
+	 */
 	public function after_create() {
 		/**
 		 * Fires after creating a project.
@@ -78,8 +70,55 @@ class GP_Project extends GP_Thing {
 		 * @param GP_Project $project The project that was created.
 		 */
 		do_action( 'gp_project_created', $this );
+		
 		// TODO: pass some args to pre/after_create?
-		if ( is_null( $this->update_path() ) ) return false;
+		if ( is_null( $this->update_path() ) ) {
+			return false;
+		}
+		
+		return true;
+	}
+
+	/**
+	 * Executes after saving a project.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool
+	 */
+	public function after_save() {
+		/**
+		 * Fires after saving a project.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param GP_Project $project The project that was saved.
+		 */
+		do_action( 'gp_project_saved', $this );
+		
+		// TODO: pass the update args to after/pre_save?
+		// TODO: only call it if the slug or parent project were changed
+		return ! is_null( $this->update_path() );
+	}
+
+	/**
+	 * Executes after deleting a project.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool
+	 */
+	public function after_delete() {
+		/**
+		 * Fires after deleting a project.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param GP_Project $project The project that was deleted.
+		 */
+		do_action( 'gp_project_deleted', $this );
+
+		return true;
 	}
 
 	// Field handling

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -435,6 +435,15 @@ class GP_Translation extends GP_Thing {
 		return $last_modified;
 	}
 
+	// Triggers
+
+	/**
+	 * Executes after creating a translation.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool
+	 */
 	public function after_create() {
 		/**
 		 * Fires after a translation was created.
@@ -444,9 +453,17 @@ class GP_Translation extends GP_Thing {
 		 * @param GP_Translation $translation Translation that was created.
 		 */
 		do_action( 'gp_translation_created', $this );
+		
 		return true;
 	}
 
+	/**
+	 * Executes after saving a translation.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool
+	 */
 	public function after_save() {
 		/**
 		 * Fires after a translation was saved.
@@ -456,9 +473,29 @@ class GP_Translation extends GP_Thing {
 		 * @param GP_Translation $translation Translation that was saved.
 		 */
 		do_action( 'gp_translation_saved', $this );
+		
 		return true;
 	}
 
+	/**
+	 * Executes after deleting a translation.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool
+	 */
+	public function after_delete() {
+		/**
+		 * Fires after a translation was deleted.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param GP_Translation $translation Translation that was deleted.
+		 */
+		do_action( 'gp_translation_deleted', $this );
+		
+		return true;
+	}
 }
 
 GP::$translation = new GP_Translation();


### PR DESCRIPTION
Add support for the after_delete() trigger and ensure all three object types have support for after_save() and after_create().

Add doc blocks and clean up formatting.

Part 2 of #305.

Resolves #294.
