### PR TITLE
524: Add filters: for_translation sql clauses and returned rows

### DIFF
--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -442,18 +442,18 @@ class GP_Translation extends GP_Thing {
 		 */
 		$clauses = apply_filters( 'gp_for_translation_clauses', compact( 'fields', 'join', 'join_where', 'where', 'orderby', 'limit' ), $translation_set, $filters, $sort );
 
-		$fields = isset( $clauses['fields'] ) ? $clauses['fields'] : '';
+		$fields = isset( $clauses['fields'] ) ? $clauses['fields'] : '*';
 		$join = isset( $clauses['join'] ) ? $clauses['join'] : '';
 		$join_where = isset( $clauses['join_where'] ) ? $clauses['join_where'] : '';
 		$where = isset( $clauses['where'] ) ? $clauses['where'] : '';
-		$orderby = isset( $clauses['orderby'] ) ? $clauses['orderby'] : '';
+		$orderby = isset( $clauses['orderby'] ) ? 'ORDER BY ' . $clauses['orderby'] : '';
 		$limit = isset( $clauses['limit'] ) ? $clauses['limit'] : '';
 
 		$sql_for_translations = "
 			SELECT SQL_CALC_FOUND_ROWS $fields
 			FROM $wpdb->gp_originals as o
 			$join $join_where
-			WHERE o.project_id = " . (int) $project->id . " AND o.status = '+active' $where ORDER BY $orderby $limit";
+			WHERE o.project_id = " . (int) $project->id . " AND o.status = '+active' $where $orderby $limit";
 
 		$rows = $this->many_no_map( $sql_for_translations );
 

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -417,8 +417,10 @@ class GP_Translation extends GP_Thing {
 
 		$where = implode( ' AND ', $where );
 		if ( $where ) {
-			$where = 'AND '.$where;
+			$where = 'AND ' . $where;
 		}
+
+		$where = 'o.project_id = ' . (int) $project->id . ' AND o.status = "+active" ' . $where;
 
 		$join_where = implode( ' AND ', $join_where );
 		if ( $join_where ) {
@@ -451,9 +453,9 @@ class GP_Translation extends GP_Thing {
 
 		$sql_for_translations = "
 			SELECT SQL_CALC_FOUND_ROWS $fields
-			FROM $wpdb->gp_originals as o
+			FROM {$wpdb->gp_originals} as o
 			$join $join_where
-			WHERE o.project_id = " . (int) $project->id . " AND o.status = '+active' $where $orderby $limit";
+			WHERE $where $orderby $limit";
 
 		$rows = $this->many_no_map( $sql_for_translations );
 

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -449,7 +449,16 @@ class GP_Translation extends GP_Thing {
 		 *
 		 * @since 2.3.0
 		 *
-		 * @param array              $pieces          Terms query SQL clauses.
+		 * @param array              $pieces          {
+		 *     Translation query SQL clauses.
+		 *
+		 *     @type array  $fields     Fields to select in the query.
+		 *     @type string $join       JOIN clause of the query.
+		 *     @type string $join_where Conditions for the JOIN clause.
+		 *     @type string $where      WHERE clause of the query.
+		 *     @type string $orderby    Fields for ORDER BY clause.
+		 *     @type string $limit      LIMIT clause of the query.
+		 * }
 		 * @param GP_Translation_Set $translation_set The translation set object being queried.
 		 * @param array              $filters         An array of search filters.
 		 * @param array              $sort            An array of sort settings.

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -427,9 +427,21 @@ class GP_Translation extends GP_Thing {
 			$join_where = 'AND ' . $join_where;
 		}
 
-		$fields = 't.*, o.*, t.id as id, o.id as original_id, t.status as translation_status, o.status as original_status, t.date_added as translation_added, o.date_added as original_added';
+		$fields = array(
+			't.*',
+			'o.*',
+			't.id as id',
+			'o.id as original_id',
+			't.status as translation_status',
+			'o.status as original_status',
+			't.date_added as translation_added',
+			'o.date_added as original_added',
+		);
+
 		$join = "$join_type JOIN {$wpdb->gp_translations} AS t ON o.id = t.original_id AND t.translation_set_id = " . (int) $translation_set->id;
+
 		$orderby = sprintf( $sort_by, $sort_how );
+
 		$limit = $this->sql_limit_for_paging( $page, $this->per_page );
 
 		/**
@@ -444,7 +456,7 @@ class GP_Translation extends GP_Thing {
 		 */
 		$clauses = apply_filters( 'gp_for_translation_clauses', compact( 'fields', 'join', 'join_where', 'where', 'orderby', 'limit' ), $translation_set, $filters, $sort );
 
-		$fields = isset( $clauses['fields'] ) ? $clauses['fields'] : '*';
+		$fields = isset( $clauses['fields'] ) ? implode( ', ', $clauses['fields'] ) : '*';
 		$join = isset( $clauses['join'] ) ? $clauses['join'] : '';
 		$join_where = isset( $clauses['join_where'] ) ? $clauses['join_where'] : '';
 		$where = isset( $clauses['where'] ) ? $clauses['where'] : '';

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -422,11 +422,11 @@ class GP_Translation extends GP_Thing {
 
 		$join_where = implode( ' AND ', $join_where );
 		if ( $join_where ) {
-			$join_where = 'AND '.$join_where;
+			$join_where = 'AND ' . $join_where;
 		}
 
 		$fields = 't.*, o.*, t.id as id, o.id as original_id, t.status as translation_status, o.status as original_status, t.date_added as translation_added, o.date_added as original_added';
-		$join = "$join_type JOIN $wpdb->gp_translations AS t ON o.id = t.original_id AND t.translation_set_id = {$translation_set->id}";
+		$join = "$join_type JOIN {$wpdb->gp_translations} AS t ON o.id = t.original_id AND t.translation_set_id = " . (int) $translation_set->id;
 		$orderby = sprintf( $sort_by, $sort_how );
 		$limit = $this->sql_limit_for_paging( $page, $this->per_page );
 

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -433,7 +433,7 @@ class GP_Translation extends GP_Thing {
 		/**
 		 * Filters the 'for_translation' query SQL clauses.
 		 *
-		 * @since 2.3
+		 * @since 2.3.0
 		 *
 		 * @param array              $pieces          Terms query SQL clauses.
 		 * @param GP_Translation_Set $translation_set The translation set object being queried.

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -483,7 +483,7 @@ class GP_Translation extends GP_Thing {
 		/**
 		 * Filters the rows returned from the for_translation query.
 		 *
-		 * @since 2.3
+		 * @since 2.3.0
 		 *
 		 * @param array              $rows            Array of arrays returned by the query.
 		 * @param GP_Translation_Set $translation_set The translation set object being queried.


### PR DESCRIPTION
This PR adds a `gp_for_translation_clauses` filter that will enable plugins to control all the various elements of the `for_translation` sql query. 

Fixes #524 
