### PR TITLE
Add PHP 7.1 to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
     env: WP_VERSION=trunk WP_MULTISITE=0 WP_TRAVISCI=codecoverage
   - php: 7.0
     env: WP_VERSION=trunk WP_MULTISITE=0
+  - php: 7.1
+    env: WP_VERSION=trunk WP_MULTISITE=0
 
 install:
   - export DEV_LIB_PATH=dev-lib


### PR DESCRIPTION
I noticed that 7.1 isn't in the Travis config when testing, so I figured I would add it.