### PR TITLE
Add HHVM and nightly PHP to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ cache:
     - $HOME/.composer/cache
 
 matrix:
+  allow_failures:
+    - php: hhvm
+    - php: nightly
   include:
   - php: 5.3
     env: WP_VERSION=latest WP_MULTISITE=0
@@ -26,6 +29,10 @@ matrix:
   - php: 7.0
     env: WP_VERSION=trunk WP_MULTISITE=0
   - php: 7.1
+    env: WP_VERSION=trunk WP_MULTISITE=0
+  - php: hhvm
+    env: WP_VERSION=trunk WP_MULTISITE=0
+  - php: nightly
     env: WP_VERSION=trunk WP_MULTISITE=0
 
 install:


### PR DESCRIPTION
They are allowed to fail because they can be flaky, but it is still
nice to be able to see their build status.