### PR TITLE
471: Replace getMock() with getMockBuilder() for PHPUnit tests.

### DIFF
--- a/tests/phpunit/testcases/test_builtin_warnings.php
+++ b/tests/phpunit/testcases/test_builtin_warnings.php
@@ -51,7 +51,7 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 	}
 
 	function test_add_all() {
-		$warnings = $this->getMock( 'GP_Translation_Warnings' );
+		$warnings = $this->getMockBuilder('GP_Translation_Warnings')->getMock();
 		// we check for the number of warnings, because PHPUnit doesn't allow
 		// us to check if each argument is a callable
 		$warnings->expects( $this->exactly( 7 ) )->method( 'add' )->will( $this->returnValue( true ) );

--- a/tests/phpunit/testcases/test_template.php
+++ b/tests/phpunit/testcases/test_template.php
@@ -12,7 +12,7 @@ class GP_Test_Template_Functions extends GP_UnitTestCase {
 	}
 
 	function test_gp_breadcrumb_should_run_empty_string_through_filter_without_params() {
-		$filter = $this->getMock('Dummy', array('breadcrumb_filter'));
+		$filter = $this->getMockBuilder('stdClass')->setMethods(array('breadcrumb_filter'))->getMock();
 		$filter->expects( $this->once() )->method( 'breadcrumb_filter' )->with( $this->equalTo( array() ) );
 
 		add_filter( 'gp_breadcrumb_items', array( $filter, 'breadcrumb_filter') );

--- a/tests/phpunit/testcases/tests_formats/test_format_android.php
+++ b/tests/phpunit/testcases/tests_formats/test_format_android.php
@@ -50,7 +50,7 @@ class GP_Test_Format_Android extends GP_UnitTestCase {
 			list( $context, $original, $translation ) = $sample;
 			$stubbed_originals[] = new GP_Original( array( 'singular' => $original, 'context' => $context ) );
 		}
-		GP::$original = $this->getMock( 'GP_Original', array('by_project_id') );
+		GP::$original = $this->getMockBuilder( 'GP_Original' )->setMethods( array('by_project_id') )->getMock();
 		GP::$original->expects( $this->once() )
 					->method( 'by_project_id' )
 					->with( $this->equalTo(2) )

--- a/tests/phpunit/testcases/tests_formats/test_format_properties.php
+++ b/tests/phpunit/testcases/tests_formats/test_format_properties.php
@@ -63,7 +63,7 @@ class GP_Test_Format_Properties extends GP_UnitTestCase {
 			$stubbed_originals[] = new GP_Original( array( 'singular' => $original, 'context' => $context ) );
 		}
 
-		GP::$original = $this->getMock( 'GP_Original', array('by_project_id') );
+		GP::$original = $this->getMockBuilder( 'GP_Original' )->setMethods( array('by_project_id') )->getMock();
 		GP::$original->expects( $this->once() )
 					->method( 'by_project_id' )
 					->with( $this->equalTo(2) )

--- a/tests/phpunit/testcases/tests_formats/test_format_resx.php
+++ b/tests/phpunit/testcases/tests_formats/test_format_resx.php
@@ -51,7 +51,7 @@ class GP_Test_Format_ResX extends GP_UnitTestCase {
 			list( $context, $original, $translation ) = $sample;
 			$stubbed_originals[] = new GP_Original( array( 'singular' => $original, 'context' => $context ) );
 		}
-		GP::$original = $this->getMock( 'GP_Original', array('by_project_id') );
+		GP::$original = $this->getMockBuilder( 'GP_Original' )->setMethods( array('by_project_id') )->getMock();
 		GP::$original->expects( $this->once() )
 					->method( 'by_project_id' )
 					->with( $this->equalTo(2) )

--- a/tests/phpunit/testcases/tests_formats/test_format_strings.php
+++ b/tests/phpunit/testcases/tests_formats/test_format_strings.php
@@ -62,7 +62,7 @@ class GP_Test_Format_Strings extends GP_UnitTestCase {
 			$stubbed_originals[] = new GP_Original( array( 'singular' => $original, 'context' => $context ) );
 		}
 
-		GP::$original = $this->getMock( 'GP_Original', array('by_project_id') );
+		GP::$original = $this->getMockBuilder( 'GP_Original' )->setMethods( array('by_project_id') )->getMock();
 		GP::$original->expects( $this->once() )
 					->method( 'by_project_id' )
 					->with( $this->equalTo(2) )

--- a/tests/phpunit/testcases/tests_routes/test_route_translation_set.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_translation_set.php
@@ -59,7 +59,7 @@ class GP_Test_Route_Translation_Set extends GP_UnitTestCase_Route {
 
 	function test_new_post_error_redirect_if_create_was_unsuccessful() {
 		$this->set_admin_user_as_current();
-		GP::$translation_set = $this->getMock( 'GP_Translation_Set', array( 'create_and_select' ) );
+		GP::$translation_set = $this->getMockBuilder('GP_Translation_Set')->setMethods(array('create_and_select'))->getMock();
 		GP::$translation_set->expects( $this->any() )->method( 'create_and_select' );
 		$_POST['set'] = $this->factory->translation_set->generate_args();
 		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'add-translation-set' );
@@ -138,7 +138,7 @@ class GP_Test_Route_Translation_Set extends GP_UnitTestCase_Route {
 
 	function test_edit_post_error_redirect_if_create_was_unsuccessful() {
 		$this->set_admin_user_as_current();
-		GP::$translation_set = $this->getMock( 'GP_Translation_Set', array( 'update' ) );
+		GP::$translation_set = $this->getMockBuilder( 'GP_Translation_Set' )->setMethods( array( 'update' ) )->getMock();
 		$_POST['set'] = $this->factory->translation_set->generate_args();
 		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'edit-translation-set_' . $this->set->id );
 		$this->route->edit_post( $this->set->id );

--- a/tests/phpunit/testcases/tests_testlib/test_factory.php
+++ b/tests/phpunit/testcases/tests_testlib/test_factory.php
@@ -83,7 +83,7 @@ class GP_Test_Unittest_Factory extends GP_UnitTestCase {
 	}
 
 	function test_factory_for_thing_generate_args_should_use_generator() {
-		$generator_stub = $this->getMock( 'GP_UnitTest_Generator_Sequence' );
+		$generator_stub = $this->getMockBuilder( 'GP_UnitTest_Generator_Sequence' )->getMock();
 		$generator_stub->expects( $this->exactly( 2 ) )->method( 'next' )->will( $this->onConsecutiveCalls( 'name 1', 'name 2' ) );
 		$factory = $this->create_factory( array('name') );
 		$generation_defintions = array( 'name' =>  $generator_stub );
@@ -110,7 +110,7 @@ class GP_Test_Unittest_Factory extends GP_UnitTestCase {
 	}
 
 	private function create_thing_mock_with_name_field_and_with_create_which_should_be_called_once_with( $expected_create_args ) {
-		$thing = $this->getMock( 'GP_Thing_Test_Factory' );
+		$thing = $this->getMockBuilder( 'GP_Thing_Test_Factory' )->getMock();
 		$thing->field_names = array('name');
 		$thing->expects( $this->once() )->method( 'create' )->with( $this->equalTo( $expected_create_args ) );
 		return $thing;
@@ -129,9 +129,9 @@ class GP_Test_Unittest_Factory extends GP_UnitTestCase {
 	}
 
 	private function create_thing_stub_with_name_and_full_name_which_on_create_returns_mock_whose_save_should_be_called_with( $create_args, $expected_save_args ) {
-		$thing = $this->getMock( 'GP_Thing_Test_Factory' );
+		$thing = $this->getMockBuilder( 'GP_Thing_Test_Factory' )->getMock();
 		$thing->field_names = array('name', 'full_name');
-		$created_thing = $this->getMock( 'GP_Thing_Test_Factory' );
+		$created_thing = $this->getMockBuilder( 'GP_Thing_Test_Factory' )->getMock();
 		foreach( $create_args as $name => $value ) {
 			$created_thing->$name = $value;
 		}


### PR DESCRIPTION
Resolves #471.
and
Resolves #528.
