### PR TITLE
688: Remove invalid 'me' language code

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -1361,7 +1361,6 @@ class GP_Locales {
 		$me = new GP_Locale();
 		$me->english_name = 'Montenegrin';
 		$me->native_name = 'Crnogorski jezik';
-		$me->lang_code_iso_639_1 = 'me';
 		$me->country_code = 'me';
 		$me->wp_locale = 'me_ME';
 		$me->slug = 'me';


### PR DESCRIPTION
'me' is not a valid 639-1 language code, so it should not be in here. See the [Wiki page](https://en.wikipedia.org/wiki/Montenegrin_language) for the language.

See #688.