### PR TITLE
Declare user_login and user_display_name properties on GP_Glossary_Entry

### DIFF
--- a/gp-includes/things/glossary-entry.php
+++ b/gp-includes/things/glossary-entry.php
@@ -29,6 +29,8 @@ class GP_Glossary_Entry extends GP_Thing {
 	public $translation;
 	public $date_modified;
 	public $last_edited_by;
+	public $user_login;
+	public $user_display_name;
 
 
 	public function __construct( $fields = array() ) {


### PR DESCRIPTION
## Summary

`GP_Route_Glossary_Entry::glossary_entries_get()` enriches each glossary entry by assigning `user_login` and `user_display_name` from the last editor's `WP_User`. These have never been declared on `GP_Glossary_Entry`, so under PHP 8.2+ each glossary view triggers:

```
PHP Deprecated:  Creation of dynamic property GP_Glossary_Entry::$user_login is deprecated in gp-includes/routes/glossary-entry.php on line 43
PHP Deprecated:  Creation of dynamic property GP_Glossary_Entry::$user_display_name is deprecated in gp-includes/routes/glossary-entry.php on line 44
```


Declare them on the class so the warning goes away and the post-enrichment shape of the object is documented.

## Test plan

- [ ] Visit a glossary page (e.g. `/locale/<locale>/default/glossary`) and confirm the editor's login/display name still appear next to each entry.
- [ ] Tail PHP error log during the request; confirm the two deprecation lines no longer appear.