### PR TITLE
Restore edit text for non translated entries

### DIFF
--- a/gp-includes/misc.php
+++ b/gp-includes/misc.php
@@ -343,7 +343,17 @@ function gp_is_int( $value ) {
  * @return bool
  */
 function gp_is_null( $value ) {
-	return is_null( $value );
+	return null === $value;
+}
+
+/**
+ * Checks if the passed value is not null.
+ *
+ * @param string $value The value you want to check.
+ * @return bool
+ */
+function gp_is_not_null( $value ) {
+	return null !== $value;
 }
 
 /**

--- a/gp-templates/translation-row.php
+++ b/gp-templates/translation-row.php
@@ -36,13 +36,13 @@ $can_reject_self = ( isset( $t->user->user_login ) && $user->user_login === $t->
 			$edit_text = __( 'You are not allowed to add a translation.', 'glotpress' );
 		}
 		else {
-			$edit_text = sprintf( __( 'You <a href="%s">have to login</a> to add a translation.', 'glotpress' ), esc_url( wp_login_url() ) );
+			$edit_text = sprintf( __( 'You <a href="%s">have to log in</a> to add a translation.', 'glotpress' ), esc_url( wp_login_url( gp_url_current() ) ) );
 		}
 
 		$missing_text = "<span class='missing'>$edit_text</span>";
-		if ( ! count( array_filter( $t->translations, 'gp_is_not_empty_string' ) ) ):
+		if ( ! count( array_filter( $t->translations, 'gp_is_not_null' ) ) ) :
 			echo $missing_text;
-		elseif ( !$t->plural ):
+		elseif ( ! $t->plural ) :
 			echo esc_translation( $t->translations[0] );
 		else: ?>
 		<ul>


### PR DESCRIPTION
Broken since 7b103dd.
Fixes #519.

Also:
- Add `redirect_to` to `wp_login_url()`
- Fix typo, "login" is not a verb
