### PR TITLE
575: Update jed language field

### DIFF
--- a/gp-includes/formats/format-jed1x.php
+++ b/gp-includes/formats/format-jed1x.php
@@ -51,7 +51,7 @@ class GP_Format_Jed1x extends GP_Format_JSON {
 		if ( false !== $language_code ) {
 			$language_code = $locale->slug;
 		}
-		
+
 		$result = array(
 			'translation-revision-date' => GP::$translation->last_modified( $translation_set ) . '+0000',
 			'generator'                 => 'GlotPress/' . GP_VERSION,

--- a/gp-includes/formats/format-jed1x.php
+++ b/gp-includes/formats/format-jed1x.php
@@ -48,7 +48,7 @@ class GP_Format_Jed1x extends GP_Format_JSON {
 	 */
 	public function print_exported_file( $project, $locale, $translation_set, $entries ) {
 		$language_code = $this->get_language_code( $locale );
-		if ( false !== $language_code ) {
+		if ( false === $language_code ) {
 			$language_code = $locale->slug;
 		}
 

--- a/gp-includes/formats/format-jed1x.php
+++ b/gp-includes/formats/format-jed1x.php
@@ -47,6 +47,11 @@ class GP_Format_Jed1x extends GP_Format_JSON {
 	 * @return string The exported Jed 1.x compatible JSON string.
 	 */
 	public function print_exported_file( $project, $locale, $translation_set, $entries ) {
+		$language_code = $this->get_language_code( $locale );
+		if ( false !== $language_code ) {
+			$language_code = $locale->slug;
+		}
+		
 		$result = array(
 			'translation-revision-date' => GP::$translation->last_modified( $translation_set ) . '+0000',
 			'generator'                 => 'GlotPress/' . GP_VERSION,
@@ -56,7 +61,7 @@ class GP_Format_Jed1x extends GP_Format_JSON {
 					'__GP_EMPTY__' => array(
 						'domain'       => 'messages',
 						'plural-forms' => sprintf( 'nplurals=%1$s; plural=%2$s;', $locale->nplurals, $locale->plural_expression ),
-						'lang'         => $locale->slug,
+						'lang'         => $language_code,
 					),
 				),
 			),

--- a/tests/phpunit/testcases/tests_formats/test_format_jed1x.php
+++ b/tests/phpunit/testcases/tests_formats/test_format_jed1x.php
@@ -22,9 +22,10 @@ class GP_Test_Format_Jed1x extends GP_UnitTestCase {
 		$this->translation_set = $this->factory->translation_set->create_with_project_and_locale( array(), array( 'name' => 'foo_project' ) );
 
 		$this->locale = new GP_Locale( array(
-			'slug'              => $this->translation_set->locale,
-			'nplurals'          => 2,
-			'plural_expression' => 'n != 1',
+			'slug'                => $this->translation_set->locale,
+			'nplurals'            => 2,
+			'plural_expression'   => 'n != 1',
+			'lang_code_iso_639_1' => $this->translation_set->locale,
 		) );
 	}
 


### PR DESCRIPTION
Use $format->get_language_code() if possible, otherwise default to the locale slug.

Resolves #575.