### PR TITLE
397: Replace the null return value with an integer zero.

### DIFF
--- a/tests/phpunit/testcases/tests_things/test_thing_original.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_original.php
@@ -260,6 +260,6 @@ class GP_Test_Thing_Original extends GP_UnitTestCase {
 		$this->assertSame( 1, $public );
 
 		$non_existent = GP::$original->count_by_project_id( $project->id, 'non_existent' );
-		$this->assertSame( null, $non_existent );
+		$this->assertSame( 0, $non_existent );
 	}
 }


### PR DESCRIPTION
Alternate return standard for #397.
