### PR TITLE
342: Update schema definitions to work with WP's dbDelta()

### DIFF
--- a/gp-includes/schema.php
+++ b/gp-includes/schema.php
@@ -22,12 +22,12 @@ function gp_schema_get() {
 	$max_index_length = 191;
 
 	/*
-	Translations
-	 - There are fields to take all the plural forms (no known locale has more than 4 plural forms)
-	 - Belongs to an original string
-	 - Belongs to a user
-	 - Status can be: new, approved, unaproved, current, spam or whatever you'd like
-	*/
+	 * Translations
+	 *  - There are fields to take all the plural forms (no known locale has more than 4 plural forms)
+	 *  - Belongs to an original string
+	 *  - Belongs to a user
+	 *  - Status can be: new, approved, unaproved, current, spam or whatever you'd like
+	 */
 	$gp_schema['translations'] = "CREATE TABLE $wpdb->gp_translations (
 		id INT(10) NOT NULL auto_increment,
 		original_id INT(10) DEFAULT NULL,
@@ -49,14 +49,14 @@ function gp_schema_get() {
 		KEY translation_set_id (translation_set_id),
 		KEY translation_set_id_status (translation_set_id,status),
 		KEY date_added (date_added),
-		KEY warnings (warnings (1))
+		KEY warnings (warnings(1))
 	) $charset_collate;";
 
 	/*
-	Translations sets: A "translation set" holds all translated strings within a project for a specific locale.
-	For example each WordPress Spanish translation (formal, informal and that of Diego) will be different sets.
-	Most projects will have only one translation set per locale.
-	*/
+	 * Translations sets: A "translation set" holds all translated strings within a project for a specific locale.
+	 * For example each WordPress Spanish translation (formal, informal and that of Diego) will be different sets.
+	 * Most projects will have only one translation set per locale.
+	 */
 	$gp_schema['translation_sets'] = "CREATE TABLE $wpdb->gp_translation_sets (
 		id INT(10) NOT NULL auto_increment,
 		name VARCHAR(255) NOT NULL,
@@ -64,14 +64,21 @@ function gp_schema_get() {
 		project_id INT(10) DEFAULT NULL,
 		locale VARCHAR(10) DEFAULT NULL,
 		PRIMARY KEY  (id),
-		UNIQUE KEY project_id_slug_locale (project_id, slug(171), locale),
-		KEY locale_slug (locale, slug(181))
+		UNIQUE KEY project_id_slug_locale (project_id,slug(171),locale),
+		KEY locale_slug (locale,slug(181))
 	) $charset_collate;";
 
 	/*
-	Original strings
-	 - Has many translations
-	 - Belongs to a project
+	 * Original strings
+	 *  - Has many translations
+	 *  - Belongs to a project
+	 *
+	 * Note that 'references' is a reserved keyword in MySQL it *MUST* be surrounded in
+	 * backticks during the creation of the table.  However during upgrades this will
+	 * cause a warning to be created in the PHP error logs about incorrect SQL syntax.
+	 *
+	 * See https://core.trac.wordpress.org/ticket/20263 for more information.
+	 *
 	 */
 	$gp_schema['originals'] = "CREATE TABLE $wpdb->gp_originals (
 		id INT(10) NOT NULL auto_increment,
@@ -86,12 +93,12 @@ function gp_schema_get() {
 		date_added DATETIME DEFAULT NULL,
 		PRIMARY KEY  (id),
 		KEY project_id_status (project_id, status),
-		KEY singular_plural_context (singular(63), plural(63), context(63))
+		KEY singular_plural_context (singular(63),plural(63),context(63))
 	) $charset_collate;";
 
 	/*
-	Glossary Entries
-	*/
+	 * Glossary Entries
+	 */
 	$gp_schema['glossary_entries'] = "CREATE TABLE $wpdb->gp_glossary_entries (
 		id INT(10) unsigned NOT NULL auto_increment,
 		glossary_id INT(10) unsigned NOT NULL,
@@ -105,8 +112,8 @@ function gp_schema_get() {
 	) $charset_collate;";
 
 	/*
-	Glossaries
-	*/
+	 * Glossaries
+	 */
 	$gp_schema['glossaries'] = "CREATE TABLE $wpdb->gp_glossaries (
 		id INT(10) unsigned NOT NULL auto_increment,
 		translation_set_id INT(10)  NOT NULL,
@@ -115,10 +122,10 @@ function gp_schema_get() {
 	) $charset_collate;";
 
 	/*
-	Projects
-	- Has a project -- its parent
-	- The path is the combination of the slugs of all its parents, separated by /
-	*/
+	 * Projects
+	 * - Has a project -- its parent
+	 * - The path is the combination of the slugs of all its parents, separated by /
+	 */
 	$gp_schema['projects'] = "CREATE TABLE $wpdb->gp_projects (
 		id INT(10) NOT NULL auto_increment,
 		name VARCHAR(255) NOT NULL,
@@ -133,7 +140,9 @@ function gp_schema_get() {
 		KEY parent_project_id (parent_project_id)
 	) $charset_collate;";
 
-	// meta
+	/*
+	 * Meta
+	 */
 	$gp_schema['meta'] = "CREATE TABLE $wpdb->gp_meta (
 		meta_id bigint(20) NOT NULL auto_increment,
 		object_type varchar(32) NOT NULL default 'gp_option',
@@ -141,11 +150,13 @@ function gp_schema_get() {
 		meta_key varchar($max_index_length) DEFAULT NULL,
 		meta_value longtext DEFAULT NULL,
 		PRIMARY KEY  (meta_id),
-		KEY object_type__meta_key (object_type, meta_key),
-		KEY object_type__object_id__meta_key (object_type, object_id, meta_key)
+		KEY object_type__meta_key (object_type,meta_key),
+		KEY object_type__object_id__meta_key (object_type,object_id,meta_key)
 	) $charset_collate;";
 
-	// permissions
+	/*
+	 * Permissions
+	 */
 	$gp_schema['permissions'] = "CREATE TABLE $wpdb->gp_permissions (
 		id INT(10) NOT NULL AUTO_INCREMENT,
 		user_id INT(10) DEFAULT NULL,


### PR DESCRIPTION
dbDelta() doesn't support backticks so remove them from the references column name.

On compond index key's, dbDelta() expects there to be no spaces between each component and the size, so remove them.

Resolves #342.
