### PR TITLE
669: Improve readability of double-slash hack

### DIFF
--- a/gp-includes/things/glossary.php
+++ b/gp-includes/things/glossary.php
@@ -187,14 +187,18 @@ class GP_Glossary extends GP_Thing {
 		 *
 		 * @since 2.3.1
 		 *
-		 * @param string $$locale_glossary_path_prefix Prefix for the locale glossary path.
+		 * @param string $locale_glossary_path_prefix Prefix for the locale glossary path.
 		 */
 		$locale_glossary_path_prefix = apply_filters( 'gp_locale_glossary_path_prefix', '/languages' );
+
+		// A leading double-slash prevents gp_url_project() from prepending /projects/ to the URL.
+		$locale_glossary_path_prefix = '//' . ltrim( $locale_glossary_path_prefix, '/' );
+
 		return new GP::$project( array(
 			'id'   => 0,
 			'name' => 'Locale Glossary',
 			'slug' => 0,
-			'path' => "/$locale_glossary_path_prefix",
+			'path' => $locale_glossary_path_prefix,
 		) );
 	}
 }

--- a/gp-includes/url.php
+++ b/gp-includes/url.php
@@ -137,6 +137,8 @@ function gp_url_current() {
 /**
  * Get the URL for a project
  *
+ * A leading double-slash will avoid prepending /projects/ to the path.
+ *
  * @param bool|string|object $project_or_path Project path or object
  * @param string|array $path Addition path to append to the base path
  * @param array $query associative array of query arguments (optional)
@@ -144,8 +146,10 @@ function gp_url_current() {
  * @return string
  */
 function gp_url_project( $project_or_path = '', $path = '', $query = null ) {
-	$project_path = is_object( $project_or_path )? $project_or_path->path : $project_or_path;
+	$project_path = is_object( $project_or_path ) ? $project_or_path->path : $project_or_path;
 
+	// A leading double-slash will avoid prepending /projects/ to the path.
+	// This was introduced to enable linking to the locale glossary.
 	if ( '//' === substr( $project_path, 0, 2 ) ) {
 		$project_path = ltrim( $project_path, '/' );
 	} else {


### PR DESCRIPTION
This PR is to clarify the meaning of a double-slash for the path that's used for the locale glossary.