### PR TITLE
531: Remove 'SET storage_engine' from test setup.

### DIFF
--- a/tests/phpunit/includes/install.php
+++ b/tests/phpunit/includes/install.php
@@ -43,7 +43,15 @@ require_once ABSPATH . '/wp-settings.php';
 
 echo "Installing GlotPress...\n";
 
-$wpdb->query( 'SET storage_engine = INNODB' );
+/*
+ * default_storage_engine and storage_engine are the same option, but storage_engine
+ * was deprecated in MySQL (and MariaDB) 5.5.3, and removed in 5.7.
+ */
+if ( version_compare( $wpdb->db_version(), '5.5.3', '>=' ) ) {
+	$wpdb->query( 'SET default_storage_engine = InnoDB' );
+} else {
+	$wpdb->query( 'SET storage_engine = InnoDB' );
+}
 $wpdb->select( DB_NAME, $wpdb->dbh );
 
 // Drop GlotPress tables.


### PR DESCRIPTION
This system variable was removed in MySQL 5.7.5 as per https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_storage_engine

Resolves #531.
