### PR TITLE
377: Allow to translations to be imported with status "waiting"

### DIFF
--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -29,7 +29,7 @@ class GP_Route_Translation extends GP_Route_Main {
 		}
 
 		$can_import_current = $this->can( 'approve', 'translation-set', $translation_set->id );
-		$can_import_waiting = $can_approve || $this->can( 'import-waiting', 'translation-set', $translation_set->id );
+		$can_import_waiting = $can_import_current || $this->can( 'import-waiting', 'translation-set', $translation_set->id );
 
 		if ( ! $can_import_current && ! $can_import_waiting ) {
 			$this->redirect_with_error( __( 'You are not allowed to do that!', 'glotpress' ) );
@@ -59,7 +59,7 @@ class GP_Route_Translation extends GP_Route_Main {
 		}
 
 		$can_import_current = $this->can( 'approve', 'translation-set', $translation_set->id );
-		$can_import_waiting = $can_approve || $this->can( 'import-waiting', 'translation-set', $translation_set->id );
+		$can_import_waiting = $can_import_current || $this->can( 'import-waiting', 'translation-set', $translation_set->id );
 
 		if ( ! $can_import_current && ! $can_import_waiting ) {
 			$this->redirect_with_error( __( 'You are not allowed to do that!', 'glotpress' ) );

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -28,7 +28,11 @@ class GP_Route_Translation extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
-		if ( $this->cannot_and_redirect( 'approve', 'translation-set', $translation_set->id ) ) {
+		$can_import_current = $this->can( 'approve', 'translation-set', $translation_set->id );
+		$can_import_waiting = $can_approve || $this->can( 'import-waiting', 'translation-set', $translation_set->id );
+
+		if ( ! $can_import_current && ! $can_import_waiting ) {
+			$this->redirect_with_error( __( 'You are not allowed to do that!', 'glotpress' ) );
 			return;
 		}
 
@@ -54,7 +58,26 @@ class GP_Route_Translation extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
-		if ( $this->cannot_and_redirect( 'approve', 'translation-set', $translation_set->id ) ) {
+		$can_import_current = $this->can( 'approve', 'translation-set', $translation_set->id );
+		$can_import_waiting = $can_approve || $this->can( 'import-waiting', 'translation-set', $translation_set->id );
+
+		if ( ! $can_import_current && ! $can_import_waiting ) {
+			$this->redirect_with_error( __( 'You are not allowed to do that!', 'glotpress' ) );
+			return;
+		}
+
+		$import_status = gp_post( 'status', 'waiting' );
+
+		$allowed_import_status = array();
+		if ( $can_import_current ) {
+			$allowed_import_status[] = 'current';
+		}
+		if ( $can_import_waiting ) {
+			$allowed_import_status[] = 'waiting';
+		}
+
+		if ( ! in_array( $import_status, $allowed_import_status, true ) ) {
+			$this->redirect_with_error( __( 'Invalid translation status.', 'glotpress' ) );
 			return;
 		}
 
@@ -63,7 +86,7 @@ class GP_Route_Translation extends GP_Route_Main {
 			return;
 		}
 
-		$format = gp_get_import_file_format( gp_post( 'format', 'po' ), $_FILES[ 'import-file' ][ 'name' ] );
+		$format = gp_get_import_file_format( gp_post( 'format', 'po' ), $_FILES['import-file']['name'] );
 
 		if ( ! $format ) {
 			$this->redirect_with_error( __( 'No such format.', 'glotpress' ) );
@@ -71,12 +94,12 @@ class GP_Route_Translation extends GP_Route_Main {
 		}
 
 		$translations = $format->read_translations_from_file( $_FILES['import-file']['tmp_name'], $project );
-		if ( !$translations ) {
+		if ( ! $translations ) {
 			$this->redirect_with_error( __( 'Couldn&#8217;t load translations from file!', 'glotpress' ) );
 			return;
 		}
 
-		$translations_added = $translation_set->import( $translations );
+		$translations_added = $translation_set->import( $translations, $import_status );
 		$this->notices[] = sprintf( __( '%s translations were added', 'glotpress' ), $translations_added );
 
 		$this->redirect( gp_url_project( $project, gp_url_join( $locale->slug, $translation_set->slug ) ) );
@@ -192,6 +215,8 @@ class GP_Route_Translation extends GP_Route_Main {
 		$can_edit = $this->can( 'edit', 'translation-set', $translation_set->id );
 		$can_write = $this->can( 'write', 'project', $project->id );
 		$can_approve = $this->can( 'approve', 'translation-set', $translation_set->id );
+		$can_import_current = $can_approve;
+		$can_import_waiting = $can_approve || $this->can( 'import-waiting', 'translation-set', $translation_set->id );
 		$url = gp_url_project( $project, gp_url_join( $locale->slug, $translation_set->slug ) );
 		$set_priority_url = gp_url( '/originals/%original-id%/set_priority');
 		$discard_warning_url = gp_url_project( $project, gp_url_join( $locale->slug, $translation_set->slug, '-discard-warning' ) );

--- a/gp-templates/project-import.php
+++ b/gp-templates/project-import.php
@@ -46,7 +46,7 @@ gp_tmpl_header();
 			<input type="hidden" name="status" value="<?php echo esc_attr( reset( array_keys( $status_options ) ) ); ?>" />
 			<?php echo esc_html( reset( array_values( $status_options ) ) ); ?>
 		<?php elseif ( count( $status_options ) > 1 ) : ?>
-			<?php echo gp_select( 'status', $status_options, 'waiting' ); ?>
+			<?php echo gp_select( 'status', $status_options, 'current' ); ?>
 		<?php endif; ?>
 	</dd>
 <?php endif; ?>

--- a/gp-templates/project-import.php
+++ b/gp-templates/project-import.php
@@ -2,13 +2,17 @@
 if ( 'originals' == $kind ) {
  	$title = sprintf( __( 'Import Originals &lt; %s &lt; GlotPress', 'glotpress' ), esc_html( $project->name ) );
 	$return_link = gp_url_project( $project );
+	gp_breadcrumb_project( $project );
 } else {
 	$title = sprintf( __( 'Import Translations &lt; %s &lt; GlotPress', 'glotpress' ), esc_html( $project->name ) );
 	$return_link = gp_url_project_locale( $project, $locale->slug, $translation_set->slug );
+	gp_breadcrumb( array(
+		gp_project_links_from_root( $project ),
+		gp_link_get( $return_link, $translation_set->name ),
+	) );
 }
 
 gp_title( $title );
-gp_breadcrumb_project( $project );
 gp_tmpl_header();
 ?>
 
@@ -24,9 +28,28 @@ gp_tmpl_header();
 		$format_options[$slug] = $format->name;
 	}
 	$format_dropdown = gp_select( 'format', $format_options, 'auto' );
+
+	$status_options = array();
+	if ( isset( $can_import_current ) && $can_import_current ) {
+		$status_options['current'] = __( 'Current', 'glotpress' );
+	}
+	if ( isset( $can_import_waiting ) && $can_import_waiting ) {
+		$status_options['waiting'] = __( 'Waiting', 'glotpress' );
+	}
 ?>
-	<dt><label	for="format"><?php _e( 'Format:', 'glotpress' ); ?></label></dt>
+	<dt><label for="format"><?php _e( 'Format:', 'glotpress' ); ?></label></dt>
 	<dd><?php echo $format_dropdown; ?></dd>
+<?php if ( ! empty( $status_options ) ) : ?>
+	<dt><label for="status"><?php _e( 'Status:', 'glotpress' ); ?></label></dt>
+	<dd>
+		<?php if ( count( $status_options ) === 1 ) : ?>
+			<input type="hidden" name="status" value="<?php echo esc_attr( reset( array_keys( $status_options ) ) ); ?>" />
+			<?php echo esc_html( reset( array_values( $status_options ) ) ); ?>
+		<?php elseif ( count( $status_options ) > 1 ) : ?>
+			<?php echo gp_select( 'status', $status_options, 'waiting' ); ?>
+		<?php endif; ?>
+	</dd>
+<?php endif; ?>
 	<dt>
 	<p>
 		<input type="submit" name="submit" value="<?php esc_attr_e( 'Import', 'glotpress' ); ?>" id="submit" />

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -254,7 +254,7 @@ $i = 0;
 <p class="clear actionlist secondary">
 	<?php
 		$footer_links = array();
-		if ( $can_approve ) {
+		if ( ( isset( $can_import_current ) && $can_import_current ) || ( isset( $can_import_waiting ) && $can_import_waiting ) ) {
 			$footer_links[] = gp_link_get( gp_url_project( $project, array( $locale->slug, $translation_set->slug, 'import-translations' ) ), __( 'Import translations', 'glotpress' ) );
 		}
 		$export_url = gp_url_project( $project, array( $locale->slug, $translation_set->slug, 'export-translations' ) );

--- a/tests/phpunit/testcases/test_import.php
+++ b/tests/phpunit/testcases/test_import.php
@@ -1,0 +1,366 @@
+<?php
+
+class GP_Import extends GP_UnitTestCase {
+
+	/**
+	 * @ticket gh-377
+	 */
+	private function _verify_multiple_imports( $originals, $runs ) {
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+
+		if ( isset( $originals['singular'] ) ) {
+			$originals = array( $originals );
+		}
+
+		foreach ( $originals as $original ) {
+			$o = $this->factory->original->create( array_merge( array(
+				'project_id' => $set->project_id,
+				'status'     => '+active',
+			), $original ) );
+		}
+
+		$this->assertEquals( count( $originals ), $set->all_count() );
+		$this->assertEquals( 0, $set->current_count() );
+		$this->assertEquals( count( $originals ), $set->untranslated_count() );
+
+		$status_sequence = '';
+		foreach ( $runs as $run ) {
+			$status_sequence .= $run['status'] . '|';
+			$set->import( $run['translations'], $run['status'] );
+
+			wp_cache_flush();
+			$set->update_status_breakdown();
+
+			foreach ( $run['counts'] as $function => $count ) {
+				$this->assertEquals( $count, $set->$function(), $status_sequence . $function . '()' );
+			}
+		}
+	}
+
+	function test_multiple_imports_singular() {
+		$original = array(
+			'singular'   => 'Good morning',
+		);
+
+		$translations = new Translations();
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => $original['singular'],
+			'translations' => array( 'Guten Morgen' ),
+		)));
+
+		$this->_verify_multiple_imports( $original, array(
+			array(
+				'status' => 'current',
+				'translations' => $translations,
+				'counts' => array(
+					'all_count' => 1,
+					'current_count' => 1,
+					'untranslated_count' => 0,
+					'waiting_count' => 0,
+				),
+			),
+			array(
+				'status' => 'current',
+				'translations' => $translations,
+				'counts' => array(
+					'all_count' => 1,
+					'current_count' => 1,
+					'untranslated_count' => 0,
+					'waiting_count' => 0,
+				),
+			),
+		));
+
+		$this->_verify_multiple_imports( $original, array(
+			array(
+				'status' => 'current',
+				'translations' => $translations,
+				'counts' => array(
+					'all_count' => 1,
+					'current_count' => 1,
+					'untranslated_count' => 0,
+					'waiting_count' => 0,
+				),
+			),
+			array(
+				'status' => 'waiting',
+				'translations' => $translations,
+				'counts' => array(
+					'all_count' => 1,
+					'current_count' => 1,
+					'untranslated_count' => 0,
+					'waiting_count' => 0,
+				),
+			),
+		));
+
+		$this->_verify_multiple_imports( $original, array(
+			array(
+				'status' => 'waiting',
+				'translations' => $translations,
+				'counts' => array(
+					'all_count' => 1,
+					'current_count' => 0,
+					'untranslated_count' => 1,
+					'waiting_count' => 1,
+				),
+			),
+			array(
+				'status' => 'current',
+				'translations' => $translations,
+				'counts' => array(
+					'all_count' => 1,
+					'current_count' => 1,
+					'untranslated_count' => 0,
+					'waiting_count' => 0,
+				),
+			),
+		));
+
+		$this->_verify_multiple_imports( $original, array(
+			array(
+				'status' => 'waiting',
+				'translations' => $translations,
+				'counts' => array(
+					'all_count' => 1,
+					'current_count' => 0,
+					'untranslated_count' => 1,
+					'waiting_count' => 1,
+				),
+			),
+			array(
+				'status' => 'waiting',
+				'translations' => $translations,
+				'counts' => array(
+					'all_count' => 1,
+					'current_count' => 0,
+					'untranslated_count' => 1,
+					'waiting_count' => 1,
+				),
+			),
+		));
+	}
+
+	function test_multiple_imports_plural() {
+		$original = array(
+			'singular'   => '%d apple',
+			'plural'   => '%d apples',
+		);
+
+		$translations = new Translations();
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => $original['singular'],
+			'plural' => $original['plural'],
+			'translations' => array( '%d Apfel', '%d Äpfel' ),
+		)));
+
+		$this->_verify_multiple_imports( $original, array(
+			array(
+				'status' => 'current',
+				'translations' => $translations,
+				'counts' => array(
+					'all_count' => 1,
+					'current_count' => 1,
+					'untranslated_count' => 0,
+					'waiting_count' => 0,
+				),
+			),
+			array(
+				'status' => 'current',
+				'translations' => $translations,
+				'counts' => array(
+					'all_count' => 1,
+					'current_count' => 1,
+					'untranslated_count' => 0,
+					'waiting_count' => 0,
+				),
+			),
+		));
+
+		$this->_verify_multiple_imports( $original, array(
+			array(
+				'status' => 'current',
+				'translations' => $translations,
+				'counts' => array(
+					'all_count' => 1,
+					'current_count' => 1,
+					'untranslated_count' => 0,
+					'waiting_count' => 0,
+				),
+			),
+			array(
+				'status' => 'waiting',
+				'translations' => $translations,
+				'counts' => array(
+					'all_count' => 1,
+					'current_count' => 1,
+					'untranslated_count' => 0,
+					'waiting_count' => 0,
+				),
+			),
+		));
+
+		$this->_verify_multiple_imports( $original, array(
+			array(
+				'status' => 'waiting',
+				'translations' => $translations,
+				'counts' => array(
+					'all_count' => 1,
+					'current_count' => 0,
+					'untranslated_count' => 1,
+					'waiting_count' => 1,
+				),
+			),
+			array(
+				'status' => 'current',
+				'translations' => $translations,
+				'counts' => array(
+					'all_count' => 1,
+					'current_count' => 1,
+					'untranslated_count' => 0,
+					'waiting_count' => 0,
+				),
+			),
+		));
+
+		$this->_verify_multiple_imports( $original, array(
+			array(
+				'status' => 'waiting',
+				'translations' => $translations,
+				'counts' => array(
+					'all_count' => 1,
+					'current_count' => 0,
+					'untranslated_count' => 1,
+					'waiting_count' => 1,
+				),
+			),
+			array(
+				'status' => 'waiting',
+				'translations' => $translations,
+				'counts' => array(
+					'all_count' => 1,
+					'current_count' => 0,
+					'untranslated_count' => 1,
+					'waiting_count' => 1,
+				),
+			),
+		));
+	}
+
+
+	function test_multiple_imports_multiple_singulars() {
+		$originals = array(
+			array(
+				'singular'   => 'Good morning',
+			),
+			array(
+				'singular'   => 'Good evening',
+			),
+		);
+
+		$translations1 = new Translations();
+		$translations1->add_entry( new Translation_Entry( array(
+			'singular' => $originals[0]['singular'],
+			'translations' => array( 'Guten Morgen' ),
+		)));
+
+		$translations2 = new Translations();
+		$translations2->add_entry( new Translation_Entry( array(
+			'singular' => $originals[1]['singular'],
+			'translations' => array( 'Guten Abend' ),
+		)));
+
+		$this->_verify_multiple_imports( $originals, array(
+			array(
+				'status' => 'current',
+				'translations' => $translations1,
+				'counts' => array(
+					'all_count' => 2,
+					'current_count' => 1,
+					'untranslated_count' => 1,
+					'waiting_count' => 0,
+				),
+			),
+			array(
+				'status' => 'current',
+				'translations' => $translations2,
+				'counts' => array(
+					'all_count' => 2,
+					'current_count' => 2,
+					'untranslated_count' => 0,
+					'waiting_count' => 0,
+				),
+			),
+		));
+
+		$this->_verify_multiple_imports( $originals, array(
+			array(
+				'status' => 'current',
+				'translations' => $translations1,
+				'counts' => array(
+					'all_count' => 2,
+					'current_count' => 1,
+					'untranslated_count' => 1,
+					'waiting_count' => 0,
+				),
+			),
+			array(
+				'status' => 'waiting',
+				'translations' => $translations2,
+				'counts' => array(
+					'all_count' => 2,
+					'current_count' => 1,
+					'untranslated_count' => 1,
+					'waiting_count' => 1,
+				),
+			),
+		));
+
+		$this->_verify_multiple_imports( $originals, array(
+			array(
+				'status' => 'waiting',
+				'translations' => $translations1,
+				'counts' => array(
+					'all_count' => 2,
+					'current_count' => 0,
+					'untranslated_count' => 2,
+					'waiting_count' => 1,
+				),
+			),
+			array(
+				'status' => 'waiting',
+				'translations' => $translations2,
+				'counts' => array(
+					'all_count' => 2,
+					'current_count' => 0,
+					'untranslated_count' => 2,
+					'waiting_count' => 2,
+				),
+			),
+		));
+
+		$this->_verify_multiple_imports( $originals, array(
+			array(
+				'status' => 'waiting',
+				'translations' => $translations1,
+				'counts' => array(
+					'all_count' => 2,
+					'current_count' => 0,
+					'untranslated_count' => 2,
+					'waiting_count' => 1,
+				),
+			),
+			array(
+				'status' => 'current',
+				'translations' => $translations1,
+				'counts' => array(
+					'all_count' => 2,
+					'current_count' => 1,
+					'untranslated_count' => 1,
+					'waiting_count' => 0,
+				),
+			),
+		));
+	}
+
+}

--- a/tests/phpunit/testcases/test_permissions.php
+++ b/tests/phpunit/testcases/test_permissions.php
@@ -134,4 +134,23 @@ class GP_Test_Permissions extends GP_UnitTestCase {
 		$permissions = GP::$administrator_permission->find( array( 'user_id' => $user ) );
 		$this->assertSame( 1, count( $permissions ) );
 	}
+
+	/**
+	 * @ticket gh-377
+	 */
+	function test_import_permissions() {
+		$user = $this->factory->user->create();
+
+		$project = $this->factory->project->create();
+		$set = GP::$translation_set->create( array( 'name' => 'Set', 'slug' => 'default', 'project_id' => $project->id, 'locale' => 'bg' ) );
+		$set2 = GP::$translation_set->create( array( 'name' => 'Set', 'slug' => 'default', 'project_id' => $project->id, 'locale' => 'de' ) );
+
+		$this->assertFalse( (bool) GP::$permission->user_can( $user, 'import-waiting', 'translation-set', $set->id ) );
+		$this->assertFalse( (bool) GP::$permission->user_can( $user, 'import-waiting', 'translation-set', $set2->id ) );
+
+		GP::$permission->create( array( 'user_id' => $user, 'action' => 'import-waiting', 'object_type' => 'translation-set', 'object_id' => $set2->id ) );
+
+		$this->assertTrue( (bool) GP::$permission->user_can( $user, 'import-waiting', 'translation-set', $set2->id ) );
+		$this->assertFalse( (bool) GP::$permission->user_can( $user, 'import-waiting', 'translation-set', $set->id ) );
+	}
 }


### PR DESCRIPTION
This adds a new dropdown to the import translations form:
<img width="332" alt="glotpress-import-waiting-current" src="https://cloud.githubusercontent.com/assets/203408/14179555/cbe7c3ae-f75f-11e5-98d7-15dcbe485135.png">

It also introduces two new permissions:
- `import`
- `import-waiting`

The latter permission will have the dropdown with just one entry, "waiting". If neither permission is set then importing is not possible and it will redirect away from the form.

Another bit changed: new translations entries will only be created if the translation doesn't yet exist in that current status (so for example if the entry already exists as "waiting" then it isn't duplicated, while this is the case without that part of the PR).

Resolves #377
