### PR TITLE
579: Prevent importing translations with warning twice

### DIFF
--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -260,6 +260,11 @@ class GP_Translation_Set extends GP_Thing {
 			 */
 			$entry->status = apply_filters( 'gp_translation_set_import_status', $is_fuzzy ? 'fuzzy' : $desired_status );
 
+			$entry->warnings = maybe_unserialize( GP::$translation_warnings->check( $entry->singular, $entry->plural, $entry->translations, $locale ) );
+			if ( ! empty( $entry->warnings ) ) {
+				$entry->status = 'waiting';
+			}
+
 			// Lazy load other entries.
 			if ( ! isset( $existing_translations[ $entry->status ] ) ) {
 				$existing_translations_list = GP::$translation->for_translation( $this->project, $this, 'no-limit', array( 'status' => $entry->status, 'translated' => 'yes' ) );
@@ -304,11 +309,6 @@ class GP_Translation_Set extends GP_Thing {
 				}
 
 				$entry->status = $is_fuzzy ? 'fuzzy' : $desired_status;
-
-				$entry->warnings = maybe_unserialize( GP::$translation_warnings->check( $entry->singular, $entry->plural, $entry->translations, $locale ) );
-				if ( ! empty( $entry->warnings ) ) {
-					$entry->status = 'waiting';
-				}
 				$entry->translation_set_id = $this->id;
 
 				/**

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -308,7 +308,6 @@ class GP_Translation_Set extends GP_Thing {
 					$entry->user_id = $user->ID;
 				}
 
-				$entry->status = $is_fuzzy ? 'fuzzy' : $desired_status;
 				$entry->translation_set_id = $this->id;
 
 				/**

--- a/tests/phpunit/testcases/tests_things/test_thing_translation_set.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_translation_set.php
@@ -58,6 +58,23 @@ class GP_Test_Thing_Translation_set extends GP_UnitTestCase {
 		$this->assertArrayHasKey( 'placeholders', $translations[0]->warnings[0] );
 	}
 
+	function test_import_should_not_import_translations_with_warnings_twice() {
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$original = $this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => 'A string with %s' ) );
+
+		$translations_for_import = new Translations;
+		$translations_for_import->add_entry( array( 'singular' => 'A string with %s', 'translations' => array( 'No Placeholder' ) ) );
+		$translations_added = $set->import( $translations_for_import );
+		$this->assertEquals( $translations_added, 1 );
+
+		$translations = GP::$translation->all();
+		$this->assertArrayHasKey( 'placeholders', $translations[0]->warnings[0] );
+
+		// Do the import again, it should not go through.
+		$translations_added = $set->import( $translations_for_import );
+		$this->assertEquals( $translations_added, 0 );
+	}
+
 	function test_import_should_not_import_existing_same_translation() {
 		$set = $this->factory->translation_set->create_with_project_and_locale();
 		$original = $this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => 'A string' ) );


### PR DESCRIPTION
Fixes #579 by checking for warnings earlier when importing.
