### PR TITLE
644: Allow CLI imports to set the status of translations to current.

### DIFF
--- a/gp-includes/advanced-permissions.php
+++ b/gp-includes/advanced-permissions.php
@@ -91,7 +91,3 @@ add_filter( 'gp_can_user', 'gp_recurse_validator_permission', 10, 2 );
 add_filter( 'gp_pre_can_user', 'gp_route_translation_set_permissions_to_validator_permissions', 10, 2 );
 add_filter( 'gp_pre_can_user', 'gp_allow_approving_translations_with_validator_permissions', 10, 2 );
 add_filter( 'gp_pre_can_user', 'gp_allow_everyone_to_translate', 10, 2 );
-
-if ( defined( 'WP_CLI' ) && WP_CLI ) {
-	add_filter( 'gp_pre_can_set_translation_status', '__return_true' );
-}

--- a/gp-includes/advanced-permissions.php
+++ b/gp-includes/advanced-permissions.php
@@ -91,3 +91,7 @@ add_filter( 'gp_can_user', 'gp_recurse_validator_permission', 10, 2 );
 add_filter( 'gp_pre_can_user', 'gp_route_translation_set_permissions_to_validator_permissions', 10, 2 );
 add_filter( 'gp_pre_can_user', 'gp_allow_approving_translations_with_validator_permissions', 10, 2 );
 add_filter( 'gp_pre_can_user', 'gp_allow_everyone_to_translate', 10, 2 );
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	add_filter( 'gp_pre_can_set_translation_status', '__return_true' );
+}

--- a/gp-includes/cli.php
+++ b/gp-includes/cli.php
@@ -14,7 +14,7 @@ function gp_cli_register() {
 	require_once GP_PATH . GP_INC . 'cli/upgrade-set-permissions.php';
 	require_once GP_PATH . GP_INC . 'cli/wipe-permissions.php';
 
-	// Legacy commands
+	// Legacy commands.
 	WP_CLI::add_command( 'glotpress add-admin', 'GP_CLI_Add_Admin' );
 	WP_CLI::add_command( 'glotpress branch-project', 'GP_CLI_Branch_Project' );
 	WP_CLI::add_command( 'glotpress import-originals', 'GP_CLI_Import_Originals' );
@@ -23,8 +23,11 @@ function gp_cli_register() {
 	WP_CLI::add_command( 'glotpress upgrade-set-permissions', 'GP_CLI_Upgrade_Set_Permissions' );
 	WP_CLI::add_command( 'glotpress wipe-permissions', 'GP_CLI_Wipe_Permissions' );
 
-	// New style commands
+	// New style commands.
 	WP_CLI::add_command( 'glotpress translation-set', 'GP_CLI_Translation_Set' );
+
+	// CLI related filters.
+	add_filter( 'gp_pre_can_set_translation_status', '__return_true' );
 }
 
 class GP_CLI {


### PR DESCRIPTION
Short circuits `GP_Translation::can_set_status()` by always returning true if `WP_CLI` is defined. Prevents duplicated entries by the missing update queries of `GP_Translation::set_as_current()`.

Fixes #644.