### PR TITLE
227: Implementation of the Locale Glossary

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -493,6 +493,13 @@ span.active {
 	font-weight: bold;
 }
 
+span.locale-entry.bubble {
+	background-color: #555;
+	color: #ddd;
+	font-weight: bold;
+	margin-right: 0.5em;
+}
+
 ul a.edit, dt a.edit {
 	background-color: #777;
 }

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -92,6 +92,9 @@ $gp.editor = (
 						var content = $( '<ul>' );
 						$.each( $( this ).data( 'translations' ), function( i, e ) {
 							var def = $( '<li>' );
+							if ( e.locale_entry ) {
+								def.append( $( '<span>', { text: e.locale_entry } ).addClass( 'locale-entry bubble' ) );
+							}
 							def.append( $( '<span>', { text: e.pos } ).addClass( 'pos' ) );
 							def.append( $( '<span>', { text: e.translation } ).addClass( 'translation' ) );
 							def.append( $( '<span>', { text: e.comment } ).addClass( 'comment' ) );

--- a/gp-includes/router.php
+++ b/gp-includes/router.php
@@ -74,6 +74,14 @@ class GP_Router {
 			'get:/settings' => array( 'GP_Route_Settings', 'settings_get' ),
 			'post:/settings' => array( 'GP_Route_Settings', 'settings_post' ),
 
+			"get:(/languages)/$locale/$dir/glossary" => array( 'GP_Route_Glossary_Entry', 'glossary_entries_get' ),
+			"post:(/languages)/$locale/$dir/glossary" => array( 'GP_Route_Glossary_Entry', 'glossary_entries_post' ),
+			"post:(/languages)/$locale/$dir/glossary/-new" => array( 'GP_Route_Glossary_Entry', 'glossary_entry_add_post' ),
+			"post:(/languages)/$locale/$dir/glossary/-delete" => array( 'GP_Route_Glossary_Entry', 'glossary_entry_delete_post' ),
+			"get:(/languages)/$locale/$dir/glossary/-export" => array( 'GP_Route_Glossary_Entry', 'export_glossary_entries_get' ),
+			"get:(/languages)/$locale/$dir/glossary/-import" => array( 'GP_Route_Glossary_Entry', 'import_glossary_entries_get' ),
+			"post:(/languages)/$locale/$dir/glossary/-import" => array( 'GP_Route_Glossary_Entry', 'import_glossary_entries_post' ),
+
 			'get:/languages' => array( 'GP_Route_Locale', 'locales_get' ),
 			"get:/languages/$locale/$path" => array( 'GP_Route_Locale', 'single' ),
 			"get:/languages/$locale" => array( 'GP_Route_Locale', 'single' ),

--- a/gp-includes/routes/glossary-entry.php
+++ b/gp-includes/routes/glossary-entry.php
@@ -46,7 +46,7 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 		}
 
 		$can_edit = $this->can( 'approve', 'translation-set', $translation_set->id );
-		$url      = gp_url_join( gp_url_project_locale( $project_path, $locale_slug, $translation_set_slug ), array('glossary') );
+		$url      = gp_url_join( gp_url_project_locale( $project->path, $locale_slug, $translation_set_slug ), array( 'glossary' ) );
 
 		$this->tmpl( 'glossary-view', get_defined_vars() );
 	}
@@ -60,36 +60,36 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 		}
 
 		$translation_set = GP::$translation_set->by_project_id_slug_and_locale( $project->id, $translation_set_slug, $locale_slug );
-
 		if ( ! $translation_set ){
 			return $this->die_with_404();
 		}
 
-		if ( $this->invalid_nonce_and_redirect( 'add-glossary-entry_' . $project_path . $locale_slug . $translation_set_slug ) ) {
+		if ( $this->invalid_nonce_and_redirect( 'add-glossary-entry_' . $project->path . $locale_slug . $translation_set_slug ) ) {
 			return;
 		}
 
 		if ( $this->cannot_and_redirect( 'approve', 'translation-set', $translation_set->id ) ) {
 			return;
 		}
-
 		$new_glossary_entry = new GP_Glossary_Entry( gp_post('new_glossary_entry') );
 		$new_glossary_entry->last_edited_by = get_current_user_id();
 
+		$glossary = GP::$glossary->get( $new_glossary_entry->glossary_id );
+
 		if ( ! $new_glossary_entry->validate() ) {
 			$this->errors = $new_glossary_entry->errors;
-			$this->redirect( gp_url_join( gp_url_project_locale( $project_path, $locale_slug, $translation_set_slug ), array('glossary' ) ) );
+			$this->redirect( gp_url_join( gp_url_project_locale( $project->path, $locale_slug, $translation_set_slug ), array( 'glossary' ) ) );
 		}
 		else {
 			$created_glossary_entry = GP::$glossary_entry->create_and_select( $new_glossary_entry );
 
 			if ( ! $created_glossary_entry ) {
 				$this->errors[] = __( 'Error in creating glossary entry!', 'glotpress' );
-				$this->redirect( gp_url_join( gp_url_project_locale( $project_path, $locale_slug, $translation_set_slug ), array('glossary') ) );
+				$this->redirect( gp_url_join( gp_url_project_locale( $project->path, $locale_slug, $translation_set_slug ), array( 'glossary' ) ) );
 			}
 			else {
 				$this->notices[] = __( 'The glossary entry was created!', 'glotpress' );
-				$this->redirect( gp_url_join( gp_url_project_locale( $project_path, $locale_slug, $translation_set_slug ), array('glossary') ) );
+				$this->redirect( gp_url_join( gp_url_project_locale( $project->path, $locale_slug, $translation_set_slug ), array( 'glossary' ) ) );
 			}
 		}
 	}
@@ -285,7 +285,7 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 			$this->notices[] = sprintf( __( '%s glossary entries were added', 'glotpress' ), $glossary_entries_added );
 		}
 
-		$this->redirect( gp_url_join( gp_url_project_locale( $project_path, $locale_slug, $translation_set_slug ), array('glossary') ) );
+		$this->redirect( gp_url_join( gp_url_project_locale( $project->path, $locale_slug, $translation_set_slug ), array( 'glossary' ) ) );
 	}
 
 	private function print_export_file( $locale_slug, $entries ) {

--- a/gp-includes/routes/glossary.php
+++ b/gp-includes/routes/glossary.php
@@ -70,7 +70,7 @@ class GP_Route_Glossary extends GP_Route_Main {
 			$this->notices[] = __( 'The glossary was created!', 'glotpress' );
 			$set_project     = GP::$project->get( $translation_set->project_id );
 
-			$this->redirect( gp_url_join( gp_url_project( $set_project, array( $translation_set->locale, $translation_set->slug ) ), array('glossary') ) );
+			$this->redirect( $created_glossary->path() );
 		}
 		else {
 			$this->errors[] = __( 'Error in creating glossary!', 'glotpress' );
@@ -114,7 +114,7 @@ class GP_Route_Glossary extends GP_Route_Main {
 		$translation_set = $new_glossary->translation_set_id ? GP::$translation_set->get( $new_glossary->translation_set_id ) : null;
 		$set_project     = GP::$project->get( $translation_set->project_id );
 
-		$this->redirect( gp_url_join( gp_url_project( $set_project, array( $translation_set->locale, $translation_set->slug ) ), array('glossary') ) );
+		$this->redirect( $glossary->path() );
 	}
 
 	/**
@@ -199,4 +199,5 @@ class GP_Route_Glossary extends GP_Route_Main {
 	private function cannot_delete_glossary_and_redirect( $glossary ) {
 		return $this->cannot_and_redirect( 'delete', 'translation-set', $glossary->translation_set_id );
 	}
+
 }

--- a/gp-includes/routes/locale.php
+++ b/gp-includes/routes/locale.php
@@ -134,6 +134,10 @@ class GP_Route_Locale extends GP_Route_Main {
 			}
 		}
 
+		$can_create_locale_glossary = GP::$permission->current_user_can( 'admin' );
+		$locale_glossary_translation_set = GP::$translation_set->by_project_id_slug_and_locale( 0, $current_set_slug, $locale_slug );
+		$locale_glossary = GP::$glossary->by_set_id( $locale_glossary_translation_set->id );
+
 		$this->tmpl( 'locale', get_defined_vars() );
 	}
 

--- a/gp-includes/template.php
+++ b/gp-includes/template.php
@@ -218,6 +218,9 @@ function gp_project_names_from_root( $leaf_project ) {
 }
 
 function gp_project_links_from_root( $leaf_project ) {
+	if ( 0 === $leaf_project->id ) {
+		return array();
+	}
 	$links = array();
 	$path_from_root = array_reverse( $leaf_project->path_to_root() );
 	$links[] = empty( $path_from_root)? __( 'Projects', 'glotpress' ) : gp_link_get( gp_url( '/projects' ), __( 'Projects', 'glotpress' ) );

--- a/gp-includes/things/glossary-entry.php
+++ b/gp-includes/things/glossary-entry.php
@@ -36,7 +36,21 @@ class GP_Glossary_Entry extends GP_Thing {
 		$this->setup_pos();
 	}
 
-	private function setup_pos(){
+	/**
+	 * A determinate key for hash lookups.
+	 *
+	 * @since 2.3.0
+	 *
+	 * @return string The key
+	 */
+	public function key() {
+		return $this->term . '_' . $this->part_of_speech;
+	}
+
+	/**
+	 * Sets up the part of speech captions.
+	 */
+	private function setup_pos() {
 		if ( ! empty( $this->parts_of_speech ) ) {
 			return;
 		}

--- a/gp-includes/things/project.php
+++ b/gp-includes/things/project.php
@@ -44,9 +44,33 @@ class GP_Project extends GP_Thing {
 	// Additional queries
 
 	public function by_path( $path ) {
+		if ( '/languages' === $path ) {
+			return GP::$glossary->get_locale_glossary_project();
+		}
 		return $this->one( "SELECT * FROM $this->table WHERE path = %s", trim( $path, '/' ) );
 	}
 
+	/**
+	 * Fetches the project by id or object.
+	 *
+	 * @since 2.3.0
+	 *
+	 * @param int|object $thing_or_id A project or the id.
+	 * @return GP_Project The project
+	 */
+	public function get( $thing_or_id ) {
+		if ( is_numeric( $thing_or_id ) && 0 === (int) $thing_or_id ) {
+			return GP::$glossary->get_locale_glossary_project();
+		}
+
+		return parent::get( $thing_or_id );
+	}
+
+	/**
+	 * Retrieves the sub projects
+	 *
+	 * @return array Array of GP_Project
+	 */
 	public function sub_projects() {
 		$sub_projects = $this->many( "SELECT * FROM $this->table WHERE parent_project_id = %d ORDER BY active DESC, id ASC", $this->id );
 

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -171,9 +171,15 @@ class GP_Translation_Set extends GP_Thing {
 	}
 
 	public function by_project_id_slug_and_locale( $project_id, $slug, $locale_slug ) {
-		return $this->one( "
+		$result = $this->one( "
 		    SELECT * FROM $this->table
 		    WHERE slug = %s AND project_id= %d AND locale = %s", $slug, $project_id, $locale_slug );
+
+		if ( ! $result && 0 === $project_id ) {
+			$result = $this->create( array( 'project_id' => $project_id, 'name' => GP_Locales::by_slug( $locale_slug )->english_name, 'slug' => $slug, 'locale' => $locale_slug ) );
+		}
+
+		return $result;
 	}
 
 	public function by_locale( $locale_slug ) {

--- a/gp-includes/url.php
+++ b/gp-includes/url.php
@@ -145,7 +145,14 @@ function gp_url_current() {
  */
 function gp_url_project( $project_or_path = '', $path = '', $query = null ) {
 	$project_path = is_object( $project_or_path )? $project_or_path->path : $project_or_path;
-	return gp_url( array( 'projects', $project_path, $path ), $query );
+
+	if ( '//' === substr( $project_path, 0, 2 ) ) {
+		$project_path = ltrim( $project_path, '/' );
+	} else {
+		$project_path = array( 'projects', $project_path );
+	}
+
+	return gp_url( array( $project_path, $path ), $query );
 }
 
 function gp_url_profile( $user_nicename = '' ) {

--- a/gp-templates/glossary-view.php
+++ b/gp-templates/glossary-view.php
@@ -14,9 +14,14 @@ gp_enqueue_scripts( 'gp-glossary' );
 wp_localize_script( 'gp-glossary', '$gp_glossary_options', $glossary_options );
 
 gp_tmpl_header();
+
+$title = __( 'Glossary for %1$s translation of %2$s', 'glotpress' );
+if ( 0 === $project->id ) {
+	$title = __( 'Glossary for %1$s', 'glotpress' );
+}
 ?>
 
-<h2><?php printf( _x( 'Glossary for %1$s translation of %2$s', '{language} / { project name}', 'glotpress' ), esc_html( $translation_set->name ), esc_html( $project->name ) ); ?>
+<h2><?php printf( esc_html( $title ), esc_html( $translation_set->name ), esc_html( $project->name ) ); ?>
 	<?php gp_link_glossary_edit( $glossary, $translation_set, __( '(edit)', 'glotpress' ) ); ?>
 	<?php gp_link_glossary_delete( $glossary, $translation_set, __( '(delete)', 'glotpress' ) ); ?>
 </h2>

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -42,8 +42,7 @@ function prepare_original( $text ) {
 }
 
 function map_glossary_entries_to_translations_originals( $translations, $glossary ) {
-	$glossary_entries = GP::$glossary_entry->by_glossary_id( $glossary->id );
-
+	$glossary_entries = $glossary->get_entries();
 	if ( empty ( $glossary_entries ) ) {
 		return $translations;
 	}
@@ -86,7 +85,13 @@ function map_glossary_entries_to_translations_originals( $translations, $glossar
 		foreach ( $glossary_entries_terms as $i => $terms ) {
 			$glossary_entry = $glossary_entries[ $i ];
 			if ( preg_match( '/\b(' . $terms . ')\b/', $t->singular . ' ' . $t->plural, $m ) ) {
-				$matching_entries[ $m[1] ][] = array( 'translation' => $glossary_entry->translation, 'pos' => $glossary_entry->part_of_speech, 'comment' => $glossary_entry->comment );
+				$locale_entry = '';
+				if ( $glossary_entry->glossary_id !== $glossary->id ) {
+					/* translators: Denotes an entry from the locale glossary in the tooltip */
+					$locale_entry = _x( 'Locale Glossary', 'Bubble', 'glotpress' );
+				}
+
+				$matching_entries[ $m[1] ][] = array( 'translation' => $glossary_entry->translation, 'pos' => $glossary_entry->part_of_speech, 'comment' => $glossary_entry->comment, 'locale_entry' => $locale_entry );
 			}
 		}
 

--- a/gp-templates/locale.php
+++ b/gp-templates/locale.php
@@ -6,14 +6,20 @@ $breadcrumb[] = gp_link_get( gp_url( '/languages' ), __( 'Locales', 'glotpress' 
 if ( 'default' == $current_set_slug ) {
 	$breadcrumb[] = esc_html( $locale->english_name );
 } else {
-	$breadcrumb[] = gp_link_get( gp_url_join( '/languages', $locale->slug ), esc_html( $locale->english_name ) );
+	$breadcrumb[] = gp_link_get( gp_url_join( gp_url( '/languages' ), $locale->slug ), esc_html( $locale->english_name ) );
 	$breadcrumb[] = $set_list[ $current_set_slug ];
 }
 gp_breadcrumb( $breadcrumb );
 gp_tmpl_header();
 ?>
 
-	<h2><?php printf( __( 'Active Projects translated to %s', 'glotpress' ), esc_html( $locale->english_name ) ); ?></h2>
+	<h2><?php printf( __( 'Active Projects translated to %s', 'glotpress' ), esc_html( $locale->english_name ) ); ?>
+		<?php if ( $locale_glossary ) : ?>
+			<a href="<?php echo esc_url( gp_url_join( gp_url( '/languages' ), $locale->slug, 'default', 'glossary' ) ); ?>" class="glossary-link">Locale Glossary</a>
+		<?php elseif ( $can_create_locale_glossary ) : ?>
+			<a href="<?php echo esc_url( gp_url_join( gp_url( '/languages' ), $locale->slug, 'default', 'glossary' ) ); ?>" class="glossary-link">Create Locale Glossary</a>
+		<?php endif; ?>
+	</h2>
 
 <?php if ( count( $set_list ) > 1 ) : ?>
 	<p class="actionlist secondary">

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -19,7 +19,7 @@ $i = 0;
 	<?php printf( __( 'Translation of %s', 'glotpress' ), esc_html( $project->name )); ?>: <?php echo esc_html( $translation_set->name ); ?>
 	<?php gp_link_set_edit( $translation_set, $project, __( '(edit)', 'glotpress' ) ); ?>
 	<?php gp_link_set_delete( $translation_set, $project, __( '(delete)', 'glotpress' ) ); ?>
-	<?php if ( $glossary ): ?>
+	<?php if ( $glossary && $glossary->translation_set_id === $translation_set->id ) : ?>
 	<?php echo gp_link( $glossary->path(), __( 'glossary', 'glotpress' ), array('class'=>'glossary-link') ); ?>
 	<?php elseif ( $can_approve ): ?>
 		<?php echo gp_link_get( gp_url( '/glossaries/-new', array( 'translation_set_id' => $translation_set->id ) ), __( 'Create Glossary', 'glotpress' ), array('class'=>'glossary-link') ); ?>

--- a/tests/phpunit/testcases/tests_things/test_thing_glossary.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_glossary.php
@@ -39,12 +39,125 @@ class GP_Test_Glossary extends GP_UnitTestCase {
 		$this->assertEquals( $glossary, $subsub_glossary );
 		$this->assertEquals( $glossary->path(), $subsub_glossary->path() );
 	}
-	
+
 	function test_delete() {
 		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => '1' ) );
 		$glossary->delete();
 		$new = GP::$glossary->by_set_id( '1' );
 		$this->assertNotEquals( $glossary, $new );
-		
+
+	}
+
+	/**
+	 * @ticket gh-435
+	 */
+	function test_get_entries() {
+
+		$this->assertFalse( GP::$glossary->get_entries() );
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
+
+		$test_entries = array(
+			array(
+				'term' => 'Term',
+				'translation' => 'Translation',
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'Term 2',
+				'translation' => 'Translation 2',
+				'glossary_id' => $glossary->id,
+			),
+		);
+
+		GP::$glossary_entry->create_and_select( $test_entries[0] );
+		$entries = $glossary->get_entries();
+
+		$this->assertCount( 1, $entries );
+		$this->assertInstanceOf( 'GP_Glossary_Entry', $entries[0] );
+
+		$this->assertEquals( $entries[0]->term, $test_entries[0]['term'] );
+		$this->assertEquals( $entries[0]->translation, $test_entries[0]['translation'] );
+
+		GP::$glossary_entry->create_and_select( $test_entries[1] );
+
+		// Test that caching is working.
+		$this->assertCount( 1, $glossary->get_entries() );
+
+		$new_glossary = GP::$glossary->get( $glossary->id );
+		$this->assertCount( 2, $new_glossary->get_entries() );
+	}
+
+	/**
+	 * @ticket gh-435
+	 */
+	function test_locale_glossary() {
+		$locale = $this->factory->locale->create();
+		$locale_set = $this->factory->translation_set->create( array( 'project_id' => 0, 'locale' => $locale->slug ));
+		$locale_glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $locale_set->id ) );
+
+		$args = array(
+			'locale' => $locale_set->locale,
+			'slug' => $locale_set->slug,
+		);
+		$set = $this->factory->translation_set->create_with_project( $args );
+		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
+
+		$test_entries = array(
+			array(
+				'term' => 'Term',
+				'part_of_speech' => 'noun',
+				'translation' => 'Translation',
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'Term 2',
+				'part_of_speech' => 'noun',
+				'translation' => 'Translation 2',
+				'glossary_id' => $locale_glossary->id,
+			),
+		);
+
+		GP::$glossary_entry->create_and_select( $test_entries[0] );
+		$this->assertCount( 1, $glossary->get_entries() );
+
+		$route = new Testable_GP_Route_Translation;
+		$extended_glossary = $route->testable_get_extended_glossary( $set, $set->project );
+		$this->assertCount( 1, $extended_glossary->get_entries() );
+
+		$locale_glossary_entry = GP::$glossary_entry->create_and_select( $test_entries[1] );
+		$this->assertCount( 1, $locale_glossary->get_entries() );
+
+		$route = new Testable_GP_Route_Translation;
+		$extended_glossary = $route->testable_get_extended_glossary( $set, $set->project );
+		$this->assertCount( 2, $extended_glossary->get_entries() );
+
+		$locale_glossary_entry->term = 'Term';
+		$locale_glossary_entry->save();
+
+		$route = new Testable_GP_Route_Translation;
+		$extended_glossary = $route->testable_get_extended_glossary( $set, $set->project );
+		$entries = $extended_glossary->get_entries();
+
+		// Count is now 1 as the term is overwritten by the locale glossary.
+		$this->assertCount( 1, $entries );
+		$this->assertEquals( $test_entries[1]['translation'], $entries[0]->translation );
+	}
+}
+
+/**
+ * Class that makes it possible to test protected functions.
+ */
+class Testable_GP_Route_Translation extends GP_Route_Translation {
+	/**
+	 * Wraps the protected get_extended_glossary function
+	 *
+	 * @param  GP_Translation_Set $translation_set translation_set for which to retrieve the glossary.
+	 * @param  GP_Project         $project         project for finding potential parent projects.
+	 * @return GP_Glossary                         extended glossary
+	 */
+	public function testable_get_extended_glossary( $translation_set, $project ) {
+		return $this->get_extended_glossary( $translation_set, $project );
 	}
 }

--- a/tests/phpunit/testcases/tests_things/test_thing_project.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_project.php
@@ -100,7 +100,7 @@ class GP_Test_Project extends GP_UnitTestCase {
 		$sub->regenerate_paths();
 		$sub->reload();
 		$this->assertEquals( 'root/sub', $sub->path );
-		
+
 		// Run the same test a second time with a permalink structure that includes a trailing slash.
 		$this->set_permalink_structure( GP_TESTS_PERMALINK_STRUCTURE_WITH_TRAILING_SLASH );
 		$wpdb->update( $wpdb->gp_projects, array( 'path' => 'wrong-path' ), array( 'id' => $sub->id ) );
@@ -277,13 +277,13 @@ class GP_Test_Project extends GP_UnitTestCase {
 
 	function test_delete() {
 		$project = GP::$project->create( array( 'name' => 'Root', 'slug' => 'root' ) );
-		
+
 		$pre_delete = GP::$project->find_one( array( 'id' => $project->id ) );
 
 		$project->delete();
-		
+
 		$post_delete = GP::$project->find_one( array( 'id' => $project->id ) );
-		
+
 		$this->assertFalse( empty( $pre_delete ) );
 		$this->assertNotEquals( $pre_delete, $post_delete );
 	}


### PR DESCRIPTION
**Update 2016-10-05:** The PR has been updated to reflect the consensus of #227. It changes the URL of a locale glossary to `/languages/de/default/glossary`.

<img width="288" alt="screen shot 2016-10-05 at 21 55 53" src="https://cloud.githubusercontent.com/assets/203408/19129158/8c61560c-8b46-11e6-9ebe-8b2f60f4d69a.png">

Locale Glossary entries override local project glossary entries. In the screenshot, for demo purposes, the Locale Glossary doesn't contain the _verb_ version of the term.

**Update:** after discussion with @ocean90 I have incorporated the code from gp-master-glossary into this PR.

By adding this filter it will be possible to install the [gp-master-glossary](https://github.com/Automattic/gp-master-glossary) plugin which makes it possible to define a master glossary project.

For translate.wordpress.org this addresses a shortcoming of the [recently introduced](https://make.wordpress.org/polyglots/2016/04/05/glotdict-custom-glossaries-for-glotpress-in-the-browser/) Chrome extension [GlotDict](https://github.com/Mte90/GlotDict) which needs to have a [copy of the glossary](https://github.com/Mte90/GlotDictJSON), which making it problematic when the glossaries are updated.

<img width="502" alt="screen shot 2016-05-06 at 10 34 27" src="https://cloud.githubusercontent.com/assets/203408/15068238/2830c26e-1376-11e6-8202-f8b0a365aa2d.png">
This screenshot shows the gp-master-glossary plugin active. I have modifed the glossary entry descriptions to show where they are coming from. It is likely that the project glossary won't define the same terms as the master glossary.

See https://glotpress.trac.wordpress.org/ticket/97#comment:66
Ref #227 
