### PR TITLE
397: Translation sets: Split status counts by hidden and public

### DIFF
--- a/gp-includes/things/original.php
+++ b/gp-includes/things/original.php
@@ -119,6 +119,11 @@ class GP_Original extends GP_Thing {
 			$project_id
 		), ARRAY_A );
 
+		// Make sure $wpdb->get_row() returned an array, if not set all results to 0.
+		if ( ! is_array( $counts ) ) {
+			$counts = array( 'total' => 0, 'hidden' => 0, 'public' => 0 );
+		}
+
 		// Make sure counts are integers.
 		$counts = (object) array_map( 'intval', $counts );
 

--- a/gp-includes/things/original.php
+++ b/gp-includes/things/original.php
@@ -97,7 +97,7 @@ class GP_Original extends GP_Thing {
 		global $wpdb;
 
 		// If an unknown type has been passed in, just return a null result immediately instead of running the SQL code.
-		if ( ! in_array( $type, array( 'total', 'hidden', 'public', 'all' ) ) ) {
+		if ( ! in_array( $type, array( 'total', 'hidden', 'public', 'all' ), true ) ) {
 			return null;
 		}
 

--- a/gp-includes/things/original.php
+++ b/gp-includes/things/original.php
@@ -96,6 +96,11 @@ class GP_Original extends GP_Thing {
 	public function count_by_project_id( $project_id, $type = 'total' ) {
 		global $wpdb;
 
+		// If an unknown type has been passed in, just return a null result immediately instead of running the SQL code.
+		if ( ! in_array( $type, array( 'total', 'hidden', 'public', 'all' ) ) ) {
+			return null;
+		}
+
 		$cached = wp_cache_get( $project_id, self::$count_cache_group );
 		if ( false !== $cached && is_object( $cached ) ) { // Since 2.1.0 stdClass.
 			if ( 'all' === $type ) {

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -428,7 +428,7 @@ class GP_Translation_Set extends GP_Thing {
 	public function update_status_breakdown() {
 		$counts = wp_cache_get( $this->id, 'translation_set_status_breakdown' );
 
-		if ( ! is_array( $counts ) ) { // @todo: Check if new or old format
+		if ( ! is_array( $counts ) || ! isset( $counts[0]->total ) ) { // The format was changed in 2.1.
 			global $wpdb;
 			$counts = array();
 

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -20,17 +20,88 @@ class GP_Translation_Set extends GP_Thing {
 	var $int_fields = array( 'id', 'project_id' );
 	var $non_updatable_attributes = array( 'id' );
 
+	/**
+	 * ID of the translation set.
+	 *
+	 * @var int
+	 */
 	public $id;
+
+	/**
+	 * Name of the translation set.
+	 *
+	 * @var string
+	 */
 	public $name;
+
+	/**
+	 * Slug of the translation set.
+	 *
+	 * @var string
+	 */
 	public $slug;
+
+	/**
+	 * Project ID of the translation set.
+	 *
+	 * @var int
+	 */
 	public $project_id;
+
+	/**
+	 * Locale of the translation set.
+	 *
+	 * @var string
+	 */
 	public $locale;
+
+	/**
+	 * GP project of the translation set.
+	 *
+	 * @var GP_Project
+	 */
 	public $project;
+
+	/**
+	 * Number of waiting translations.
+	 *
+	 * @var int
+	 */
 	public $waiting_count;
+
+	/**
+	 * Number of fuzzy translations.
+	 *
+	 * @var int
+	 */
 	public $fuzzy_count;
+
+	/**
+	 * Number of untranslated originals.
+	 *
+	 * @var int
+	 */
 	public $untranslated_count;
+
+	/**
+	 * Number of current translations.
+	 *
+	 * @var int
+	 */
 	public $current_count;
+
+	/**
+	 * Number of translations with warnings.
+	 *
+	 * @var int
+	 */
 	public $warnings_count;
+
+	/**
+	 * Number of all originals.
+	 *
+	 * @var int
+	 */
 	public $all_count;
 
 	/**
@@ -273,72 +344,160 @@ class GP_Translation_Set extends GP_Thing {
 		return $translations_added;
 	}
 
+	/**
+	 * Retrieves the number of waiting translations.
+	 *
+	 * @return int Number of waiting translations.
+	 */
 	public function waiting_count() {
-		if ( !isset( $this->waiting_count ) ) $this->update_status_breakdown();
+		if ( ! isset( $this->waiting_count ) ) {
+			$this->update_status_breakdown();
+		}
+
 		return $this->waiting_count;
 	}
 
+	/**
+	 * Retrieves the number of untranslated originals.
+	 *
+	 * @return int Number of untranslated originals.
+	 */
 	public function untranslated_count() {
-		if ( !isset( $this->untranslated_count ) ) $this->update_status_breakdown();
+		if ( ! isset( $this->untranslated_count ) ) {
+			$this->update_status_breakdown();
+		}
+
 		return $this->untranslated_count;
 	}
 
+	/**
+	 * Retrieves the number of fuzzy translations.
+	 *
+	 * @return int Number of fuzzy translations.
+	 */
 	public function fuzzy_count() {
-		if ( !isset( $this->fuzzy_count ) ) $this->update_status_breakdown();
+		if ( ! isset( $this->fuzzy_count ) ) {
+			$this->update_status_breakdown();
+		}
+
 		return $this->fuzzy_count;
 	}
 
+	/**
+	 * Retrieves the number of current translations.
+	 *
+	 * @return int Number of current translations.
+	 */
 	public function current_count() {
-		if ( !isset( $this->current_count ) ) $this->update_status_breakdown();
+		if ( ! isset( $this->current_count ) ) {
+			$this->update_status_breakdown();
+		}
+
 		return $this->current_count;
 	}
 
+	/**
+	 * Retrieves the number of translations with warnings.
+	 *
+	 * @return int Number of translations with warnings.
+	 */
 	public function warnings_count() {
-		if ( !isset( $this->warnings_count ) ) $this->update_status_breakdown();
+		if ( ! isset( $this->warnings_count ) ) {
+			$this->update_status_breakdown();
+		}
+
 		return $this->warnings_count;
 	}
 
+	/**
+	 * Retrieves the number of all originals.
+	 *
+	 * @return int Number of all originals.
+	 */
 	public function all_count() {
-		$this->all_count = GP::$original->count_by_project_id( $this->project_id );
+		if ( ! isset( $this->all_count ) ) {
+			$this->update_status_breakdown();
+		}
+
 		return $this->all_count;
 	}
 
-
+	/**
+	 * Populates the count properties.
+	 */
 	public function update_status_breakdown() {
 		$counts = wp_cache_get( $this->id, 'translation_set_status_breakdown' );
 
-		if ( ! is_array( $counts ) ) {
-			/*
-			 * TODO:
-			 *  - calculate weighted coefficient by priority to know how much of the strings are translated
-			 * 	- calculate untranslated
-			 */
-			$t = GP::$translation->table;
-			$o = GP::$original->table;
-			$counts = GP::$translation->many_no_map("
-				SELECT t.status as translation_status, COUNT(*) as n
-				FROM $t AS t INNER JOIN $o AS o ON t.original_id = o.id WHERE t.translation_set_id = %d AND o.status = '+active' GROUP BY t.status", $this->id);
-			$warnings_count = GP::$translation->value("
-				SELECT COUNT(*) FROM $t AS t INNER JOIN $o AS o ON t.original_id = o.id
-				WHERE t.translation_set_id = %d AND o.status = '+active' AND (t.status = 'current' OR t.status = 'waiting') AND warnings IS NOT NULL", $this->id);
-			$counts[] = (object)array( 'translation_status' => 'warnings', 'n' => $warnings_count );
+		if ( ! is_array( $counts ) ) { // @todo: Check if new or old format
+			global $wpdb;
+			$counts = array();
+
+			$status_counts = $wpdb->get_results( $wpdb->prepare( "
+				SELECT
+					t.status AS translation_status,
+					COUNT(*) AS total,
+					COUNT( CASE WHEN o.priority = '-2' THEN o.priority END ) AS `hidden`,
+					COUNT( CASE WHEN o.priority <> '-2' THEN o.priority END ) AS `public`
+				FROM {$wpdb->gp_translations} AS t
+				INNER JOIN {$wpdb->gp_originals} AS o ON t.original_id = o.id
+				WHERE
+					t.translation_set_id = %d
+					AND o.status = '+active'
+				GROUP BY t.status
+			", $this->id ) );
+
+			if ( $status_counts ) {
+				$counts = $status_counts;
+			}
+
+			$warnings_counts = $wpdb->get_row( $wpdb->prepare( "
+				SELECT
+					COUNT(*) AS total,
+					COUNT( CASE WHEN o.priority = '-2' THEN o.priority END ) AS `hidden`,
+					COUNT( CASE WHEN o.priority <> '-2' THEN o.priority END ) AS `public`
+				FROM {$wpdb->gp_translations} AS t
+				INNER JOIN {$wpdb->gp_originals} AS o ON t.original_id = o.id
+				WHERE
+					t.translation_set_id = %d AND
+					o.status = '+active' AND
+					( t.status = 'current' OR t.status = 'waiting' )
+					AND warnings IS NOT NULL
+			", $this->id ) );
+
+			if ( $warnings_counts ) {
+				$counts[] = (object) array(
+					'translation_status' => 'warnings',
+					'total'              => $warnings_counts->total,
+					'hidden'             => $warnings_counts->hidden,
+					'public'             => $warnings_counts->public,
+				);
+			}
 			wp_cache_set( $this->id, $counts, 'translation_set_status_breakdown' );
 		}
-		$counts[] = (object)array( 'translation_status' => 'all', 'n' => $this->all_count() );
+
+		$all_count = GP::$original->count_by_project_id( $this->project_id );
+		$counts[] = (object) array(
+			'translation_status' => 'all',
+			'total'              => $all_count->total,
+			'hidden'             => $all_count->hidden,
+			'public'             => $all_count->public,
+		);
 
 		$statuses = GP::$translation->get_static( 'statuses' );
 		$statuses[] = 'warnings';
 		$statuses[] = 'all';
-		foreach( $statuses as $status ) {
-			$this->{$status.'_count'} = 0;
+		foreach ( $statuses as $status ) {
+			$this->{$status . '_count'} = 0;
 		}
-		$this->untranslated_count = 0;
-		foreach( $counts as $count ) {
-			if ( in_array( $count->translation_status, $statuses ) ) {
-				$this->{$count->translation_status.'_count'} = $count->n;
+
+		$user_can_view_hidden = GP::$permission->current_user_can( 'write', 'project', $this->project_id );
+		foreach ( $counts as $count ) {
+			if ( in_array( $count->translation_status, $statuses, true ) ) {
+				$this->{$count->translation_status . '_count'} = $user_can_view_hidden ? $count->total : $count->public;
 			}
 		}
-		$this->untranslated_count = $this->all_count() - $this->current_count;
+
+		$this->untranslated_count = $this->all_count - $this->current_count; // @todo Improve this.
 	}
 
 	/**
@@ -377,7 +536,13 @@ class GP_Translation_Set extends GP_Thing {
 
 
 	public function percent_translated() {
-		$original_count = GP::$original->count_by_project_id( $this->project_id );
+		$original_counts = GP::$original->count_by_project_id( $this->project_id );
+
+		if ( GP::$permission->current_user_can( 'write', 'project', $this->project_id ) ) {
+			$original_count = $original_counts->total;
+		} else {
+			$original_count = $original_counts->public;
+		}
 
 		return $original_count ? floor( $this->current_count() / $original_count * 100 ) : 0;
 	}

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -467,15 +467,15 @@ class GP_Translation_Set extends GP_Thing {
 			if ( $warnings_counts ) {
 				$counts[] = (object) array(
 					'translation_status' => 'warnings',
-					'total'              => $warnings_counts->total,
-					'hidden'             => $warnings_counts->hidden,
-					'public'             => $warnings_counts->public,
+					'total'              => (int) $warnings_counts->total,
+					'hidden'             => (int) $warnings_counts->hidden,
+					'public'             => (int) $warnings_counts->public,
 				);
 			}
 			wp_cache_set( $this->id, $counts, 'translation_set_status_breakdown' );
 		}
 
-		$all_count = GP::$original->count_by_project_id( $this->project_id );
+		$all_count = GP::$original->count_by_project_id( $this->project_id, 'all' );
 		$counts[] = (object) array(
 			'translation_status' => 'all',
 			'total'              => $all_count->total,
@@ -493,7 +493,7 @@ class GP_Translation_Set extends GP_Thing {
 		$user_can_view_hidden = GP::$permission->current_user_can( 'write', 'project', $this->project_id );
 		foreach ( $counts as $count ) {
 			if ( in_array( $count->translation_status, $statuses, true ) ) {
-				$this->{$count->translation_status . '_count'} = $user_can_view_hidden ? $count->total : $count->public;
+				$this->{$count->translation_status . '_count'} = $user_can_view_hidden ? (int) $count->total : (int) $count->public;
 			}
 		}
 
@@ -536,7 +536,7 @@ class GP_Translation_Set extends GP_Thing {
 
 
 	public function percent_translated() {
-		$original_counts = GP::$original->count_by_project_id( $this->project_id );
+		$original_counts = GP::$original->count_by_project_id( $this->project_id, 'all' );
 
 		if ( GP::$permission->current_user_can( 'write', 'project', $this->project_id ) ) {
 			$original_count = $original_counts->total;

--- a/tests/phpunit/testcases/tests_things/test_thing_original.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_original.php
@@ -50,13 +50,12 @@ class GP_Test_Thing_Original extends GP_UnitTestCase {
 	function test_import_for_project_should_update_cache() {
 		$project  = $this->factory->project->create();
 		$original = $this->factory->original->create( array( 'project_id' => $project->id, 'status' => '+active', 'singular' => 'baba' ) );
-		$count    = $original->count_by_project_id( $project->id );
 
 		$translations_array = array( array( 'singular' => $original->singular ), array( 'singular' => 'dyado' ) );
 		$translations       = $this->create_translations_with( $translations_array );
 		$original->import_for_project( $project, $translations );
 
-		$this->assertEquals( count( $translations_array ), $original->count_by_project_id( $project->id ) );
+		$this->assertEquals( count( $translations_array ), $original->count_by_project_id( $project->id )->total );
 	}
 
 	function test_is_different_from_should_return_true_if_only_singular_is_for_update_and_it_is_the_same() {
@@ -123,7 +122,7 @@ class GP_Test_Thing_Original extends GP_UnitTestCase {
 		$original = $this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+obsolete', 'singular' => 'baba baba' ) );
 
 		$count = $original->count_by_project_id( $set->project->id );
-		$this->assertEquals( 0, $count );
+		$this->assertEquals( 0, $count->total );
 
 		$translations_for_import = $this->create_translations_with( array( array( 'singular' => 'baba baba' ) ) );
 
@@ -136,7 +135,7 @@ class GP_Test_Thing_Original extends GP_UnitTestCase {
 		$this->assertEquals( 0, $originals_error );
 
 		$count = $original->count_by_project_id( $set->project->id );
-		$this->assertEquals( 1, $count );
+		$this->assertEquals( 1, $count->total );
 	}
 
 	function test_import_should_remove_from_active_missing_strings() {


### PR DESCRIPTION
This PR changes the return value of `GP_Original::count_by_project_id()` to a `stdClass` object which includes `total`, `public`, `hidden`. The type in the cache changes too.

It also changes the value of the `translation_set_status_breakdown` cache in `GP_Translation_Set::update_status_breakdown()`. It now contains a  `stdClass` object which includes `total`, `public`, `hidden` for each status.

Alternative to #398.
Fixes #397.
