### PR TITLE
Pass explicit $escape arg to fputcsv()/fgetcsv() in glossary import/export

### DIFF
--- a/gp-includes/routes/glossary-entry.php
+++ b/gp-includes/routes/glossary-entry.php
@@ -309,11 +309,11 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 	private function print_export_file( $locale_slug, $entries ) {
 		$outstream = fopen( 'php://output', 'w' );
 
-		fputcsv( $outstream, array( 'en', $locale_slug, 'pos', 'description' ) );
+		fputcsv( $outstream, array( 'en', $locale_slug, 'pos', 'description' ), ',', '"', '' );
 
 		foreach ( $entries as $entry ) {
 			$values = array( $entry->term, $entry->translation, $entry->part_of_speech, $entry->comment );
-			fputcsv( $outstream, $values );
+			fputcsv( $outstream, $values, ',', '"', '' );
 		}
 
 		fclose( $outstream );
@@ -323,7 +323,7 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 		$f                = fopen( $file, 'r' );
 		$glossary_entries = 0;
 
-		$data = fgetcsv( $f, 0, ',' );
+		$data = fgetcsv( $f, 0, ',', '"', '' );
 
 		if ( ! is_array( $data ) ) {
 			return;
@@ -332,7 +332,7 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 			return;
 		}
 
-		while ( ( $data = fgetcsv( $f, 0, ',' ) ) !== false ) {
+		while ( ( $data = fgetcsv( $f, 0, ',', '"', '' ) ) !== false ) {
 			// We're only parsing one locale per file right now
 			if ( count( $data ) > 4 ) {
 				$data = array_splice( $data, 2, -2 );


### PR DESCRIPTION
> **Note:** This PR was generated by an AI assistant (Claude Code) and reviewed before opening. Please double-check before merging.

## Problem

PHP 8.4 emits a deprecation notice for every `fputcsv()` / `fgetcsv()` call that doesn't explicitly pass the `$escape` argument, because the default is changing in PHP 9.0:

```
PHP Deprecated: fputcsv(): the $escape parameter must be provided as its default value will change in gp-includes/routes/glossary-entry.php on line 318
```

There are four such calls in `gp-includes/routes/glossary-entry.php` — two in `print_export_file()` and two in `read_glossary_entries_from_file()` — so any GlotPress install running PHP 8.4 logs deprecation notices on every glossary CSV export and import.

## Solution

Pass `''` as the explicit `$escape` argument to all four calls. This:

- Silences the PHP 8.4 deprecation notice.
- Matches PHP 9.0's upcoming default value.
- Is RFC 4180-compliant (no extra backslash escaping, only `"` enclosure-doubling) — which is the standard format spreadsheet tools and other CSV consumers expect.

The historical default was `'\\'`, but in practice the existing enclosure (`"`) and the data being exported (glossary terms, translations, parts of speech, comments) make backslash escaping unnecessary, and matching the future default avoids needing to revisit this in PHP 9.0.

## To-do

- [x] Update both `fputcsv()` calls in `print_export_file()`.
- [x] Update both `fgetcsv()` calls in `read_glossary_entries_from_file()`.

## Testing Instructions

1. Run GlotPress on PHP 8.4 with `WP_DEBUG` and `WP_DEBUG_LOG` enabled.
2. Open a project glossary and export it as CSV.
3. Confirm no `fputcsv()` deprecation notice appears in the PHP error log, and the downloaded CSV opens correctly in a spreadsheet tool.
4. Import the just-exported CSV back into a glossary.
5. Confirm no `fgetcsv()` deprecation notice appears, and the entries round-trip correctly (term, translation, part of speech, comment).
6. Optional: spot-check a glossary entry containing a double quote — the existing `"` enclosure-doubling should continue to handle it correctly.

## Screenshots or screencast

n/a — server-side fix with no UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)