### PR TITLE
469: Escape string references in android string files.

### DIFF
--- a/gp-includes/formats/format_android.php
+++ b/gp-includes/formats/format_android.php
@@ -146,7 +146,7 @@ class GP_Format_Android extends GP_Format {
 	 * @return string Returns the escaped string.
 	 */
 	protected function escape( $string ) {
-		$string = addcslashes( $string, "'\n");
+		$string = addcslashes( $string, "'\n" );
 		$string = str_replace( array( '&', '<' ), array( '&amp;', '&lt;' ), $string );
 
 		// Android strings that start with an '@' are references to other strings and need to be escaped.  See GH469.

--- a/gp-includes/formats/format_android.php
+++ b/gp-includes/formats/format_android.php
@@ -136,9 +136,14 @@ class GP_Format_Android extends GP_Format {
 		return stripcslashes( $string );
 	}
 
-	private function escape( $string ) {
+	protected function escape( $string ) {
 		$string = addcslashes( $string, "'\n");
 		$string = str_replace( array( '&', '<' ), array( '&amp;', '&lt;' ), $string );
+
+		// Android strings that start with an '@' are references to other strings and need to be escaped.  See GH469.
+		if ( gp_startswith( $string, '@' ) ) {
+			$string = '\\' . $string;
+		}
 
 		return $string;
 	}

--- a/gp-includes/formats/format_android.php
+++ b/gp-includes/formats/format_android.php
@@ -136,6 +136,15 @@ class GP_Format_Android extends GP_Format {
 		return stripcslashes( $string );
 	}
 
+	/**
+	 * Escapes a string with c style slashes and html entities as required.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $string The string to escape.
+	 *
+	 * @return string Returns the escaped string.
+	 */
 	protected function escape( $string ) {
 		$string = addcslashes( $string, "'\n");
 		$string = str_replace( array( '&', '<' ), array( '&amp;', '&lt;' ), $string );

--- a/tests/phpunit/testcases/tests_formats/test_format_android.php
+++ b/tests/phpunit/testcases/tests_formats/test_format_android.php
@@ -62,4 +62,29 @@ class GP_Test_Format_Android extends GP_UnitTestCase {
 		}
 	}
 
+	function test_escape() {
+		$test_class = new Testable_GP_Format_Strings_escape;
+
+		$this->assertEquals( "test \'string\'", $test_class->testable_escape( "test 'string'" ) );
+		$this->assertEquals( "test\\nstring", $test_class->testable_escape( "test\nstring" ) );
+		$this->assertEquals( '\@test string', $test_class->testable_escape( '@test string' ) );
+		$this->assertEquals( 'test @string', $test_class->testable_escape( 'test @string' ) );
+	}
+
+}
+
+/**
+ * Class that makes it possible to test protected functions.
+ */
+class Testable_GP_Format_Strings_escape extends GP_Format_Android {
+	/**
+	 * Wraps the protected escape function
+	 *
+	 * @param string $string The string to escape.
+	 *
+	 * @return string Returns escaped string.
+	 */
+	public function testable_escape( $string ) {
+		return $this->escape( $string );
+	}
 }


### PR DESCRIPTION
Resolves #469.
