### PR TITLE
537: Adds the filters that allow the implementation of Cross-Locale PTEs

### DIFF
--- a/gp-includes/advanced-permissions.php
+++ b/gp-includes/advanced-permissions.php
@@ -29,6 +29,10 @@ function gp_recurse_validator_permission( $verdict, $args ) {
 
 
 function gp_route_translation_set_permissions_to_validator_permissions( $verdict, $args ) {
+	if ( is_bool( $verdict ) ) {
+		return $verdict;
+	}
+
 	if ( !( $verdict == 'no-verdict' && $args['action'] == 'approve' && $args['object_type'] == 'translation-set'
 			&& $args['object_id'] && $args['user'] ) ) {
 		return $verdict;
@@ -42,6 +46,10 @@ function gp_route_translation_set_permissions_to_validator_permissions( $verdict
 }
 
 function gp_allow_everyone_to_translate( $verdict, $args ) {
+	if ( is_bool( $verdict ) ) {
+		return $verdict;
+	}
+
 	if ( 'edit' == $args['action'] && 'translation-set' == $args['object_type'] ) {
 		return is_user_logged_in();
 	}
@@ -59,6 +67,10 @@ function gp_allow_everyone_to_translate( $verdict, $args ) {
  * @return string|bool New decision whether the user can do this.
  */
 function gp_allow_approving_translations_with_validator_permissions( $verdict, $args ) {
+	if ( is_bool( $verdict ) ) {
+		return $verdict;
+	}
+
 	if ( 'approve' === $args['action'] && 'translation' === $args['object_type'] ) {
 		$args['object_type'] = 'translation-set';
 

--- a/gp-includes/advanced-permissions.php
+++ b/gp-includes/advanced-permissions.php
@@ -62,8 +62,6 @@ function gp_allow_approve_translation_with_validator_permissions( $verdict, $arg
 
 		if ( isset( $args['extra']['translation']->translation_set_id ) ) {
 			$args['object_id'] = $args['extra']['translation']->translation_set_id;
-		} elseif ( isset( $args['extra']['set']->id ) ) {
-			$args['object_id'] = $args['extra']['set']->id;
 		} else {
 			return $verdict;
 		}

--- a/gp-includes/advanced-permissions.php
+++ b/gp-includes/advanced-permissions.php
@@ -49,7 +49,26 @@ function gp_allow_everyone_to_translate( $verdict, $args ) {
 	return $verdict;
 }
 
+function gp_allow_approve_translation_with_validator_permissions( $verdict, $args ) {
+	if ( 'approve' === $args['action'] && 'translation' === $args['object_type'] ) {
+		$args['object_type'] = 'translation-set';
+
+		if ( isset( $args['extra']['translation']->translation_set_id ) ) {
+			$args['object_id'] = $args['extra']['translation']->translation_set_id;
+		} elseif ( isset( $args['extra']['set']->id ) ) {
+			$args['object_id'] = $args['extra']['set']->id;
+		} else {
+			return $verdict;
+		}
+
+		return gp_route_translation_set_permissions_to_validator_permissions( $verdict, $args );
+	}
+
+	return $verdict;
+}
+
 add_filter( 'gp_can_user', 'gp_recurse_project_permissions', 10, 2 );
 add_filter( 'gp_can_user', 'gp_recurse_validator_permission', 10, 2 );
 add_filter( 'gp_pre_can_user', 'gp_route_translation_set_permissions_to_validator_permissions', 10, 2 );
 add_filter( 'gp_pre_can_user', 'gp_allow_everyone_to_translate', 10, 2 );
+add_filter( 'gp_pre_can_user', 'gp_allow_approve_translation_with_validator_permissions', 9, 2 );

--- a/gp-includes/advanced-permissions.php
+++ b/gp-includes/advanced-permissions.php
@@ -49,6 +49,13 @@ function gp_allow_everyone_to_translate( $verdict, $args ) {
 	return $verdict;
 }
 
+/**
+ * Map the translation check to the translation-set
+ *
+ * @param  string|bool $verdict Previous decision whether the user can do this.
+ * @param  array       $args Permission details.
+ * @return string|bool New decision whether the user can do this.
+ */
 function gp_allow_approve_translation_with_validator_permissions( $verdict, $args ) {
 	if ( 'approve' === $args['action'] && 'translation' === $args['object_type'] ) {
 		$args['object_type'] = 'translation-set';

--- a/gp-includes/advanced-permissions.php
+++ b/gp-includes/advanced-permissions.php
@@ -50,10 +50,12 @@ function gp_allow_everyone_to_translate( $verdict, $args ) {
 }
 
 /**
- * Map the translation check to the translation-set
+ * Maps the translation check to the translation-set.
  *
- * @param  string|bool $verdict Previous decision whether the user can do this.
- * @param  array       $args Permission details.
+ * @since 2.3.0
+ *
+ * @param string|bool $verdict Previous decision whether the user can do this.
+ * @param array       $args    Permission details.
  * @return string|bool New decision whether the user can do this.
  */
 function gp_allow_approving_translations_with_validator_permissions( $verdict, $args ) {

--- a/gp-includes/advanced-permissions.php
+++ b/gp-includes/advanced-permissions.php
@@ -56,7 +56,7 @@ function gp_allow_everyone_to_translate( $verdict, $args ) {
  * @param  array       $args Permission details.
  * @return string|bool New decision whether the user can do this.
  */
-function gp_allow_approve_translation_with_validator_permissions( $verdict, $args ) {
+function gp_allow_approving_translations_with_validator_permissions( $verdict, $args ) {
 	if ( 'approve' === $args['action'] && 'translation' === $args['object_type'] ) {
 		$args['object_type'] = 'translation-set';
 
@@ -76,4 +76,4 @@ add_filter( 'gp_can_user', 'gp_recurse_project_permissions', 10, 2 );
 add_filter( 'gp_can_user', 'gp_recurse_validator_permission', 10, 2 );
 add_filter( 'gp_pre_can_user', 'gp_route_translation_set_permissions_to_validator_permissions', 10, 2 );
 add_filter( 'gp_pre_can_user', 'gp_allow_everyone_to_translate', 10, 2 );
-add_filter( 'gp_pre_can_user', 'gp_allow_approve_translation_with_validator_permissions', 9, 2 );
+add_filter( 'gp_pre_can_user', 'gp_allow_approving_translations_with_validator_permissions', 9, 2 );

--- a/gp-includes/advanced-permissions.php
+++ b/gp-includes/advanced-permissions.php
@@ -89,5 +89,5 @@ function gp_allow_approving_translations_with_validator_permissions( $verdict, $
 add_filter( 'gp_can_user', 'gp_recurse_project_permissions', 10, 2 );
 add_filter( 'gp_can_user', 'gp_recurse_validator_permission', 10, 2 );
 add_filter( 'gp_pre_can_user', 'gp_route_translation_set_permissions_to_validator_permissions', 10, 2 );
+add_filter( 'gp_pre_can_user', 'gp_allow_approving_translations_with_validator_permissions', 10, 2 );
 add_filter( 'gp_pre_can_user', 'gp_allow_everyone_to_translate', 10, 2 );
-add_filter( 'gp_pre_can_user', 'gp_allow_approving_translations_with_validator_permissions', 9, 2 );

--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -97,8 +97,8 @@ class GP_Route {
 		return false;
 	}
 
-	public function can( $action, $object_type = null, $object_id = null ) {
-		return GP::$permission->current_user_can( $action, $object_type, $object_id );
+	public function can( $action, $object_type = null, $object_id = null, $extra = null ) {
+		return GP::$permission->current_user_can( $action, $object_type, $object_id, $extra );
 	}
 
 	/**
@@ -168,8 +168,8 @@ class GP_Route {
 	 *                                 Default: 'You are not allowed to do that!'.
 	 * @return false
 	 */
-	public function can_or_forbidden( $action, $object_type = null, $object_id = null, $message = 'You are not allowed to do that!' ) {
-		$can = $this->can( $action, $object_type, $object_id );
+	public function can_or_forbidden( $action, $object_type = null, $object_id = null, $extra = null, $message = 'You are not allowed to do that!' ) {
+		$can = $this->can( $action, $object_type, $object_id, $extra );
 		if ( !$can ) {
 			$this->die_with_error( $message, 403 );
 		}

--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -98,7 +98,9 @@ class GP_Route {
 	}
 
 	/**
-	 * Check whether a user is allowed to do an action.
+	 * Checks whether a user is allowed to do an action.
+	 *
+	 * @since 2.3.0 Parameter $extra added.
 	 *
 	 * @param string      $action      The action.
 	 * @param string|null $object_type Optional. Type of an object. Default null.
@@ -111,12 +113,13 @@ class GP_Route {
 	}
 
 	/**
-	 * If the current user isn't allowed to do an action, redirect and exit the current request
+	 * Redirects and exits if the current user isn't allowed to do an action.
 	 *
-	 * @param string $action
-	 * @param`string $object_type
-	 * @param string|array $object_id
-	 * @param string $url	The URL to redirect. Default value: referrer or index page, if referrer is missing
+	 * @param string      $action      The action.
+	 * @param string|null $object_type Optional. Type of an object. Default null.
+	 * @param int|null    $object_id   Optional. ID of an object. Default null.
+	 * @param string|null $url         Optional. URL to redirect to. Default: referrer or index page, if referrer is missing.
+	 * @return bool Whether a redirect happened.
 	 */
 	public function cannot_and_redirect( $action, $object_type = null, $object_id = null, $url = null ) {
 		$can = $this->can( $action, $object_type, $object_id );
@@ -180,7 +183,7 @@ class GP_Route {
 	 */
 	public function can_or_forbidden( $action, $object_type = null, $object_id = null, $message = null, $extra = null ) {
 		if ( ! isset( $message ) ) {
-			$message = 'You are not allowed to do that!';
+			$message = __( 'You are not allowed to do that!', 'glotpress' );
 		}
 		if ( ! $this->can( $action, $object_type, $object_id, $extra ) ) {
 			$this->die_with_error( $message, 403 );

--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -97,6 +97,15 @@ class GP_Route {
 		return false;
 	}
 
+	/**
+	 * Check whether a user is allowed to do an action.
+	 *
+	 * @param string      $action      The action.
+	 * @param string|null $object_type Optional. Type of an object. Default null.
+	 * @param int|null    $object_id   Optional. ID of an object. Default null.
+	 * @param array|null  $extra       Optional. Extra information for deciding the outcome.
+	 * @return bool       The verdict.
+	 */
 	public function can( $action, $object_type = null, $object_id = null, $extra = null ) {
 		return GP::$permission->current_user_can( $action, $object_type, $object_id, $extra );
 	}
@@ -163,18 +172,17 @@ class GP_Route {
 	 *
 	 * @param string      $action      The action.
 	 * @param string|null $object_type Optional. Type of an object. Default null.
-	 * @param int|null    $object_id   Otional. ID of an object Default null.
+	 * @param int|null    $object_id   Optional. ID of an object. Default null.
 	 * @param string|null $message     Error message in case of a failure.
 	 *                                 Default: 'You are not allowed to do that!'.
-	 * @param array|null  $extra       Pass-through parameter to can()
+	 * @param array|null  $extra       Pass-through parameter to can().
 	 * @return false
 	 */
 	public function can_or_forbidden( $action, $object_type = null, $object_id = null, $message = null, $extra = null ) {
 		if ( ! isset( $message ) ) {
 			$message = 'You are not allowed to do that!';
 		}
-		$can = $this->can( $action, $object_type, $object_id, $extra );
-		if ( !$can ) {
+		if ( ! $this->can( $action, $object_type, $object_id, $extra ) ) {
 			$this->die_with_error( $message, 403 );
 		}
 		return false;

--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -168,7 +168,10 @@ class GP_Route {
 	 *                                 Default: 'You are not allowed to do that!'.
 	 * @return false
 	 */
-	public function can_or_forbidden( $action, $object_type = null, $object_id = null, $extra = null, $message = 'You are not allowed to do that!' ) {
+	public function can_or_forbidden( $action, $object_type = null, $object_id = null, $message = null, $extra = null ) {
+		if ( ! isset( $message ) ) {
+			$message = 'You are not allowed to do that!';
+		}
 		$can = $this->can( $action, $object_type, $object_id, $extra );
 		if ( !$can ) {
 			$this->die_with_error( $message, 403 );

--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -164,8 +164,9 @@ class GP_Route {
 	 * @param string      $action      The action.
 	 * @param string|null $object_type Optional. Type of an object. Default null.
 	 * @param int|null    $object_id   Otional. ID of an object Default null.
-	 * @param string      $message     Error message in case of a failure.
+	 * @param string|null $message     Error message in case of a failure.
 	 *                                 Default: 'You are not allowed to do that!'.
+	 * @param array|null  $extra       Pass-through parameter to can()
 	 * @return false
 	 */
 	public function can_or_forbidden( $action, $object_type = null, $object_id = null, $message = null, $extra = null ) {

--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -100,7 +100,7 @@ class GP_Route {
 	/**
 	 * Checks whether a user is allowed to do an action.
 	 *
-	 * @since 2.3.0 Parameter $extra added.
+	 * @since 2.3.0 Added the `$extra` parameter.
 	 *
 	 * @param string      $action      The action.
 	 * @param string|null $object_type Optional. Type of an object. Default null.
@@ -115,6 +115,8 @@ class GP_Route {
 	/**
 	 * Redirects and exits if the current user isn't allowed to do an action.
 	 *
+	 * @since 1.0.0
+	 *
 	 * @param string      $action      The action.
 	 * @param string|null $object_type Optional. Type of an object. Default null.
 	 * @param int|null    $object_id   Optional. ID of an object. Default null.
@@ -123,7 +125,7 @@ class GP_Route {
 	 */
 	public function cannot_and_redirect( $action, $object_type = null, $object_id = null, $url = null ) {
 		$can = $this->can( $action, $object_type, $object_id );
-		if ( !$can ) {
+		if ( ! $can ) {
 			$this->redirect_with_error( __( 'You are not allowed to do that!', 'glotpress' ), $url );
 			return true;
 		}

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -315,10 +315,9 @@ class GP_Route_Translation extends GP_Route_Main {
 					$can_approve = $this->can( 'approve', 'translation-set', $translation_set->id );
 					$can_approve_translation = $this->can( 'approve', 'translation', $translation->id, array( 'translation' => $translation ) );
 
-					$output[$original_id] = gp_tmpl_get_output( 'translation-row', get_defined_vars() );
-				}
-				else {
-					$output[$original_id] = false;
+					$output[ $original_id ] = gp_tmpl_get_output( 'translation-row', get_defined_vars() );
+				} else {
+					$output[ $original_id ] = false;
 				}
 			}
 		}

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -320,7 +320,7 @@ class GP_Route_Translation extends GP_Route_Main {
 					$can_edit = $this->can( 'edit', 'translation-set', $translation_set->id );
 					$can_write = $this->can( 'write', 'project', $project->id );
 					$can_approve = $this->can( 'approve', 'translation-set', $translation_set->id );
-					$can_approve_translation = $this->can( 'approve', 'translation', $translation->id, array( 'translation' => $translation ) );
+					$can_approve_translation = $this->can( 'approve', 'translation', $t->id, array( 'translation' => $t ) );
 
 					$output[ $original_id ] = gp_tmpl_get_output( 'translation-row', get_defined_vars() );
 				} else {

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -266,7 +266,12 @@ class GP_Route_Translation extends GP_Route_Main {
 				}
 			}
 
-			$set_status = isset( $data['status'] ) ? $data['status'] : 'waiting';
+			if ( isset( $data['status'] ) ) {
+				$set_status = $data['status'];
+			} else {
+				$set_status = 'waiting';
+			}
+
 			$data['status'] = 'waiting';
 
 			if ( $this->can( 'approve', 'translation-set', $translation_set->id ) || $this->can( 'write', 'project', $project->id ) )

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -265,7 +265,8 @@ class GP_Route_Translation extends GP_Route_Main {
 					$data[ "translation_$i" ] = $translations[ $i ];
 				}
 			}
-			$set_status = $data['status'];
+
+			$set_status = isset( $data['status'] ) ? $data['status'] : 'waiting';
 			$data['status'] = 'waiting';
 
 			if ( $this->can( 'approve', 'translation-set', $translation_set->id ) || $this->can( 'write', 'project', $project->id ) )

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -312,7 +312,9 @@ class GP_Route_Translation extends GP_Route_Main {
 
 					$can_edit = $this->can( 'edit', 'translation-set', $translation_set->id );
 					$can_write = $this->can( 'write', 'project', $project->id );
-					$can_approve = $this->can( 'approve', 'translation-set', $translation_set->id ) && apply_filters( 'gp_current_user_can_set_translation_status', 'current', $t );
+					$can_approve = $this->can( 'approve', 'translation-set', $translation_set->id );
+					$can_approve_translation = $this->can( 'approve', 'translation', $translation->id, [ 'translation' => $translation ] );
+
 					$output[$original_id] = gp_tmpl_get_output( 'translation-row', get_defined_vars() );
 				}
 				else {
@@ -526,7 +528,9 @@ class GP_Route_Translation extends GP_Route_Main {
 
 			$can_edit = $this->can( 'edit', 'translation-set', $translation_set->id );
 			$can_write = $this->can( 'write', 'project', $project->id );
-			$can_approve = $this->can( 'approve', 'translation-set', $translation_set->id ) && apply_filters( 'gp_current_user_can_set_translation_status', 'current', $t );
+			$can_approve = $this->can( 'approve', 'translation-set', $translation_set->id );
+			$can_approve_translation = $this->can( 'approve', 'translation', $t->id, [ 'translation' => $t ] );
+
 			$this->tmpl( 'translation-row', get_defined_vars() );
 		} else {
 			return $this->die_with_error( 'Error in retrieving translation!' );
@@ -596,6 +600,6 @@ class GP_Route_Translation extends GP_Route_Main {
 		if ( $can_reject_self ) {
 			return;
 		}
-		$this->can_or_forbidden( 'approve', 'translation-set', $translation->translation_set_id );
+		$this->can_or_forbidden( 'approve', 'translation', $translation->id, [ 'translation' => $translation ] );
 	}
 }

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -600,6 +600,6 @@ class GP_Route_Translation extends GP_Route_Main {
 		if ( $can_reject_self ) {
 			return;
 		}
-		$this->can_or_forbidden( 'approve', 'translation', $translation->id, [ 'translation' => $translation ] );
+		$this->can_or_forbidden( 'approve', 'translation', $translation->id, null, [ 'translation' => $translation ] );
 	}
 }

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -265,11 +265,13 @@ class GP_Route_Translation extends GP_Route_Main {
 					$data[ "translation_$i" ] = $translations[ $i ];
 				}
 			}
+			$set_status = $data['status'];
+			$data['status'] = 'waiting';
 
 			if ( $this->can( 'approve', 'translation-set', $translation_set->id ) || $this->can( 'write', 'project', $project->id ) )
-				$data['status'] = 'current';
+				$set_status = 'current';
 			else
-				$data['status'] = 'waiting';
+				$set_status = 'waiting';
 
 			$original = GP::$original->get( $original_id );
 			$data['warnings'] = GP::$translation_warnings->check( $original->singular, $original->plural, $translations, $locale );
@@ -299,7 +301,7 @@ class GP_Route_Translation extends GP_Route_Main {
 				return $this->die_with_error( $error_output, 200 );
 			}
 			else {
-				if ( 'current' == $data['status'] ) {
+				if ( 'current' === $set_status ) {
 					$translation->set_status( 'current' );
 				}
 
@@ -310,7 +312,7 @@ class GP_Route_Translation extends GP_Route_Main {
 
 					$can_edit = $this->can( 'edit', 'translation-set', $translation_set->id );
 					$can_write = $this->can( 'write', 'project', $project->id );
-					$can_approve = $this->can( 'approve', 'translation-set', $translation_set->id );
+					$can_approve = $this->can( 'approve', 'translation-set', $translation_set->id ) && apply_filters( 'gp_current_user_can_set_translation_status', 'current', $t );
 					$output[$original_id] = gp_tmpl_get_output( 'translation-row', get_defined_vars() );
 				}
 				else {
@@ -524,7 +526,7 @@ class GP_Route_Translation extends GP_Route_Main {
 
 			$can_edit = $this->can( 'edit', 'translation-set', $translation_set->id );
 			$can_write = $this->can( 'write', 'project', $project->id );
-			$can_approve = $this->can( 'approve', 'translation-set', $translation_set->id );
+			$can_approve = $this->can( 'approve', 'translation-set', $translation_set->id ) && apply_filters( 'gp_current_user_can_set_translation_status', 'current', $t );
 			$this->tmpl( 'translation-row', get_defined_vars() );
 		} else {
 			return $this->die_with_error( 'Error in retrieving translation!' );

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -274,10 +274,11 @@ class GP_Route_Translation extends GP_Route_Main {
 
 			$data['status'] = 'waiting';
 
-			if ( $this->can( 'approve', 'translation-set', $translation_set->id ) || $this->can( 'write', 'project', $project->id ) )
+			if ( $this->can( 'approve', 'translation-set', $translation_set->id ) || $this->can( 'write', 'project', $project->id ) ) {
 				$set_status = 'current';
-			else
+			} else {
 				$set_status = 'waiting';
+			}
 
 			$original = GP::$original->get( $original_id );
 			$data['warnings'] = GP::$translation_warnings->check( $original->singular, $original->plural, $translations, $locale );

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -313,7 +313,7 @@ class GP_Route_Translation extends GP_Route_Main {
 					$can_edit = $this->can( 'edit', 'translation-set', $translation_set->id );
 					$can_write = $this->can( 'write', 'project', $project->id );
 					$can_approve = $this->can( 'approve', 'translation-set', $translation_set->id );
-					$can_approve_translation = $this->can( 'approve', 'translation', $translation->id, [ 'translation' => $translation ] );
+					$can_approve_translation = $this->can( 'approve', 'translation', $translation->id, array( 'translation' => $translation ) );
 
 					$output[$original_id] = gp_tmpl_get_output( 'translation-row', get_defined_vars() );
 				}
@@ -529,7 +529,7 @@ class GP_Route_Translation extends GP_Route_Main {
 			$can_edit = $this->can( 'edit', 'translation-set', $translation_set->id );
 			$can_write = $this->can( 'write', 'project', $project->id );
 			$can_approve = $this->can( 'approve', 'translation-set', $translation_set->id );
-			$can_approve_translation = $this->can( 'approve', 'translation', $t->id, [ 'translation' => $t ] );
+			$can_approve_translation = $this->can( 'approve', 'translation', $t->id, array( 'translation' => $t ) );
 
 			$this->tmpl( 'translation-row', get_defined_vars() );
 		} else {
@@ -600,6 +600,6 @@ class GP_Route_Translation extends GP_Route_Main {
 		if ( $can_reject_self ) {
 			return;
 		}
-		$this->can_or_forbidden( 'approve', 'translation', $translation->id, null, [ 'translation' => $translation ] );
+		$this->can_or_forbidden( 'approve', 'translation', $translation->id, null, array( 'translation' => $translation ) );
 	}
 }

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -255,11 +255,11 @@ class GP_Translation_Set extends GP_Thing {
 			/**
 			 * Filter the the status of imported translations of a translation set.
 			 *
-			 * @since 2.2.0
+			 * @since 2.3.0
 			 *
 			 * @param string $status The status of imported translations.
-			 * @param Translation_Entry $entry  Translation entry object to import.
-			 * @param GP_Translation|false $translated The previous translation.
+			 * @param Translation_Entry $new_translation Translation entry object to import.
+			 * @param GP_Translation|false $old_translation The previous translation.
 			 */
 			$entry->status = apply_filters( 'gp_translation_set_import_status', $is_fuzzy ? 'fuzzy' : $desired_status, $entry, false );
 
@@ -316,11 +316,11 @@ class GP_Translation_Set extends GP_Thing {
 				/**
 				 * Filter the the status of imported translations of a translation set.
 				 *
-				 * @since 2.2.0
+				 * @since 2.3.0
 				 *
 				 * @param string $status The status of imported translations.
-				 * @param Translation_Entry $entry  Translation entry object to import.
-				 * @param GP_Translation|false $translated The previous translation.
+				 * @param Translation_Entry $new_translation Translation entry object to import.
+				 * @param GP_Translation|false $old_translation The previous translation.
 				 */
 				$entry->status = apply_filters( 'gp_translation_set_import_status', $entry->status, $entry, $translated );
 				// Check for errors.

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -253,16 +253,16 @@ class GP_Translation_Set extends GP_Thing {
 			}
 
 			/**
-			 * Filter the the status of imported translations of a translation set.
+			 * Filters the the status of imported translations of a translation set.
 			 *
 			 * @since 1.0.0
-			 * @since 2.3.0 Added the `$new_translation` and `$old_translation` parameters.
+			 * @since 2.3.0 Added `$new_translation` and `$old_translation` parameters.
 			 *
-			 * @param string $status The status of imported translations.
-			 * @param Translation_Entry $new_translation Translation entry object to import.
-			 * @param GP_Translation|false $old_translation The previous translation.
+			 * @param string              $status          The status of imported translations.
+			 * @param Translation_Entry   $new_translation Translation entry object to import.
+			 * @param GP_Translation|null $old_translation The previous translation.
 			 */
-			$entry->status = apply_filters( 'gp_translation_set_import_status', $is_fuzzy ? 'fuzzy' : $desired_status, $entry, false );
+			$entry->status = apply_filters( 'gp_translation_set_import_status', $is_fuzzy ? 'fuzzy' : $desired_status, $entry, null );
 
 			$entry->warnings = maybe_unserialize( GP::$translation_warnings->check( $entry->singular, $entry->plural, $entry->translations, $locale ) );
 			if ( ! empty( $entry->warnings ) ) {
@@ -314,16 +314,6 @@ class GP_Translation_Set extends GP_Thing {
 
 				$entry->translation_set_id = $this->id;
 
-				/**
-				 * Filter the the status of imported translations of a translation set.
-				 *
-				 * @since 1.0.0
-				 * @since 2.3.0 Added the `$new_translation` and `$old_translation` parameters.
-				 *
-				 * @param string $status The status of imported translations.
-				 * @param Translation_Entry $new_translation Translation entry object to import.
-				 * @param GP_Translation|false $old_translation The previous translation.
-				 */
 				$entry->status = apply_filters( 'gp_translation_set_import_status', $entry->status, $entry, $translated );
 				// Check for errors.
 				$translation = GP::$translation->create( $entry );

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -255,11 +255,13 @@ class GP_Translation_Set extends GP_Thing {
 			/**
 			 * Filter the the status of imported translations of a translation set.
 			 *
-			 * @since 1.0.0
+			 * @since 2.2.0
 			 *
 			 * @param string $status The status of imported translations.
+			 * @param Translation_Entry $entry  Translation entry object to import.
+			 * @param GP_Translation|false $translated The previous translation.
 			 */
-			$entry->status = apply_filters( 'gp_translation_set_import_status', $is_fuzzy ? 'fuzzy' : $desired_status );
+			$entry->status = apply_filters( 'gp_translation_set_import_status', $is_fuzzy ? 'fuzzy' : $desired_status, $entry, false );
 
 			$entry->warnings = maybe_unserialize( GP::$translation_warnings->check( $entry->singular, $entry->plural, $entry->translations, $locale ) );
 			if ( ! empty( $entry->warnings ) ) {
@@ -314,13 +316,13 @@ class GP_Translation_Set extends GP_Thing {
 				/**
 				 * Filter the the status of imported translations of a translation set.
 				 *
-				 * @since 1.0.0
+				 * @since 2.2.0
 				 *
-				 * @param string            $status The status of imported translations.
+				 * @param string $status The status of imported translations.
 				 * @param Translation_Entry $entry  Translation entry object to import.
+				 * @param GP_Translation|false $translated The previous translation.
 				 */
-				$entry->status = apply_filters( 'gp_translation_set_import_status', $entry->status, $entry );
-
+				$entry->status = apply_filters( 'gp_translation_set_import_status', $entry->status, $entry, $translated );
 				// Check for errors.
 				$translation = GP::$translation->create( $entry );
 				if ( is_object( $translation ) ) {

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -254,8 +254,9 @@ class GP_Translation_Set extends GP_Thing {
 
 			/**
 			 * Filter the the status of imported translations of a translation set.
+			 * Parameters $new_translation and $old_translation since 2.3.0.
 			 *
-			 * @since 2.3.0
+			 * @since 1.0.0
 			 *
 			 * @param string $status The status of imported translations.
 			 * @param Translation_Entry $new_translation Translation entry object to import.
@@ -315,8 +316,9 @@ class GP_Translation_Set extends GP_Thing {
 
 				/**
 				 * Filter the the status of imported translations of a translation set.
+				 * Parameters $new_translation and $old_translation since 2.3.0.
 				 *
-				 * @since 2.3.0
+				 * @since 1.0.0
 				 *
 				 * @param string $status The status of imported translations.
 				 * @param Translation_Entry $new_translation Translation entry object to import.

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -254,9 +254,9 @@ class GP_Translation_Set extends GP_Thing {
 
 			/**
 			 * Filter the the status of imported translations of a translation set.
-			 * Parameters $new_translation and $old_translation since 2.3.0.
 			 *
 			 * @since 1.0.0
+			 * @since 2.3.0 Added the `$new_translation` and `$old_translation` parameters.
 			 *
 			 * @param string $status The status of imported translations.
 			 * @param Translation_Entry $new_translation Translation entry object to import.
@@ -316,9 +316,9 @@ class GP_Translation_Set extends GP_Thing {
 
 				/**
 				 * Filter the the status of imported translations of a translation set.
-				 * Parameters $new_translation and $old_translation since 2.3.0.
 				 *
 				 * @since 1.0.0
+				 * @since 2.3.0 Added the `$new_translation` and `$old_translation` parameters.
 				 *
 				 * @param string $status The status of imported translations.
 				 * @param Translation_Entry $new_translation Translation entry object to import.

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -559,7 +559,7 @@ class GP_Translation extends GP_Thing {
 	}
 
 	public function set_status( $status ) {
-		if ( ( 'current' === $status || 'rejected' === $status ) && ! GP::$permission->current_user_can( 'approve', 'translation', $this->id, [ 'translation' => $this ] ) ) {
+		if ( ( 'current' === $status || 'rejected' === $status ) && ! GP::$permission->current_user_can( 'approve', 'translation', $this->id, array( 'translation' => $this ) ) ) {
 			return false;
 		}
 		if ( 'current' === $status ) {

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -568,7 +568,7 @@ class GP_Translation extends GP_Thing {
 	 */
 	public function can_set_status( $desired_status ) {
 		/**
-		 * Filter the decision whether a translation can be set to a status.
+		 * Filters the decision whether a translation can be set to a status.
 		 *
 		 * @since 2.3.0
 		 *
@@ -596,7 +596,7 @@ class GP_Translation extends GP_Thing {
 		}
 
 		/**
-		 * Filter the decision whether a translation can be set to a status.
+		 * Filters the decision whether a translation can be set to a status.
 		 *
 		 * @since 2.3.0
 		 *

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -558,12 +558,18 @@ class GP_Translation extends GP_Thing {
 		$this->set_status( 'rejected' );
 	}
 
-	public function can_set_status( $status ) {
-		if ( 'rejected' === $status && get_current_user_id() == $this->user_id ) {
+	/**
+	 * Decides whether the status of a translation can be changed to $desired_status.
+	 *
+	 * @param  string $desired_status The desired status.
+	 * @return bool Whether the status can be set.
+	 */
+	public function can_set_status( $desired_status ) {
+		if ( 'rejected' === $desired_status && get_current_user_id() === intval( $this->user_id ) ) {
 			return true;
 		}
 
-		if ( 'current' === $status || 'rejected' === $status ) {
+		if ( 'current' === $desired_status || 'rejected' === $desired_status ) {
 			if ( ! GP::$permission->current_user_can( 'approve', 'translation', $this->id, array( 'translation' => $this ) ) ) {
 				return false;
 			}
@@ -572,6 +578,11 @@ class GP_Translation extends GP_Thing {
 		return true;
 	}
 
+	/**
+	 * Changes the status of a translation if possible.
+	 *
+	 * @param string $status The status to be set.
+	 */
 	public function set_status( $status ) {
 		if ( ! $this->can_set_status( $status ) ) {
 			return false;

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -565,17 +565,46 @@ class GP_Translation extends GP_Thing {
 	 * @return bool Whether the status can be set.
 	 */
 	public function can_set_status( $desired_status ) {
-		if ( 'rejected' === $desired_status && get_current_user_id() === intval( $this->user_id ) ) {
-			return true;
+		/**
+		 * Filter the decision whether a translation can be set to a status.
+		 *
+		 * @since 2.3
+		 *
+		 * @param string|bool    $can_set_status Whether the user can set the desired status.
+		 * @param GP_Translation $translation    The translation to decide this for.
+		 * @param string         $desired_status The desired status.
+		 */
+		$can_set_status = apply_filters( 'gp_pre_can_set_translation_status', 'no-verdict', $this, $desired_status );
+		if ( is_bool( $can_set_status ) ) {
+			return $can_set_status;
 		}
 
-		if ( 'current' === $desired_status || 'rejected' === $desired_status ) {
+		if ( ! is_bool( $can_set_status ) && 'rejected' === $desired_status && get_current_user_id() === intval( $this->user_id ) ) {
+			$can_set_status = true;
+		}
+
+		if ( ! is_bool( $can_set_status ) & ( 'current' === $desired_status || 'rejected' === $desired_status ) ) {
 			if ( ! GP::$permission->current_user_can( 'approve', 'translation', $this->id, array( 'translation' => $this ) ) ) {
-				return false;
+				$can_set_status = false;
 			}
 		}
 
-		return true;
+		if ( ! is_bool( $can_set_status ) ) {
+			$can_set_status = true;
+		}
+
+		/**
+		 * Filter the decision whether a translation can be set to a status.
+		 *
+		 * @since 2.3
+		 *
+		 * @param bool           $can_set_status Whether the user can set the desired status.
+		 * @param GP_Translation $translation    The translation to decide this for.
+		 * @param string         $desired_status The desired status.
+		 */
+		$can_set_status = apply_filters( 'gp_can_set_translation_status', $can_set_status, $this, $desired_status );
+
+		return $can_set_status;
 	}
 
 	/**

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -559,7 +559,18 @@ class GP_Translation extends GP_Thing {
 	}
 
 	public function set_status( $status ) {
-		if ( 'current' == $status ) {
+		/**
+		 * Allows overriding whether the current user can set a translation to a status.
+		 *
+		 * @since 2.2.0
+		 *
+		 * @param string $status The status the translation is to be set to.
+		 * @param GP_Translation $translated The translation in question.
+		 */
+		if ( ! apply_filters( 'gp_current_user_can_set_translation_status', $status, $this ) ) {
+			return false;
+		}
+		if ( 'current' === $status ) {
 			$updated = $this->set_as_current();
 		} else {
 			$updated = $this->save( array( 'user_id_last_modified' => get_current_user_id(), 'status' => $status ) );

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -559,15 +559,7 @@ class GP_Translation extends GP_Thing {
 	}
 
 	public function set_status( $status ) {
-		/**
-		 * Allows overriding whether the current user can set a translation to a status.
-		 *
-		 * @since 2.2.0
-		 *
-		 * @param string $status The status the translation is to be set to.
-		 * @param GP_Translation $translated The translation in question.
-		 */
-		if ( ! apply_filters( 'gp_current_user_can_set_translation_status', $status, $this ) ) {
+		if ( ( 'current' === $status || 'rejected' === $status ) && ! GP::$permission->current_user_can( 'approve', 'translation', $this->id, [ 'translation' => $this ] ) ) {
 			return false;
 		}
 		if ( 'current' === $status ) {

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -558,10 +558,25 @@ class GP_Translation extends GP_Thing {
 		$this->set_status( 'rejected' );
 	}
 
+	public function can_set_status( $status ) {
+		if ( 'rejected' === $status && get_current_user_id() == $this->user_id ) {
+			return true;
+		}
+
+		if ( 'current' === $status || 'rejected' === $status ) {
+			if ( ! GP::$permission->current_user_can( 'approve', 'translation', $this->id, array( 'translation' => $this ) ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 	public function set_status( $status ) {
-		if ( ( 'current' === $status || 'rejected' === $status ) && ! GP::$permission->current_user_can( 'approve', 'translation', $this->id, array( 'translation' => $this ) ) ) {
+		if ( ! $this->can_set_status( $status ) ) {
 			return false;
 		}
+
 		if ( 'current' === $status ) {
 			$updated = $this->set_as_current();
 		} else {

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -559,16 +559,18 @@ class GP_Translation extends GP_Thing {
 	}
 
 	/**
-	 * Decides whether the status of a translation can be changed to $desired_status.
+	 * Decides whether the status of a translation can be changed to a desired status.
 	 *
-	 * @param  string $desired_status The desired status.
+	 * @since 2.3.0
+	 *
+	 * @param string $desired_status The desired status.
 	 * @return bool Whether the status can be set.
 	 */
 	public function can_set_status( $desired_status ) {
 		/**
 		 * Filter the decision whether a translation can be set to a status.
 		 *
-		 * @since 2.3
+		 * @since 2.3.0
 		 *
 		 * @param string|bool    $can_set_status Whether the user can set the desired status.
 		 * @param GP_Translation $translation    The translation to decide this for.
@@ -579,11 +581,11 @@ class GP_Translation extends GP_Thing {
 			return $can_set_status;
 		}
 
-		if ( ! is_bool( $can_set_status ) && 'rejected' === $desired_status && get_current_user_id() === intval( $this->user_id ) ) {
+		if ( ! is_bool( $can_set_status ) && 'rejected' === $desired_status && get_current_user_id() === (int) $this->user_id ) {
 			$can_set_status = true;
 		}
 
-		if ( ! is_bool( $can_set_status ) & ( 'current' === $desired_status || 'rejected' === $desired_status ) ) {
+		if ( ! is_bool( $can_set_status ) && ( 'current' === $desired_status || 'rejected' === $desired_status ) ) {
 			if ( ! GP::$permission->current_user_can( 'approve', 'translation', $this->id, array( 'translation' => $this ) ) ) {
 				$can_set_status = false;
 			}
@@ -596,7 +598,7 @@ class GP_Translation extends GP_Thing {
 		/**
 		 * Filter the decision whether a translation can be set to a status.
 		 *
-		 * @since 2.3
+		 * @since 2.3.0
 		 *
 		 * @param bool           $can_set_status Whether the user can set the desired status.
 		 * @param GP_Translation $translation    The translation to decide this for.
@@ -610,7 +612,10 @@ class GP_Translation extends GP_Thing {
 	/**
 	 * Changes the status of a translation if possible.
 	 *
+	 * @since 2.3.0
+	 *
 	 * @param string $status The status to be set.
+	 * @return bool Whether the setting of status was successful.
 	 */
 	public function set_status( $status ) {
 		if ( ! $this->can_set_status( $status ) ) {

--- a/gp-templates/translation-row.php
+++ b/gp-templates/translation-row.php
@@ -43,8 +43,11 @@ $more_links = apply_filters( 'gp_translation_row_template_more_links', $more_lin
 ?>
 
 <tr class="preview <?php gp_translation_row_classes( $t ); ?>" id="preview-<?php echo esc_attr( $t->row_id ) ?>" row="<?php echo esc_attr( $t->row_id ); ?>">
-	<?php if ( $can_approve ) : ?><th scope="row" class="checkbox"><input type="checkbox" name="selected-row[]" /></th><?php endif; ?>
-	<?php if ( isset( $can_approve_translation_set ) && ! $can_approve && $can_approve_translation_set ) : ?><th scope="row"></th><?php endif; ?>
+	<?php if ( $can_approve_translation ) : ?>
+		<th scope="row" class="checkbox"><input type="checkbox" name="selected-row[]" /></th>
+	<?php elseif ( $can_approve ) : ?>
+		<th scope="row"></th>
+	<?php endif; ?>
 	<?php /*
 	<td class="priority" style="background-color: <?php echo $priority_char[$t->priority][1] ?>; color: <?php echo $priority_char[$t->priority][2] ?>; text-align: center; font-size: 1.2em;" title="<?php echo esc_attr('Priority: '.gp_array_get( GP::$original->get_static( 'priorities' ), $t->priority )); ?>">
 	*/ ?>
@@ -103,7 +106,7 @@ $more_links = apply_filters( 'gp_translation_row_template_more_links', $more_lin
 
 		<?php if ( ! $t->plural ): ?>
 		<p class="original"><?php echo prepare_original( $singular ); ?></p>
-		<?php textareas( $t, array( $can_edit, $can_approve ) ); ?>
+		<?php textareas( $t, array( $can_edit, $can_approve_translation ) ); ?>
 		<?php else: ?>
 			<?php if ( $locale->nplurals == 2 && $locale->plural_expression == 'n != 1'): ?>
 				<p><?php printf(__( 'Singular: %s', 'glotpress' ), '<span class="original">'. $singular .'</span>'); ?></p>
@@ -138,7 +141,7 @@ $more_links = apply_filters( 'gp_translation_row_template_more_links', $more_lin
 				<dd>
 					<?php echo display_status( $t->translation_status ); ?>
 					<?php if ( $t->translation_status ): ?>
-						<?php if ( $can_approve ): ?>
+						<?php if ( $can_approve_translation ): ?>
 							<?php if ( $t->translation_status != 'current' ): ?>
 							<button class="approve" tabindex="-1" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-current_' . $t->id ) ); ?>"><strong>+</strong> <?php _e( 'Approve', 'glotpress' ); ?></button>
 							<?php endif; ?>
@@ -232,7 +235,7 @@ $more_links = apply_filters( 'gp_translation_row_template_more_links', $more_lin
 		<div class="actions">
 		<?php if ( $can_edit ): ?>
 			<button class="ok" data-nonce="<?php echo esc_attr( wp_create_nonce( 'add-translation_' . $t->original_id ) ); ?>">
-				<?php echo $can_approve? __( 'Add translation &rarr;', 'glotpress' ) : __( 'Suggest new translation &rarr;', 'glotpress' ); ?>
+				<?php echo $can_approve_translation ? __( 'Add translation &rarr;', 'glotpress' ) : __( 'Suggest new translation &rarr;', 'glotpress' ); ?>
 			</button>
 		<?php endif; ?>
 			<?php _e( 'or', 'glotpress' ); ?> <a href="#" class="close"><?php _e( 'Cancel', 'glotpress' ); ?></a>

--- a/gp-templates/translation-row.php
+++ b/gp-templates/translation-row.php
@@ -44,6 +44,7 @@ $more_links = apply_filters( 'gp_translation_row_template_more_links', $more_lin
 
 <tr class="preview <?php gp_translation_row_classes( $t ); ?>" id="preview-<?php echo esc_attr( $t->row_id ) ?>" row="<?php echo esc_attr( $t->row_id ); ?>">
 	<?php if ( $can_approve ) : ?><th scope="row" class="checkbox"><input type="checkbox" name="selected-row[]" /></th><?php endif; ?>
+	<?php if ( isset( $can_approve_translation_set ) && ! $can_approve && $can_approve_translation_set ) : ?><th scope="row"></th><?php endif; ?>
 	<?php /*
 	<td class="priority" style="background-color: <?php echo $priority_char[$t->priority][1] ?>; color: <?php echo $priority_char[$t->priority][2] ?>; text-align: center; font-size: 1.2em;" title="<?php echo esc_attr('Priority: '.gp_array_get( GP::$original->get_static( 'priorities' ), $t->priority )); ?>">
 	*/ ?>

--- a/gp-templates/translation-row.php
+++ b/gp-templates/translation-row.php
@@ -48,9 +48,6 @@ $more_links = apply_filters( 'gp_translation_row_template_more_links', $more_lin
 	<?php elseif ( $can_approve ) : ?>
 		<th scope="row"></th>
 	<?php endif; ?>
-	<?php /*
-	<td class="priority" style="background-color: <?php echo $priority_char[$t->priority][1] ?>; color: <?php echo $priority_char[$t->priority][2] ?>; text-align: center; font-size: 1.2em;" title="<?php echo esc_attr('Priority: '.gp_array_get( GP::$original->get_static( 'priorities' ), $t->priority )); ?>">
-	*/ ?>
 	<td class="priority" title="<?php echo esc_attr( sprintf( __( 'Priority: %s', 'glotpress' ), gp_array_get( GP::$original->get_static( 'priorities' ), $t->priority ) ) ); ?>">
 	   <?php echo $priority_char[$t->priority][0] ?>
 	</td>
@@ -141,7 +138,7 @@ $more_links = apply_filters( 'gp_translation_row_template_more_links', $more_lin
 				<dd>
 					<?php echo display_status( $t->translation_status ); ?>
 					<?php if ( $t->translation_status ): ?>
-						<?php if ( $can_approve_translation ): ?>
+						<?php if ( $can_approve_translation ) : ?>
 							<?php if ( $t->translation_status != 'current' ): ?>
 							<button class="approve" tabindex="-1" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-current_' . $t->id ) ); ?>"><strong>+</strong> <?php _e( 'Approve', 'glotpress' ); ?></button>
 							<?php endif; ?>

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -200,7 +200,7 @@ $i = 0;
 ?>
 <?php foreach( $translations as $t ):
 		$t->translation_set_id = $translation_set->id;
-		$can_approve_translation = GP::$permission->current_user_can( 'approve', 'translation', $t->id, [ 'translation' => $t ] );
+		$can_approve_translation = GP::$permission->current_user_can( 'approve', 'translation', $t->id, array( 'translation' => $t ) );
 		gp_tmpl_load( 'translation-row', get_defined_vars() );
 ?>
 <?php endforeach; ?>

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -197,15 +197,14 @@ $i = 0;
 	if ( $glossary ) {
 		$translations = map_glossary_entries_to_translations_originals( $translations, $glossary );
 	}
-	$can_approve_translation_set = $can_approve;
 ?>
 <?php foreach( $translations as $t ):
-		$can_approve = $can_approve_translation_set && apply_filters( 'gp_current_user_can_set_translation_status', 'current', $t );
+		$t->translation_set_id = $translation_set->id;
+		$can_approve_translation = GP::$permission->current_user_can( 'approve', 'translation', $t->id, [ 'translation' => $t ] );
 		gp_tmpl_load( 'translation-row', get_defined_vars() );
 ?>
 <?php endforeach; ?>
 <?php
-	$can_approve = $can_approve_translation_set;
 	if ( !$translations ):
 ?>
 	<tr><td colspan="<?php echo $can_approve ? 5 : 4; ?>"><?php _e( 'No translations were found!', 'glotpress' ); ?></td></tr>

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -197,12 +197,15 @@ $i = 0;
 	if ( $glossary ) {
 		$translations = map_glossary_entries_to_translations_originals( $translations, $glossary );
 	}
+	$can_approve_translation_set = $can_approve;
 ?>
 <?php foreach( $translations as $t ):
+		$can_approve = $can_approve_translation_set && apply_filters( 'gp_current_user_can_set_translation_status', 'current', $t );
 		gp_tmpl_load( 'translation-row', get_defined_vars() );
 ?>
 <?php endforeach; ?>
 <?php
+	$can_approve = $can_approve_translation_set;
 	if ( !$translations ):
 ?>
 	<tr><td colspan="<?php echo $can_approve ? 5 : 4; ?>"><?php _e( 'No translations were found!', 'glotpress' ); ?></td></tr>

--- a/tests/phpunit/testcases/test_import.php
+++ b/tests/phpunit/testcases/test_import.php
@@ -6,7 +6,13 @@ class GP_Import extends GP_UnitTestCase {
 	 * @ticket gh-377
 	 */
 	private function _verify_multiple_imports( $originals, $runs ) {
+		$object_type = GP::$validator_permission->object_type;
+		$user = $this->factory->user->create();
+		wp_set_current_user( $user );
+
 		$set = $this->factory->translation_set->create_with_project_and_locale();
+		GP::$validator_permission->create( array( 'user_id' => $user, 'action' => 'approve',
+		                                          'project_id' => $set->project_id, 'locale_slug' => $set->locale, 'set_slug' => $set->slug ) );
 
 		if ( isset( $originals['singular'] ) ) {
 			$originals = array( $originals );

--- a/tests/phpunit/testcases/tests_things/test_thing_translation_set.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_translation_set.php
@@ -151,6 +151,29 @@ class GP_Test_Thing_Translation_set extends GP_UnitTestCase {
 		$this->assertEquals( $translations_added, 0 );
 	}
 
+	function test_user_can_reject_his_own_translation() {
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$original = $this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => 'A string' ) );
+		$translation = $this->factory->translation->create( array( 'translation_set_id' => $set->id, 'original_id' => $original->id, 'translations' => array( 'baba' ), 'status' => 'current' ) );
+
+		$this->assertFalse( $translation->set_status( 'current' ) );
+		$this->assertTrue( $translation->set_status( 'rejected' ) );
+		$this->assertTrue( $translation->set_status( 'waiting' ) );
+		$this->assertFalse( $translation->set_status( 'current' ) );
+
+		$translation = $this->factory->translation->create( array( 'translation_set_id' => $set->id, 'original_id' => $original->id, 'translations' => array( 'baba2' ), 'status' => 'rejected' ) );
+
+		$this->assertFalse( $translation->set_status( 'current' ) );
+		$this->assertTrue( $translation->set_status( 'rejected' ) );
+		$this->assertFalse( $translation->set_status( 'current' ) );
+
+		$translation = $this->factory->translation->create( array( 'translation_set_id' => $set->id, 'original_id' => $original->id, 'translations' => array( 'baba3' ), 'status' => 'waiting' ) );
+
+		$this->assertFalse( $translation->set_status( 'current' ) );
+		$this->assertTrue( $translation->set_status( 'rejected' ) );
+		$this->assertFalse( $translation->set_status( 'current' ) );
+	}
+
 	/**
 	 * @ticket 512
 	 */


### PR DESCRIPTION
This PR makes the following changes to allow #537:
- ~~add the old translation as an argument to `gp_translation_set_import_status`~~
- ~~adds a new filter `gp_current_user_can_set_translation_status`~~
- ~~adds calls to `gp_current_user_can_set_translation_status` when displaying UI for approving/rejecting translations~~

Edit: see changed implementation [below](https://github.com/GlotPress/GlotPress-WP/pull/538#issuecomment-247592600).

The wish to selectively allow overwriting of translations depending on who created the translations created the need for `gp_current_user_can_set_translation_status` and can result in a UI where not all rows have checkboxes available for bulk editing:

![screen shot 2016-09-09 at 13 03 53](https://cloud.githubusercontent.com/assets/203408/18384946/e5e9e310-768d-11e6-943b-c95169a80a9e.png)

For testing, I am providing an [example implementation that uses the hooks for Cross-PTE](https://gist.github.com/akirk/ca2d5e6fe1b9a91e77290dfb31541cd0). This assumes that a permission `cross-pte` has been created with the user with object_type = project and object_id = project id.
