### PR TITLE
CLI: Prevent printing an empty line when running 'glotpress import-originals'

### DIFF
--- a/gp-includes/cli/import-originals.php
+++ b/gp-includes/cli/import-originals.php
@@ -39,15 +39,13 @@ class GP_CLI_Import_Originals extends WP_CLI_Command {
 
 		list( $originals_added, $originals_existing, $originals_fuzzied, $originals_obsoleted ) = GP::$original->import_for_project( $project, $translations );
 
-		WP_CLI::line(
-			sprintf(
-				/* translators: 1: number added, 2: number updated, 3: number fuzzied, 4: number obsoleted */
-				__( '%1$s new strings added, %2$s updated, %3$s fuzzied, and %4$s obsoleted.', 'glotpress' ),
-				$originals_added,
-				$originals_existing,
-				$originals_fuzzied,
-				$originals_obsoleted
-			)
+		$notice = sprintf(
+			/* translators: 1: number added, 2: number updated, 3: number fuzzied, 4: number obsoleted */
+			__( '%1$s new strings added, %2$s updated, %3$s fuzzied, and %4$s obsoleted.', 'glotpress' ),
+			$originals_added,
+			$originals_existing,
+			$originals_fuzzied,
+			$originals_obsoleted
 		);
 
 		if ( $originals_error ) {


### PR DESCRIPTION
Introduced in #314.
