### PR TITLE
673: Fix locale glossary import nonce check

### DIFF
--- a/gp-includes/routes/glossary-entry.php
+++ b/gp-includes/routes/glossary-entry.php
@@ -261,7 +261,7 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
-		if ( $this->invalid_nonce_and_redirect( 'import-glossary-entries_' . $project_path . $locale_slug . $translation_set_slug ) ) {
+		if ( $this->invalid_nonce_and_redirect( 'import-glossary-entries_' . $project->path . $locale_slug . $translation_set_slug ) ) {
 			return;
 		}
 


### PR DESCRIPTION
The path for the default project for the locale is actually `//languages` (as set by `get_locale_glossary_project`)
When using project_path from the route, we only get one slash, and the nonce check fails.
Even if it was meant to only have one slash, it is safer to use the path from the project retrieved earlier.

Fixes #673.