### PR TITLE
376: Schema: Disallow NULL for the `original_id`, `translation_set_id`, and `project_id` fields

### DIFF
--- a/glotpress.php
+++ b/glotpress.php
@@ -27,7 +27,7 @@
  */
 
 define( 'GP_VERSION', '2.1.0-rc.2' );
-define( 'GP_DB_VERSION', '980' );
+define( 'GP_DB_VERSION', '990' );
 define( 'GP_ROUTING', true );
 define( 'GP_PLUGIN_FILE', __FILE__ );
 define( 'GP_PATH', __DIR__ . '/' );

--- a/gp-includes/schema.php
+++ b/gp-includes/schema.php
@@ -37,8 +37,8 @@ function gp_schema_get() {
 	 */
 	$gp_schema['translations'] = "CREATE TABLE $wpdb->gp_translations (
 		id int(10) NOT NULL auto_increment,
-		original_id int(10) DEFAULT NULL,
-		translation_set_id int(10) DEFAULT NULL,
+		original_id int(10) NOT NULL,
+		translation_set_id int(10) NOT NULL,
 		translation_0 text NOT NULL,
 		translation_1 text DEFAULT NULL,
 		translation_2 text DEFAULT NULL,
@@ -87,7 +87,7 @@ function gp_schema_get() {
 		id int(10) NOT NULL auto_increment,
 		name varchar(255) NOT NULL,
 		slug varchar(255) NOT NULL,
-		project_id int(10) DEFAULT NULL,
+		project_id int(10) NOT NULL,
 		locale varchar(10) DEFAULT NULL,
 		PRIMARY KEY  (id),
 		UNIQUE KEY project_id_slug_locale (project_id,slug({$max_pid_slug_locale_key_length}),locale),
@@ -117,7 +117,7 @@ function gp_schema_get() {
 
 	$gp_schema['originals'] = "CREATE TABLE $wpdb->gp_originals (
 		id int(10) NOT NULL auto_increment,
-		project_id int(10) DEFAULT NULL,
+		project_id int(10) NOT NULL,
 		context varchar(255) DEFAULT NULL,
 		singular text NOT NULL,
 		plural text DEFAULT NULL,

--- a/tests/phpunit/lib/factory.php
+++ b/tests/phpunit/lib/factory.php
@@ -106,6 +106,7 @@ class GP_UnitTest_Factory_For_Translation extends GP_UnitTest_Factory_For_Thing 
 		parent::__construct( $factory, $thing? $thing : new GP_Translation );
 		$this->default_generation_definitions = array(
 			'translation_0' => new GP_UnitTest_Generator_Sequence( 'Translation %s' ),
+			'original_id' => 0,
 		);
 	}
 


### PR DESCRIPTION
[WIP]

See #376 and https://github.com/GlotPress/GlotPress-WP/issues/376#issuecomment-206592305.

There is currently one failing unit test:

```
1) GP_Test_Thing_Translation_set::test_copy_translations_from_should_copy_into_empty_set

/www/wp-develop/svn/tests/phpunit/includes/testcase.php:394
/www/glotpress-plugin/wordpress/wp-content/plugins/glotpress/tests/phpunit/testcases/tests_things/test_thing_translation_set.php:14
```
