### PR TITLE
Fix infinite loop in po export of child project

### DIFF
--- a/gp-includes/formats/format_pomo.php
+++ b/gp-includes/formats/format_pomo.php
@@ -38,7 +38,7 @@ class GP_Format_PO extends GP_Format {
 		$project_tree[] = $current->name;
 
 		while ( $current->parent_project_id > 0 ) {
-			$current = GP::$project->get( $project->parent_project_id );
+			$current = GP::$project->get( $current->parent_project_id );
 			$project_tree[] = $current->name;
 		}
 


### PR DESCRIPTION
Current PO export from a child project two or more level deep results in an infinite `while` loop.
