### PR TITLE
656: Return locale glossary if a project has no glossary

### DIFF
--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -675,6 +675,11 @@ class GP_Route_Translation extends GP_Route_Main {
 
 		$locale_glossary = GP::$glossary->by_set_id( $locale_glossary_translation_set->id );
 
+		// Return locale glossary if a project has no glossary.
+		if ( false === $glossary && $locale_glossary instanceof GP_Glossary ) {
+			return $locale_glossary;
+		}
+
 		if ( $glossary instanceof GP_Glossary && $locale_glossary instanceof GP_Glossary && $locale_glossary->id !== $glossary->id ) {
 			$glossary->merge_with_glossary( $locale_glossary );
 		}

--- a/tests/phpunit/testcases/tests_things/test_thing_glossary.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_glossary.php
@@ -158,17 +158,22 @@ class GP_Test_Glossary extends GP_UnitTestCase {
 			'slug' => $locale_set->slug,
 		) );
 
-		GP::$glossary_entry->create( array(
-			'term' => 'Term 2',
+		$entry = array(
+			'term'           => 'Term 2',
 			'part_of_speech' => 'noun',
-			'translation' => 'Translation 2',
-			'glossary_id' => $locale_glossary->id,
-		) );
+			'translation'    => 'Translation 2',
+			'glossary_id'    => $locale_glossary->id,
+		);
+
+		GP::$glossary_entry->create( $entry );
 
 		$route = new Testable_GP_Route_Translation;
 		$extended_glossary = $route->testable_get_extended_glossary( $set, $set->project );
 		$this->assertInstanceOf( 'GP_Glossary', $extended_glossary );
-		$this->assertCount( 1, $extended_glossary->get_entries() );
+
+		$entries = $extended_glossary->get_entries();
+		$this->assertCount( 1, $entries );
+		$this->assertEquals( $entry['translation'], $entries[0]->translation );
 	}
 }
 


### PR DESCRIPTION
Fixes #656.