### PR TITLE
596: Add support for importing fuzzy translations

### DIFF
--- a/gp-includes/cli/translation-set.php
+++ b/gp-includes/cli/translation-set.php
@@ -110,6 +110,9 @@ class GP_CLI_Translation_Set extends WP_CLI_Command {
 	 *
 	 * [--set=<set>]
 	 * : Translation set slug; default is "default"
+	 *
+	 * [--status=<status>]
+	 * : Translation string status; default is "current"
 	 */
 	public function import( $args, $assoc_args ) {
 		$set_slug = isset( $assoc_args['set'] ) ? $assoc_args['set'] : 'default';
@@ -124,7 +127,9 @@ class GP_CLI_Translation_Set extends WP_CLI_Command {
 			WP_CLI::error( __( "Couldn't load translations from file!", 'glotpress' ) );
 		}
 
-		$added = $translation_set->import( $po );
+		$desired_status = isset( $assoc_args['status'] ) ? $assoc_args['status'] : 'current';
+
+		$added = $translation_set->import( $po, $desired_status );
 
 		/* translators: %s: Number of imported translations */
 		WP_CLI::line( sprintf( _n( '%s translation was added', '%s translations were added', $added, 'glotpress' ), $added ) );

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -204,7 +204,7 @@ class GP_Translation_Set extends GP_Thing {
 	 * Import translations from a Translations object.
 	 *
 	 * @param  Translations $translations   the translations to be imported to this translation-set.
-	 * @param  string       $desired_status 'current' or 'waiting'.
+	 * @param  string       $desired_status 'current', 'waiting' or 'fuzzy'.
 	 * @return boolean or void
 	 */
 	public function import( $translations, $desired_status = 'current' ) {
@@ -214,7 +214,8 @@ class GP_Translation_Set extends GP_Thing {
 			$this->project = GP::$project->get( $this->project_id );
 		}
 
-		if ( ! in_array( $desired_status, array( 'current', 'waiting' ), true ) ) {
+		// Fuzzy is also checked in the flags, but if all strings in an import are fuzzy, fuzzy status can be forced.
+		if ( ! in_array( $desired_status, array( 'current', 'waiting', 'fuzzy' ), true ) ) {
 			return false;
 		}
 

--- a/tests/phpunit/testcases/tests_things/test_thing_translation_set.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_translation_set.php
@@ -46,6 +46,26 @@ class GP_Test_Thing_Translation_set extends GP_UnitTestCase {
 		$this->assertEquals( $translations[1]->status, 'current' );
 	}
 
+	function test_import_should_save_forced_fuzzy() {
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => 'A string' ) );
+		$this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => 'Second string' ) );
+
+		$fuzzy_import = new Translations;
+		$fuzzy_import->add_entry( array( 'singular' => 'A string', 'translations' => array( 'baba' ) ) );
+
+		$current_import = new Translations;
+		$current_import->add_entry( array( 'singular' => 'Second string', 'translations' => array( 'second' ) ) );
+
+		$set->import( $fuzzy_import, 'fuzzy' );
+		$set->import( $current_import );
+
+		$translations = GP::$translation->all();
+
+		$this->assertEquals( $translations[0]->status, 'fuzzy' );
+		$this->assertEquals( $translations[1]->status, 'current' );
+	}
+
 	function test_import_should_generate_warnings() {
 		$set = $this->factory->translation_set->create_with_project_and_locale();
 		$this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => 'A string with %s' ) );

--- a/tests/phpunit/testcases/tests_things/test_thing_translation_set.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_translation_set.php
@@ -66,6 +66,21 @@ class GP_Test_Thing_Translation_set extends GP_UnitTestCase {
 		$this->assertEquals( $translations[1]->status, 'current' );
 	}
 
+	function test_import_should_skip_existing_when_importing_fuzzy() {
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => 'A string' ) );
+
+		$fuzzy_import = new Translations;
+		$fuzzy_import->add_entry( array( 'singular' => 'A string', 'translations' => array( 'baba' ) ) );
+
+		$translations_added = $set->import( $fuzzy_import, 'fuzzy' );
+		$this->assertEquals( $translations_added, 1 );
+
+		// Do the import again, it should not go through.
+		$translations_added = $set->import( $fuzzy_import, 'fuzzy' );
+		$this->assertEquals( $translations_added, 0 );
+	}
+
 	function test_import_should_generate_warnings() {
 		$set = $this->factory->translation_set->create_with_project_and_locale();
 		$this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => 'A string with %s' ) );


### PR DESCRIPTION
I didn't see any unit tests for the CLI commands so I haven't added any. Let me know if I still need to add those.

Fixes #596.