### PR TITLE
PHPCS: Exclude 'WordPress.XSS.EscapeOutput.UnsafePrintingFunction' from WordPress-extra

### DIFF
--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -3,7 +3,9 @@
 
 	<rule ref="WordPress-Core" />
 	<rule ref="WordPress-Docs" />
-	<rule ref="WordPress-Extra" />
+	<rule ref="WordPress-Extra">
+		<exclude name="WordPress.XSS.EscapeOutput.UnsafePrintingFunction" />
+	</rule>
 
 	<exclude-pattern>*/tests/*</exclude-pattern>
 	<exclude-pattern>*/dev-lib/*</exclude-pattern>


### PR DESCRIPTION
https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/e3b8e576a09bcea0ca9eae713e2d822e438c66e8/WordPress/Sniffs/XSS/EscapeOutputSniff.php#L60-L70

We treat these as safe like core does.
