### PR TITLE
Update Kyrgyz locale information

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -1612,8 +1612,6 @@ class GP_Locales {
 		$ky->slug = 'ky';
 		$ky->google_code = 'ky';
 		$ky->alphabet = 'cyrillic';
-		$ky->nplurals = 1;
-		$ky->plural_expression = ‘0’;
 
 		$la = new GP_Locale();
 		$la->english_name = 'Latin';

--- a/locales/locales.php
+++ b/locales/locales.php
@@ -1601,17 +1601,19 @@ class GP_Locales {
 		$ks->slug = 'ks';
 		$ks->alphabet = 'devanagari';
 
-		$kir = new GP_Locale();
-		$kir->english_name = 'Kyrgyz';
-		$kir->native_name = 'Кыргызча';
-		$kir->lang_code_iso_639_1 = 'ky';
-		$kir->lang_code_iso_639_2 = 'kir';
-		$kir->lang_code_iso_639_3 = 'kir';
-		$kir->country_code = 'kg';
-		$kir->wp_locale = 'kir';
-		$kir->slug = 'kir';
-		$kir->google_code = 'ky';
-		$kir->alphabet = 'cyrillic';
+		$ky = new GP_Locale();
+		$ky->english_name = 'Kyrgyz';
+		$ky->native_name = 'Кыргызча';
+		$ky->lang_code_iso_639_1 = 'ky';
+		$ky->lang_code_iso_639_2 = 'kir';
+		$ky->lang_code_iso_639_3 = 'kir';
+		$ky->country_code = 'kg';
+		$ky->wp_locale = 'ky_KG';
+		$ky->slug = 'ky';
+		$ky->google_code = 'ky';
+		$ky->alphabet = 'cyrillic';
+		$ky->nplurals = 1;
+		$ky->plural_expression = ‘0’;
 
 		$la = new GP_Locale();
 		$la->english_name = 'Latin';


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

<!--
Please, describe what is the status/problem before the PR.
-->
We discovered this problem when running the Lighthouse test on https://openverse.org: [Incorrect slug for Kyrgyz locale](https://github.com/WordPress/openverse/issues/5059).

`slug` and `wp_locale` for Kyrgyz locale are incorrect. This locale was last updated in [Update Kyrgyz locale information](https://github.com/GlotPress/GlotPress/pull/550), but the data used in it did not match the language editor's request.

~~Locale object also did not have pluralization data.~~ I removed it because the tests are failing

## Solution

<!--
Please, describe how this PR improves the situation.
-->

This PR updates the locale object:

| property | old value | new value |
| --- | --- | --- |
| name | `$kir` | `$kg` |
| `wp_locale` | `kir` | `ky_KG` | 
| `slug` | `kir` | `ky` | 

## Notes

The locale list used in the Google LightHouse check (see that there is no `kir` locale in the list): https://github.com/dequelabs/axe-core/blob/e8eec734b3d32e5239fccab6645ce2ce51aa2e5e/lib/core/utils/valid-langs.js

The pluralization rules: https://www.unicode.org/cldr/charts/45/supplemental/language_plural_rules.html

Data on Kyrgyz locale: https://www.localeplanet.com/icu/ky-KG/index.html