### PR TITLE
Add ability to filter the source URL in the references

### DIFF
--- a/gp-includes/things/project.php
+++ b/gp-includes/things/project.php
@@ -233,10 +233,25 @@ class GP_Project extends GP_Thing {
 	}
 
 	public function source_url( $file, $line ) {
-		if ( $this->source_url_template() ) {
-			return str_replace( array('%file%', '%line%'), array($file, $line), $this->source_url_template() );
+		$source_url = false;
+
+		if ( $source_url_template = $this->source_url_template() ) {
+			$source_url = str_replace( array( '%file%', '%line%' ), array( $file, $line ), $source_url_template );
 		}
-		return false;
+
+		/**
+		 * Allows per-reference overriding of the source URL defined as project setting.
+		 *
+		 * @since 2.2.0
+		 *
+		 * @param string        $source_url   The originally generated source URL.
+		 * @param GP_Project    $project      The current project.
+		 * @param string        $file         The referenced file name.
+		 * @param string        $line         The line number in the referenced file.
+		 *
+		 * @return string|false
+		 */
+		return apply_filters( 'gp_reference_source_url', $source_url, $this, $file, $line );
 	}
 
 	public function source_url_template() {

--- a/gp-includes/things/project.php
+++ b/gp-includes/things/project.php
@@ -234,7 +234,6 @@ class GP_Project extends GP_Thing {
 
 	public function source_url( $file, $line ) {
 		$source_url = false;
-
 		if ( $source_url_template = $this->source_url_template() ) {
 			$source_url = str_replace( array( '%file%', '%line%' ), array( $file, $line ), $source_url_template );
 		}
@@ -244,12 +243,10 @@ class GP_Project extends GP_Thing {
 		 *
 		 * @since 2.2.0
 		 *
-		 * @param string        $source_url   The originally generated source URL.
-		 * @param GP_Project    $project      The current project.
-		 * @param string        $file         The referenced file name.
-		 * @param string        $line         The line number in the referenced file.
-		 *
-		 * @return string|false
+		 * @param string|false $source_url The originally generated source URL, or false if no URL is available.
+		 * @param GP_Project $project The current project.
+		 * @param string $file The referenced file name.
+		 * @param string $line The line number in the referenced file.
 		 */
 		return apply_filters( 'gp_reference_source_url', $source_url, $this, $file, $line );
 	}

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -140,7 +140,6 @@ function references( $project, $entry ) {
 		<?php
 		foreach( $entry->references as $reference ):
 			list( $file, $line ) = array_pad( explode( ':', $reference ), 2, 0 );
-			// TODO: allow the user to override the project setting
 			if ( $source_url = $project->source_url( $file, $line ) ):
 				?>
 				<li><a target="_blank" tabindex="-1" href="<?php echo $source_url; ?>"><?php echo $file.':'.$line ?></a></li>


### PR DESCRIPTION
This allows to create a filter that modifies the URLs for the files listed under References.

Example usage:

``` php
add_filter( 'gp_reference_source_url', function( $source_url, $project, $file, $line ) {
// Libraries don't reside in our repo but we have them translatable through GlotPress.
if ( preg_match( '#^lib/#', $file ) ) {
     return false; 
}
return $source_url;
}, 10, 4 );
```

Possible uses:
- for projects that include strings from different sources
- for only partially linkable source texts

This fixes a `TODO` source line.

I have already used `@since 2.2.0` for the docs but this can of course be changed depending on which version this lands with.
