### PR TITLE
425: Ignore PHPCS whitespace complaints in gp-templates

### DIFF
--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -21,4 +21,8 @@
 	<exclude-pattern>*/dev-lib/*</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
+
+	<rule ref="Generic.WhiteSpace.ScopeIndent">
+		<exclude-pattern>*/gp-templates/*</exclude-pattern>
+	</rule>
 </ruleset>


### PR DESCRIPTION
This adds a rule to `phpcs.ruleset.xml` that ignores the `Generic.WhiteSpace.ScopeIndent` codesniff in `gp-templates`.

See #425 
