### PR TITLE
664: allow querying by priority

### DIFF
--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -364,7 +364,7 @@ class GP_Translation extends GP_Thing {
 		if ( $priorities ) {
 			$valid_priorities = array_keys( GP::$original->get_static( 'priorities' ) );
 			$priorities = array_filter( gp_array_get( $filters, 'priority' ), function( $p ) use ( $valid_priorities ) {
-				return in_array( $p, $valid_priorities, true );
+				return in_array( intval( $p ), $valid_priorities, true );
 			} );
 
 			$priorities_where = array();

--- a/tests/phpunit/testcases/tests_things/test_thing_translation.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_translation.php
@@ -310,4 +310,41 @@ class GP_Test_Thing_Translation extends GP_UnitTestCase {
 		$this->assertEquals( $previous_translation->translation_0, 'Before' );
 		$this->assertEquals( $translation->translation_0, 'After' );
 	}
+
+	/**
+	 * @ticket gh-664
+	 */
+	function test_filter_by_permission() {
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$translation = $this->factory->translation->create_with_original_for_translation_set( $set );
+
+		// A new original has the priority 0.
+		$this->assertEquals( 1, count( GP::$translation->for_translation( $set->project, $set, 0 ) ) );
+		$this->assertEquals( 1, count( GP::$translation->for_translation( $set->project, $set, 0, array( 'priority' => array( '0' )  ) ) ) );
+
+		// Invalid priority is the same as specifying no priority.
+		$this->assertEquals( 1, count( GP::$translation->for_translation( $set->project, $set, 0, array( 'priority' => array( '10' )  ) ) ) );
+
+		// String and numeric values should work.
+		$this->assertEquals( 0, count( GP::$translation->for_translation( $set->project, $set, 0, array( 'priority' => array( '1' ) ) ) ) );
+		$this->assertEquals( 0, count( GP::$translation->for_translation( $set->project, $set, 0, array( 'priority' => array( 1 ) ) ) ) );
+
+		// Now let's modify the priority.
+		$translation->original->priority = '1';
+		$translation->original->status = '+active';
+		$translation->original->save();
+
+		// The modified original should now be found.
+		$this->assertEquals( 1, count( GP::$translation->for_translation( $set->project, $set, 0 ) ) );
+		$this->assertEquals( 1, count( GP::$translation->for_translation( $set->project, $set, 0, array( 'priority' => array( '1' ) ) ) ) );
+		$this->assertEquals( 1, count( GP::$translation->for_translation( $set->project, $set, 0, array( 'priority' => array( '10' ) ) ) ) );
+		$this->assertEquals( 0, count( GP::$translation->for_translation( $set->project, $set, 0, array( 'priority' => array( '0' ) ) ) ) );
+
+		// Should also work with the hidden priority.
+		$translation->original->priority = '-1';
+		$translation->original->save();
+
+		$this->assertEquals( 0, count( GP::$translation->for_translation( $set->project, $set, 0, array( 'priority' => array( '1' ) ) ) ) );
+		$this->assertEquals( 1, count( GP::$translation->for_translation( $set->project, $set, 0, array( 'priority' => array( '-1' ) ) ) ) );
+	}
 }


### PR DESCRIPTION
Because the `array_keys()` of a normal array are always integers and numeric query parameters are strings the strict `in_array()` comparison fails, hence it's not possible to query for translations by priority, see #664.