### PR TITLE
633: Add double quotes to the filename in the headers.

### DIFF
--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -276,17 +276,18 @@ class GP_Route {
 	 * @param string $last_modified Optional. Date when the file was last modified. Default: ''.
 	 */
 	public function headers_for_download( $filename, $last_modified = '' ) {
-		$this->header('Content-Description: File Transfer');
-		$this->header('Pragma: public');
-		$this->header('Expires: 0');
+		$this->header( 'Content-Description: File Transfer' );
+		$this->header( 'Pragma: public' );
+		$this->header( 'Expires: 0' );
 
-		if ( $last_modified )
+		if ( $last_modified ) {
 			$this->header( sprintf( 'Last-Modified: %s', $last_modified ) );
+		}
 
-		$this->header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
-		$this->header("Content-Disposition: attachment; filename=\"$filename\"");
-		$this->header("Content-Type: application/octet-stream");
-		$this->header('Connection: close');
+		$this->header( 'Cache-Control: must-revalidate, post-check=0, pre-check=0' );
+		$this->header( "Content-Disposition: attachment; filename=\"$filename\"" );
+		$this->header( "Content-Type: application/octet-stream" );
+		$this->header( 'Connection: close' );
 	}
 
 	public function set_notices_and_errors() {

--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -284,7 +284,7 @@ class GP_Route {
 			$this->header( sprintf( 'Last-Modified: %s', $last_modified ) );
 
 		$this->header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
-		$this->header("Content-Disposition: attachment; filename=$filename");
+		$this->header("Content-Disposition: attachment; filename=\"$filename\"");
 		$this->header("Content-Type: application/octet-stream");
 		$this->header('Connection: close');
 	}

--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -286,7 +286,7 @@ class GP_Route {
 
 		$this->header( 'Cache-Control: must-revalidate, post-check=0, pre-check=0' );
 		$this->header( "Content-Disposition: attachment; filename=\"$filename\"" );
-		$this->header( "Content-Type: application/octet-stream" );
+		$this->header( 'Content-Type: application/octet-stream' );
 		$this->header( 'Connection: close' );
 	}
 

--- a/tests/phpunit/testcases/test_route.php
+++ b/tests/phpunit/testcases/test_route.php
@@ -1,0 +1,11 @@
+<?php
+
+class GP_Test_Route extends GP_UnitTestCase_Route {
+	public $route_class = 'GP_Route';
+
+	function test_headers_for_download_function_includes_double_quote_around_file_name() {
+		$this->route->headers_for_download( 'test.po' );
+		
+		$this->assertEquals( ' attachment; filename="test.po"', $this->route->headers['Content-Disposition'] );
+	}
+}

--- a/tests/phpunit/testcases/test_route.php
+++ b/tests/phpunit/testcases/test_route.php
@@ -5,7 +5,7 @@ class GP_Test_Route extends GP_UnitTestCase_Route {
 
 	function test_headers_for_download_function_includes_double_quote_around_file_name() {
 		$this->route->headers_for_download( 'test.po' );
-		
+
 		$this->assertEquals( ' attachment; filename="test.po"', $this->route->headers['Content-Disposition'] );
 	}
 }


### PR DESCRIPTION
Resolves #633.