### PR TITLE
376: Replace LIKE queries for the status of an original with an exact match.

### DIFF
--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -269,10 +269,10 @@ class GP_Translation_Set extends GP_Thing {
 			$o = GP::$original->table;
 			$counts = GP::$translation->many_no_map("
 				SELECT t.status as translation_status, COUNT(*) as n
-				FROM $t AS t INNER JOIN $o AS o ON t.original_id = o.id WHERE t.translation_set_id = %d AND o.status LIKE '+%%' GROUP BY t.status", $this->id);
+				FROM $t AS t INNER JOIN $o AS o ON t.original_id = o.id WHERE t.translation_set_id = %d AND o.status = '+active' GROUP BY t.status", $this->id);
 			$warnings_count = GP::$translation->value("
 				SELECT COUNT(*) FROM $t AS t INNER JOIN $o AS o ON t.original_id = o.id
-				WHERE t.translation_set_id = %d AND o.status LIKE '+%%' AND (t.status = 'current' OR t.status = 'waiting') AND warnings IS NOT NULL", $this->id);
+				WHERE t.translation_set_id = %d AND o.status = '+active' AND (t.status = 'current' OR t.status = 'waiting') AND warnings IS NOT NULL", $this->id);
 			$counts[] = (object)array( 'translation_status' => 'warnings', 'n' => $warnings_count );
 			wp_cache_set( $this->id, $counts, 'translation_set_status_breakdown' );
 		}

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -243,7 +243,7 @@ class GP_Translation extends GP_Thing {
 			SELECT SQL_CALC_FOUND_ROWS t.*, o.*, t.id as id, o.id as original_id, t.status as translation_status, o.status as original_status, t.date_added as translation_added, o.date_added as original_added
 			FROM $wpdb->gp_originals as o
 			$join_type JOIN $wpdb->gp_translations AS t ON o.id = t.original_id AND t.translation_set_id = " . (int) $translation_set->id . " $join_where
-			WHERE o.project_id = " . (int) $project->id . " AND o.status LIKE '+%' $where ORDER BY $sql_sort $limit";
+			WHERE o.project_id = " . (int) $project->id . " AND o.status = '+active' $where ORDER BY $sql_sort $limit";
 		$rows = $this->many_no_map( $sql_for_translations );
 		$this->found_rows = $this->found_rows();
 		$translations = array();


### PR DESCRIPTION
There are only two status for originals: `+active` and `-original`.  There is no need to perform a fuzzy search which affects the performance of the GP_Translation->for_translation()` query.

See #376.
