### PR TITLE
659: Call actions when a translation set is created/saved/deleted

### DIFF
--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -565,5 +565,65 @@ class GP_Translation_Set extends GP_Thing {
 
 		return parent::delete();
 	}
+
+	/**
+	 * Executes after creating a translation set.
+	 *
+	 * @since 2.4.0
+	 *
+	 * @return bool
+	 */
+	public function after_create() {
+		/**
+		 * Fires after creating a translation set.
+		 *
+		 * @since 2.4.0
+		 *
+		 * @param GP_Translation_Set $translation_set The translation set that was created.
+		 */
+		do_action( 'gp_translation_set_created', $this );
+
+		return true;
+	}
+
+	/**
+	 * Executes after saving a translation set.
+	 *
+	 * @since 2.4.0
+	 *
+	 * @return bool
+	 */
+	public function after_save() {
+		/**
+		 * Fires after saving a translation set..
+		 *
+		 * @since 2.4.0
+		 *
+		 * @param GP_Translation_Set $translation_set The translation set that was saved.
+		 */
+		do_action( 'gp_translation_set_saved', $this );
+
+		return true;
+	}
+
+	/**
+	 * Executes after deleting a translation set.
+	 *
+	 * @since 2.4.0
+	 *
+	 * @return bool
+	 */
+	public function after_delete() {
+		/**
+		 * Fires after deleting a translation set.
+		 *
+		 * @since 2.4.0
+		 *
+		 * @param GP_Translation_Set $translation_set The translation set that was deleted.
+		 */
+		do_action( 'gp_translation_set_deleted', $this );
+
+		return true;
+	}
 }
 GP::$translation_set = new GP_Translation_Set();

--- a/tests/phpunit/testcases/tests_things/test_thing_translation_set.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_translation_set.php
@@ -258,4 +258,47 @@ class GP_Test_Thing_Translation_set extends GP_UnitTestCase {
 		$set->update_status_breakdown();
 		$this->assertEquals( $num_queries + 7, $wpdb->num_queries );
 	}
+
+	public function test_created_action_is_called() {
+		$action = new MockAction();
+
+		add_action( 'gp_translation_set_created', array( $action, 'action' ) );
+
+		$this->factory->translation_set->create_with_project_and_locale();
+
+		remove_action( 'gp_translation_set_created', array( $action, 'action' ) );
+
+		$this->assertSame( 1, $action->get_call_count() );
+	}
+
+	public function test_saved_action_is_called() {
+		$action = new MockAction();
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$locale = $this->factory->locale->create();
+
+		add_action( 'gp_translation_set_saved', array( $action, 'action' ) );
+
+		$set->save( array(
+			'locale' => $locale->slug,
+		) );
+
+		remove_action( 'gp_translation_set_saved', array( $action, 'action' ) );
+
+		$this->assertSame( 1, $action->get_call_count() );
+	}
+
+	public function test_deleted_action_is_called() {
+		$action = new MockAction();
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+
+		add_action( 'gp_translation_set_deleted', array( $action, 'action' ) );
+
+		$set->delete();
+
+		remove_action( 'gp_translation_set_deleted', array( $action, 'action' ) );
+
+		$this->assertSame( 1, $action->get_call_count() );
+	}
 }


### PR DESCRIPTION
Fixes #659.