### PR TITLE
Locales: remove duplicate statement for 'cor'

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -527,7 +527,6 @@ class GP_Locales {
 		$cor->native_name = 'Kernewek';
 		$cor->lang_code_iso_639_1 = 'kw';
 		$cor->lang_code_iso_639_2 = 'cor';
-		$cor->lang_code_iso_639_2 = 'cor';
 		$cor->country_code = 'gb';
 		$cor->wp_locale = 'cor';
 		$cor->slug = 'cor';


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

<!--
Please, describe what is the status/problem before the PR.
-->

When importing the `locales.php` to the jetpack monorepo on https://github.com/Automattic/jetpack/pull/36748, the Phan PHP static analyzer detected a duplicate definition of `lang_code_iso_639_2` within the `cor` locale.

This won't really change any functionality, but will ensure this issue won't appear again for anyone running similar linters.

## Solution

<!--
Please, describe how this PR improves the situation.
-->

Drop the duplicate definition.

## To-do

<!--
Please, describe the other undone tasks or items on the to-do list for this PR,
only if it is applicable.
-->

## Testing Instructions
<!-- 
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
Please, include step-by-step instructions on how to test this PR:
1. Open a original string in a project.
2. Add the translation.
3. etc. 
-->

## Screenshots or screencast
<!-- 
Only if it is applicable 
-->