### PR TITLE
621: Show translation history link only if there are other translations

### DIFF
--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -661,6 +661,23 @@ class GP_Translation extends GP_Thing {
 		return $last_modified;
 	}
 
+	/**
+	 * Get IDs of translations by ID of their original and translation set.
+	 *
+	 * @since 2.3.0
+	 *
+	 * @param int $original_id        ID of original.
+	 * @param int $translation_set_id ID of translation set.
+	 * @return array $ids An array of IDs of matching translations.
+	 */
+	public function ids_by_original_and_set( $original_id, $translation_set_id  ) {
+		global $wpdb;
+
+		$ids = $wpdb->get_col( $wpdb->prepare( "SELECT id FROM {$this->table} WHERE original_id = %d AND translation_set_id = %d",  $original_id, $translation_set_id ) );
+
+		return $ids;
+	}
+
 	// Triggers
 
 	/**

--- a/gp-templates/translation-row.php
+++ b/gp-templates/translation-row.php
@@ -24,8 +24,10 @@ if ( $t->translation_status ) {
 	$more_links['original-permalink'] = '<a tabindex="-1" href="' . esc_url( $original_permalink ) . '">' . __( 'Permalink to this original', 'glotpress' ) . '</a>';
 }
 
-$original_history = gp_url_project_locale( $project, $locale->slug, $translation_set->slug, array( 'filters[status]' => 'either', 'filters[original_id]' => $t->original_id, 'sort[by]' => 'translation_date_added', 'sort[how]' => 'asc' ) );
-$more_links['history'] = '<a tabindex="-1" href="' . esc_url( $original_history ) . '">' . __( 'All translations of this original', 'glotpress' ) . '</a>';
+if ( count( GP::$translation->ids_by_original_and_set( $t->original_id, $translation_set->id ) ) > 1 ) {
+	$original_history = gp_url_project_locale( $project, $locale->slug, $translation_set->slug, array( 'filters[status]' => 'either', 'filters[original_id]' => $t->original_id, 'sort[by]' => 'translation_date_added', 'sort[how]' => 'asc' ) );
+	$more_links['history'] = '<a tabindex="-1" href="' . esc_url( $original_history ) . '">' . __( 'All translations of this original', 'glotpress' ) . '</a>';
+}
 
 /**
  * Allows to modify the more links in the translation editor.


### PR DESCRIPTION
From [Trac ticket](https://glotpress.trac.wordpress.org/ticket/338), I followed approach of @yoavf but I simplified database query: instead of retrieving all translations of original, I query only for their ids.

This would create additional database queries but there is no way to completely avoid them. Other options:
 - only do querying depending on status of translation
 - cache result and clear it on `gp_translation_(created|saved|deleted)`
 - instead of ids, get statuses of translations and then show some information from them

Fixes #621 