### PR TITLE
Suspend cache invalidation during original imports.

### DIFF
--- a/gp-includes/misc.php
+++ b/gp-includes/misc.php
@@ -84,11 +84,11 @@ function gp_notice_set( $message, $key = 'notice' ) {
  * @param string $key Optional. Message key. The default is 'notice'
  */
 function gp_notice( $key = 'notice' ) {
-	// Sanitize fields 
- 	$allowed_tags = array( 
+	// Sanitize fields
+	$allowed_tags = array(
 		'a'       => array( 'href' => true ),
-		'abbr'    => array(), 
-		'acronym' => array(), 
+		'abbr'    => array(),
+		'acronym' => array(),
 		'b'       => array(),
 		'br'      => array(),
 		'button'  => array( 'disabled' => true, 'name' => true, 'type' => true, 'value' => true ),
@@ -103,8 +103,8 @@ function gp_notice( $key = 'notice' ) {
 		'sub'     => array(),
 		'sup'     => array(),
 		'u'       => array(),
- 	); 
-	
+	);
+
 	// Adds class, id, style, title, role attributes to all of the above allowed tags.
 	$allowed_tags = array_map( '_wp_add_global_attributes', $allowed_tags );
 
@@ -220,11 +220,19 @@ function gp_has_translation_been_updated( $translation_set, $timestamp = 0 ) {
 
 
 /**
- * Delete translation set counts cache
+ * Delete translation set counts cache.
  *
- * @param int $id translation set ID
+ * @global bool $_wp_suspend_cache_invalidation
+ *
+ * @param int $id Translation set ID.
  */
 function gp_clean_translation_set_cache( $id ) {
+	global $_wp_suspend_cache_invalidation;
+
+	if ( ! empty( $_wp_suspend_cache_invalidation ) ) {
+		return;
+	}
+
 	wp_cache_delete( $id, 'translation_set_status_breakdown' );
 	wp_cache_delete( $id, 'translation_set_last_modified' );
 }
@@ -395,13 +403,13 @@ function gp_get_import_file_format( $selected_format, $filename ) {
 
 	if ( ! $format ) {
 		$matched_ext_len = 0;
-		
+
 		foreach( GP::$formats as $format_entry ) {
 			$format_extensions = $format_entry->get_file_extensions();
 
 			foreach( $format_extensions as $extension ) {
 				$current_ext_len = strlen( $extension );
-				
+
 				if ( gp_endswith( $filename, $extension ) && $current_ext_len > $matched_ext_len ) {
 					$format = $format_entry;
 					$matched_ext_len = $current_ext_len;

--- a/gp-includes/things/original.php
+++ b/gp-includes/things/original.php
@@ -166,6 +166,8 @@ class GP_Original extends GP_Thing {
 		}
 		$comparison_array = array_unique( array_merge( array_keys( $possibly_dropped ), array_keys( $obsolete_originals ) ) );
 
+		$prev_suspend_cache = wp_suspend_cache_invalidation( true );
+
 		foreach ( $possibly_added as $entry ) {
 			$data = array(
 				'project_id' => $project->id,
@@ -222,9 +224,12 @@ class GP_Original extends GP_Thing {
 			$originals_obsoleted++;
 		}
 
+		wp_suspend_cache_invalidation( $prev_suspend_cache );
+
 		// Clear cache when the amount of strings are changed.
 		if ( $originals_added > 0 || $originals_existing > 0 || $originals_fuzzied > 0 || $originals_obsoleted > 0 ) {
 			wp_cache_delete( $project->id, self::$count_cache_group );
+			gp_clean_translation_sets_cache( $project->id );
 		}
 
 		/**
@@ -420,7 +425,7 @@ class GP_Original extends GP_Thing {
 		 * @param GP_original $original The original that was created.
 		 */
 		do_action( 'gp_original_created', $this );
-		
+
 		return true;
 	}
 
@@ -440,7 +445,7 @@ class GP_Original extends GP_Thing {
 		 * @param GP_original $original The original that was saved.
 		 */
 		do_action( 'gp_original_saved', $this );
-		
+
 		return true;
 	}
 
@@ -460,7 +465,7 @@ class GP_Original extends GP_Thing {
 		 * @param GP_original $original The original that was deleted.
 		 */
 		do_action( 'gp_original_deleted', $this );
-		
+
 		return true;
 	}
 }


### PR DESCRIPTION
Instead, clear the cache for translation sets after the import is done.

Fixes #332.
