### PR TITLE
547: Fix empty cancel link

### DIFF
--- a/gp-templates/project-new.php
+++ b/gp-templates/project-new.php
@@ -10,7 +10,7 @@ gp_tmpl_header();
 <?php gp_tmpl_load( 'project-form', get_defined_vars()); ?>
 	<p>
 		<input type="submit" name="submit" value="<?php esc_attr_e( 'Create', 'glotpress' ); ?>" id="submit" />
-		<span class="or-cancel"><?php _e( 'or', 'glotpress' ); ?> <a href="<?php echo gp_url_public_root(); ?>"><?php _e( 'Cancel', 'glotpress' ); ?></a></span>
+		<span class="or-cancel"><?php _e( 'or', 'glotpress' ); ?> <a href="<?php echo gp_url_public_root(); // WPCS: XSS ok. ?>"><?php _e( 'Cancel', 'glotpress' ); ?></a></span>
 	</p>
 	<?php gp_route_nonce_field( 'add-project' ); ?>
 </form>

--- a/gp-templates/project-new.php
+++ b/gp-templates/project-new.php
@@ -10,7 +10,7 @@ gp_tmpl_header();
 <?php gp_tmpl_load( 'project-form', get_defined_vars()); ?>
 	<p>
 		<input type="submit" name="submit" value="<?php esc_attr_e( 'Create', 'glotpress' ); ?>" id="submit" />
-		<span class="or-cancel"><?php _e( 'or', 'glotpress' ); ?> <a href="<?php echo gp_url_public_root(); // WPCS: XSS ok. ?>"><?php _e( 'Cancel', 'glotpress' ); ?></a></span>
+		<span class="or-cancel"><?php _e( 'or', 'glotpress' ); ?> <a href="<?php echo esc_url( gp_url_public_root() ); ?>"><?php _e( 'Cancel', 'glotpress' ); ?></a></span>
 	</p>
 	<?php gp_route_nonce_field( 'add-project' ); ?>
 </form>

--- a/gp-templates/project-new.php
+++ b/gp-templates/project-new.php
@@ -10,7 +10,7 @@ gp_tmpl_header();
 <?php gp_tmpl_load( 'project-form', get_defined_vars()); ?>
 	<p>
 		<input type="submit" name="submit" value="<?php esc_attr_e( 'Create', 'glotpress' ); ?>" id="submit" />
-		<span class="or-cancel"><?php _e( 'or', 'glotpress' ); ?> <a href="<?php echo gp_url(); ?>"><?php _e( 'Cancel', 'glotpress' ); ?></a></span>
+		<span class="or-cancel"><?php _e( 'or', 'glotpress' ); ?> <a href="<?php echo gp_url_public_root(); ?>"><?php _e( 'Cancel', 'glotpress' ); ?></a></span>
 	</p>
 	<?php gp_route_nonce_field( 'add-project' ); ?>
 </form>


### PR DESCRIPTION
The cancel link can be blank if GP is install in the root of a domain and the permalink structure is set to have no trailing slash.

Resolves #547.
