### PR TITLE
389: Correct delete permissions

### DIFF
--- a/gp-includes/routes/translation-set.php
+++ b/gp-includes/routes/translation-set.php
@@ -117,7 +117,7 @@ class GP_Route_Translation_Set extends GP_Route_Main {
 		}
 
 		list( $set, $project, $locale ) = $items;
-		if ( $this->cannot_edit_set_and_redirect( $set ) ) {
+		if ( $this->cannot_and_redirect( 'delete', 'project', $set->project_id, gp_url_project( $project ) ) ) {
 			return;
 		}
 

--- a/gp-includes/template-links.php
+++ b/gp-includes/template-links.php
@@ -104,7 +104,7 @@ function gp_link_set_edit() {
  * @return string $link
  */
 function gp_link_set_delete_get( $set, $project, $text = false, $attrs = array() ) {
-	if ( ! GP::$permission->current_user_can( 'write', 'project', $project->id ) ) {
+	if ( ! GP::$permission->current_user_can( 'delete', 'project', $project->id ) ) {
 		return '';
 	}
 
@@ -172,7 +172,7 @@ function gp_link_glossary_edit() {
  * @return string The HTML link.
  */
 function gp_link_glossary_delete_get( $glossary, $set, $text = false, $attrs = array() ) {
-	if ( ! GP::$permission->current_user_can( 'approve', 'translation-set', $set->id ) ) {
+	if ( ! GP::$permission->current_user_can( 'delete', 'translation-set', $set->id ) ) {
 		return '';
 	}
 


### PR DESCRIPTION
As per #389 the delete permissions are inconsistent in some places.

This PR only deals with the inconsistencies.  Other items, like if using translations sets rights to proxy for glossary rights ( ie https://github.com/GlotPress/GlotPress-WP/blob/2.0.0/gp-includes/routes/glossary.php#L199) are not addressed in this PR.

Resolves #389.
