### PR TITLE
595: Fix, improve and test glossary plural handling

### DIFF
--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -60,7 +60,7 @@ function map_glossary_entries_to_translations_originals( $translations, $glossar
 			$terms[] = preg_quote( substr( $value->term, 0, -1 ), '/' ) . 'ves';
 		} elseif ( 'fe' === substr( $value->term, -2 ) ) {
 			$terms[] = preg_quote( substr( $value->term, 0, -2 ), '/' ) . 'ves';
-		} else{
+		} else {
 			if ( 'an' === substr( $value->term, -2 ) ) {
 				$terms[] = preg_quote( substr( $value->term, 0, -2 ), '/' ) . 'en';
 			}
@@ -73,29 +73,29 @@ function map_glossary_entries_to_translations_originals( $translations, $glossar
 	uasort( $glossary_entries_terms, function( $a, $b ) { return gp_strlen($a) < gp_strlen($b); } );
 
 	foreach ( $translations as $key => $t ) {
-		//Save our current singular/plural strings before attempting any markup change. Also escape now, since we're going to add some html.
-		$translations[$key]->singular_glossary_markup = esc_translation( $t->singular );
-		$translations[$key]->plural_glossary_markup   = esc_translation( $t->plural );
+		// Save our current singular/plural strings before attempting any markup change. Also escape now, since we're going to add some html.
+		$translations[ $key ]->singular_glossary_markup = esc_translation( $t->singular );
+		$translations[ $key ]->plural_glossary_markup   = esc_translation( $t->plural );
 
-		//Search for glossary terms in our strings
+		// Search for glossary terms in our strings.
 		$matching_entries = array();
 
-		foreach( $glossary_entries_terms as $i => $terms ) {
+		foreach ( $glossary_entries_terms as $i => $terms ) {
 			$glossary_entry = $glossary_entries[ $i ];
 			if ( preg_match( '/\b(' . $terms . ')\b/', $t->singular . ' ' . $t->plural, $m ) ) {
 				$matching_entries[ $m[1] ][] = array( 'translation' => $glossary_entry->translation, 'pos' => $glossary_entry->part_of_speech, 'comment' => $glossary_entry->comment );
 			}
 		}
 
-		//Replace terms in strings with markup
-		foreach( $matching_entries as $term => $glossary_data ) {
-			$replacement = '<span class="glossary-word" data-translations="' . htmlspecialchars( wp_json_encode( $glossary_data ), ENT_QUOTES, 'UTF-8') . '">$1</span>';
+		// Replace terms in strings with markup.
+		foreach ( $matching_entries as $term => $glossary_data ) {
+			$replacement = '<span class="glossary-word" data-translations="' . htmlspecialchars( wp_json_encode( $glossary_data ), ENT_QUOTES, 'UTF-8' ) . '">$1</span>';
 
 			$regex = '/\b(' . preg_quote( $term, '/' ) . ')(?![^<]*<\/span>)\b/iu';
-			$translations[$key]->singular_glossary_markup = preg_replace( $regex, $replacement, $translations[$key]->singular_glossary_markup );
+			$translations[ $key ]->singular_glossary_markup = preg_replace( $regex, $replacement, $translations[ $key ]->singular_glossary_markup );
 
 			if ( $t->plural ) {
-				$translations[$key]->plural_glossary_markup = preg_replace( $regex, $replacement, $translations[$key]->plural_glossary_markup );
+				$translations[ $key ]->plural_glossary_markup = preg_replace( $regex, $replacement, $translations[ $key ]->plural_glossary_markup );
 			}
 		}
 	}

--- a/tests/phpunit/testcases/tests_things/test_thing_glossary_entry.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_glossary_entry.php
@@ -49,18 +49,67 @@ class GP_Test_Glossary_Entry extends GP_UnitTestCase {
 		$this->assertCount( 9, GP::$glossary_entry->parts_of_speech );
 		$this->assertArrayHasKey( 'noun', GP::$glossary_entry->parts_of_speech );
 	}
-	
+
 	function test_delete() {
 		$entry = GP::$glossary_entry->create( array( 'glossary_id' => '1', 'term' => 'term', 'part_of_speech' => 'verb', 'last_edited_by' =>'1' ) );
-		
+
 		$pre_delete = GP::$glossary_entry->find_one( array( 'id' => $entry->id ) );
 
 		$entry->delete();
-		
+
 		$post_delete = GP::$glossary_entry->find_one( array( 'id' => $entry->id ) );
 
 		$this->assertFalse( empty( $pre_delete ) );
 		$this->assertNotEquals( $pre_delete, $post_delete );
 	}
 
+	function test_mapping_entries_to_originals() {
+		require_once GP_TMPL_PATH . 'helper-functions.php';
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
+
+		foreach ( array( 'term', 'box', 'city', 'toy', 'wife', 'shelf', 'man', 'woman' ) as $noun ) {
+			GP::$glossary_entry->create( array( 'glossary_id' => $glossary->id, 'term' => $noun, 'part_of_speech' => 'noun', 'translation' => $noun, 'comment' => 'my comment', 'last_edited_by' =>'1' ) );
+		}
+		foreach ( array( 'post' ) as $verb ) {
+			GP::$glossary_entry->create( array( 'glossary_id' => $glossary->id, 'term' => $verb, 'part_of_speech' => 'verb', 'translation' => $verb, 'comment' => 'my comment', 'last_edited_by' =>'1' ) );
+		}
+
+		$originals = array(
+			'term' => array( 'term' ),
+			'terms' => array( 'term' ),
+			'A sentence with a term to be found.' => array( 'term' ),
+			'A sentence with some terms to be found.' => array( 'term' ),
+			'A sentence with just a box.' => array( 'box' ),
+			'A sentence that contains a few boxes.' => array( 'box' ),
+			'A sentence about a city with some boxes.' => array( 'city', 'box' ),
+			'A blog about a city.' => array( 'city' ),
+			'Two blogs about two cities.' => array( 'city' ),
+			'A blog about a toy.' => array( 'toy' ),
+			'Two blogs about two toys.' => array( 'toy' ),
+			'A blog about a shelf.' => array( 'shelf' ),
+			'Two blogs about two shelves.' => array( 'shelf' ),
+			'A blog about a wife.' => array( 'wife' ),
+			'Two blogs about two wives.' => array( 'wife' ),
+			'A blog about a man and a woman.' => array( 'man', 'woman' ),
+			'Two blogs about two men and two women.' => array( 'man', 'woman' ),
+			'I post about something.' => array( 'post' ),
+			'Someone posts something.' => array( 'post' ),
+		);
+
+		foreach ( $originals as $original => $terms ) {
+			$this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => $original, 'plural' => $original, ) );
+		}
+
+		$translations = GP::$translation->for_translation( $set->project, $set, 'no-limit' );
+		$translations = map_glossary_entries_to_translations_originals( $translations, $glossary );
+
+		foreach ( $translations as $translation ) {
+			foreach ( $originals[ $translation->singular ] as $term ) {
+				$this->assertRegExp( '#<span class="glossary-word" data-translations="\[\{&quot;translation&quot;:&quot;' . preg_quote( $term, '#' ) . '&quot;[^"]+">[^<]+</span>#', $translation->singular_glossary_markup, 'Glossary term "' . $term . '" should have been found in "' . $translation->singular . '".' );
+				$this->assertRegExp( '#<span class="glossary-word" data-translations="\[\{&quot;translation&quot;:&quot;' . preg_quote( $term, '#' ) . '&quot;[^"]+">[^<]+</span>#', $translation->plural_glossary_markup, 'Glossary term "' . $term . '" should have been found in "' . $translation->plural . '".' );
+			}
+		}
+	}
 }

--- a/tests/phpunit/testcases/tests_things/test_thing_glossary_entry.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_glossary_entry.php
@@ -69,10 +69,12 @@ class GP_Test_Glossary_Entry extends GP_UnitTestCase {
 		$set = $this->factory->translation_set->create_with_project_and_locale();
 		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
 
-		foreach ( array( 'term', 'box', 'city', 'toy', 'wife', 'shelf', 'man', 'woman' ) as $noun ) {
+		$nouns = array( 'term', 'box', 'city', 'toy', 'wife', 'shelf', 'man', 'woman', 'post' );
+		foreach ( $nouns as $noun ) {
 			GP::$glossary_entry->create( array( 'glossary_id' => $glossary->id, 'term' => $noun, 'part_of_speech' => 'noun', 'translation' => $noun, 'comment' => 'my comment', 'last_edited_by' =>'1' ) );
 		}
-		foreach ( array( 'post' ) as $verb ) {
+		$verbs = array( 'write', 'post' );
+		foreach ( $verbs as $verb ) {
 			GP::$glossary_entry->create( array( 'glossary_id' => $glossary->id, 'term' => $verb, 'part_of_speech' => 'verb', 'translation' => $verb, 'comment' => 'my comment', 'last_edited_by' =>'1' ) );
 		}
 
@@ -94,6 +96,8 @@ class GP_Test_Glossary_Entry extends GP_UnitTestCase {
 			'Two blogs about two wives.' => array( 'wife' ),
 			'A blog about a man and a woman.' => array( 'man', 'woman' ),
 			'Two blogs about two men and two women.' => array( 'man', 'woman' ),
+			'I write about something.' => array( 'write' ),
+			'Someone writes about something.' => array( 'write' ),
 			'I post about something.' => array( 'post' ),
 			'Someone posts something.' => array( 'post' ),
 		);
@@ -107,8 +111,22 @@ class GP_Test_Glossary_Entry extends GP_UnitTestCase {
 
 		foreach ( $translations as $translation ) {
 			foreach ( $originals[ $translation->singular ] as $term ) {
-				$this->assertRegExp( '#<span class="glossary-word" data-translations="\[\{&quot;translation&quot;:&quot;' . preg_quote( $term, '#' ) . '&quot;[^"]+">[^<]+</span>#', $translation->singular_glossary_markup, 'Glossary term "' . $term . '" should have been found in "' . $translation->singular . '".' );
-				$this->assertRegExp( '#<span class="glossary-word" data-translations="\[\{&quot;translation&quot;:&quot;' . preg_quote( $term, '#' ) . '&quot;[^"]+">[^<]+</span>#', $translation->plural_glossary_markup, 'Glossary term "' . $term . '" should have been found in "' . $translation->plural . '".' );
+				foreach ( array( 'noun', 'verb' ) as $pos ) {
+					if ( ! in_array( $term, ${ $pos . 's' } ) ) {
+						continue;
+					}
+
+					// echo 'Checking for ', $pos, ' ', $term, ' in ', $translation->singular, PHP_EOL;
+					$translation_json = array(
+						'translation' => $term,
+						'pos' => $pos,
+					);
+
+					$regex = '#<span class="glossary-word" data-translations="\[.*?' . preg_quote( htmlspecialchars( substr( json_encode( $translation_json ), 0, -2 ) ), '#' ) . '[^"]+">[^<]+</span>#';
+
+					$this->assertRegExp( $regex, $translation->singular_glossary_markup, 'Glossary term "' . $term . '" should have been found in "' . $translation->singular . '".' );
+					$this->assertRegExp( $regex, $translation->plural_glossary_markup, 'Glossary term "' . $term . '" should have been found in "' . $translation->plural . '".' );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The regex for matching glossary terms occuring in plurals ending with `es` was broken (`[es|s]` which should have been `(es|s)`). I have added some unit tests and added a few irregular plurals.

Fixes #595.
