### PR TITLE
Change Tibetan locale name from བོད་སྐད to བོད་ཡིག

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -340,7 +340,7 @@ class GP_Locales {
 
 		$bo = new GP_Locale();
 		$bo->english_name = 'Tibetan';
-		$bo->native_name = 'བོད་སྐད';
+		$bo->native_name = 'བོད་ཡིག';
 		$bo->lang_code_iso_639_1 = 'bo';
 		$bo->lang_code_iso_639_2 = 'tib';
 		$bo->wp_locale = 'bo';


### PR DESCRIPTION
As per a request of the General Translation Editors for Tibetan, chaning the original name here as well.
https://make.wordpress.org/polyglots/2016/09/05/please-help-us-change-our-tibetan-locale-name/
