### PR TITLE
543: translation-set-form template requires jQuery.

### DIFF
--- a/gp-templates/translation-set-edit.php
+++ b/gp-templates/translation-set-edit.php
@@ -4,6 +4,10 @@ gp_breadcrumb( array(
 	gp_project_links_from_root( $project ),
 	gp_link_get( $url, $locale->english_name . 'default' != $set->slug? ' '.$set->name : '' ),
 ) );
+
+// jQuery is required for the 'translation-set-form' template.
+gp_enqueue_scripts( array( 'jquery' ) );
+
 gp_tmpl_header();
 ?>
 <h2><?php _e( 'Edit Translation Set', 'glotpress' ); ?></h2>

--- a/gp-templates/translation-set-edit.php
+++ b/gp-templates/translation-set-edit.php
@@ -6,7 +6,7 @@ gp_breadcrumb( array(
 ) );
 
 // jQuery is required for the 'translation-set-form' template.
-gp_enqueue_scripts( array( 'jquery' ) );
+gp_enqueue_script( 'jquery' );
 
 gp_tmpl_header();
 ?>

--- a/gp-templates/translation-set-new.php
+++ b/gp-templates/translation-set-new.php
@@ -1,6 +1,10 @@
 <?php
 gp_title( __( 'Create New Translation Set &lt; GlotPress', 'glotpress'  ) );
 $project? gp_breadcrumb_project( $project ) : gp_breadcrumb( array( __( 'New Translation Set', 'glotpress' ) ) );
+
+// jQuery is required for the 'translation-set-form' template.
+gp_enqueue_scripts( array( 'jquery' ) );
+
 gp_tmpl_header();
 ?>
 <h2><?php _e( 'Create New Translation Set', 'glotpress'  ); ?></h2>

--- a/gp-templates/translation-set-new.php
+++ b/gp-templates/translation-set-new.php
@@ -3,7 +3,7 @@ gp_title( __( 'Create New Translation Set &lt; GlotPress', 'glotpress'  ) );
 $project? gp_breadcrumb_project( $project ) : gp_breadcrumb( array( __( 'New Translation Set', 'glotpress' ) ) );
 
 // jQuery is required for the 'translation-set-form' template.
-gp_enqueue_scripts( array( 'jquery' ) );
+gp_enqueue_script( 'jquery' );
 
 gp_tmpl_header();
 ?>


### PR DESCRIPTION
The translation-set-form template requires jQuery.

However since we've already sent the headers by the time the form is loaded, we have to enqueue jQuery in the edit/new template files.

Resolves #543.
