### PR TITLE
Resolve index key length issues

### DIFF
--- a/glotpress.php
+++ b/glotpress.php
@@ -27,7 +27,7 @@
  */
 
 define( 'GP_VERSION', '2.1.0-alpha' );
-define( 'GP_DB_VERSION', '960' );
+define( 'GP_DB_VERSION', '970' );
 define( 'GP_ROUTING', true );
 define( 'GP_PLUGIN_FILE', __FILE__ );
 define( 'GP_PATH', __DIR__ . '/' );


### PR DESCRIPTION
This patch does several things:
- Converts all user_id's to bigint(20) to match WordPress
- Enforces a maximum size of components for compound indexes which would otherwise be too long
- Standardizes the 'status' field to be a varchar(20) in all tables
- Sets the size of the meta_key column in the meta table to be 255 to match WordPress
- Limits the size of the 'action' column in the permissions table to be 20 characters long

Resolves #462.
Resolves #464.
