### PR TITLE
Add locale information for the Latin version of Hausa

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -962,14 +962,13 @@ class GP_Locales {
 		$gu->facebook_locale = 'gu_IN';
 
 		$ha = new GP_Locale();
-		$ha->english_name = 'Hausa';
+		$ha->english_name = 'Hausa (Arabic)';
 		$ha->native_name = 'هَوُسَ';
 		$ha->lang_code_iso_639_1 = 'ha';
 		$ha->lang_code_iso_639_2 = 'hau';
 		$ha->slug = 'ha';
 		$ha->text_direction = 'rtl';
 		$ha->google_code = 'ha';
-		$ha->facebook_locale = 'ha_NG';
 
 		$hat = new GP_Locale();
 		$hat->english_name = 'Haitian Creole';
@@ -980,6 +979,18 @@ class GP_Locales {
 		$hat->country_code = 'ht';
 		$hat->wp_locale = 'hat';
 		$hat->slug = 'hat';
+
+		$hau = new GP_Locale();
+		$hau->english_name = 'Hausa';
+		$hau->native_name = 'Harshen Hausa';
+		$hau->lang_code_iso_639_1 = 'ha';
+		$hau->lang_code_iso_639_2 = 'hau';
+		$hau->lang_code_iso_639_3 = 'hau';
+		$hau->country_code = 'ng';
+		$hau->wp_locale = 'hau';
+		$hau->slug = 'hau';
+		$hau->google_code = 'ha';
+		$hau->facebook_locale = 'ha_NG';
 
 		$haw = new GP_Locale();
 		$haw->english_name = 'Hawaiian';


### PR DESCRIPTION
Request: https://make.wordpress.org/polyglots/2016/04/22/request-for-adding-hausa-locale/

Also moves the Facebook locale from Arabic to Latin because Facebook uses the Latin version.

Previously: #512
