### PR TITLE
640: Glossary entries of project glossary should take precedence.

### DIFF
--- a/gp-includes/things/glossary.php
+++ b/gp-includes/things/glossary.php
@@ -110,11 +110,7 @@ class GP_Glossary extends GP_Thing {
 		}
 
 		foreach ( $merge->get_entries() as $entry ) {
-			if ( isset( $entry_map[ $entry->key() ] ) ) {
-				// Overwrite entry.
-				$i = $entry_map[ $entry->key() ];
-				$this->entries[ $i ] = $entry;
-			} else {
+			if ( ! isset( $entry_map[ $entry->key() ] ) ) {
 				$this->entries[] = $entry;
 			}
 		}

--- a/tests/phpunit/testcases/tests_things/test_thing_glossary.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_glossary.php
@@ -140,9 +140,9 @@ class GP_Test_Glossary extends GP_UnitTestCase {
 		$extended_glossary = $route->testable_get_extended_glossary( $set, $set->project );
 		$entries = $extended_glossary->get_entries();
 
-		// Count is now 1 as the term is overwritten by the locale glossary.
+		// Count is now 1 as the term is overwritten by the project glossary.
 		$this->assertCount( 1, $entries );
-		$this->assertEquals( $test_entries[1]['translation'], $entries[0]->translation );
+		$this->assertEquals( $test_entries[0]['translation'], $entries[0]->translation );
 	}
 }
 


### PR DESCRIPTION
Entries in a locale glossary might be to generic for a project. A translator could therefore define a specific term in a project glossary which should override the term of a locale glossary.

Fixes #640.