### PR TITLE
Simplify build tooling by removing Codecov integration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,7 +20,6 @@ composer.json export-ignore
 composer.lock export-ignore
 CONTRIBUTING.md export-ignore
 .wp-env.json export-ignore
-codecov.yml export-ignore
 Gruntfile.js export-ignore
 package-lock.json export-ignore
 package.json export-ignore

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test:
-    name: PHP ${{ matrix.php }}, WordPress${{ matrix.multisite && ' multisite' || '' }} ${{ matrix.wordpress }}${{ matrix.coverage && ' with coverage' || '' }}
+    name: PHP ${{ matrix.php }}, WordPress${{ matrix.multisite && ' multisite' || '' }} ${{ matrix.wordpress }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
 
@@ -40,16 +40,7 @@ jobs:
         php: [ '7.4', '8.3' ]
         wordpress: [ 'latest', 'nightly' ]
         multisite: [ false, true ]
-        coverage: [ false ]
         experimental: [ false ]
-        include:
-          # Run coverage only on latest PHP.
-          - os: ubuntu-latest
-            php: '8.3'
-            wordpress: 'latest'
-            multisite: false
-            coverage: true
-            experimental: false
 
     steps:
       - name: Check out Git repository
@@ -59,7 +50,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
           tools: composer
 
       # SVN is required by the WordPress test installer script
@@ -78,20 +69,8 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Run tests
-        if: ${{ ! matrix.coverage }}
         run: WP_MULTISITE=${{ matrix.multisite && '1' || '' }} vendor/bin/phpunit
 
       - name: Run tests for locales
-        if: ${{ ! matrix.coverage && ! matrix.multisite }}
+        if: ${{ ! matrix.multisite }}
         run: vendor/bin/phpunit --group locales
-
-      - name: Run tests with code coverage
-        if: ${{ matrix.coverage }}
-        run: vendor/bin/phpunit --coverage-clover coverage-clover-${{ github.sha }}.xml
-
-      - name: Upload coverage to Codecov
-        if: ${{ matrix.coverage }}
-        uses: codecov/codecov-action@v5
-        with:
-          file: coverage-clover-${{ github.sha }}.xml
-          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![GlotPress](.github/banner.png)
 
-[![PHPUnit Tests](https://github.com/GlotPress/GlotPress/actions/workflows/phpunit.yml/badge.svg?branch=develop)](https://github.com/GlotPress/GlotPress/actions/workflows/phpunit.yml) [![codecov.io](https://codecov.io/github/GlotPress/GlotPress/coverage.svg?branch=develop)](https://codecov.io/github/GlotPress/GlotPress?branch=develop)
+[![PHPUnit Tests](https://github.com/GlotPress/GlotPress/actions/workflows/phpunit.yml/badge.svg?branch=develop)](https://github.com/GlotPress/GlotPress/actions/workflows/phpunit.yml)
 
 # GlotPress
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,0 @@
-coverage:
-  status:
-    patch: false
-    changes: false
-    project:
-      default:
-        target: auto
-comment: off


### PR DESCRIPTION
## Summary
- Removes the `codecov/codecov-action` upload step and the dedicated coverage matrix variant in the PHPUnit workflow — coverage was only generated to feed Codecov, so the extra CI run is now obsolete.
- Deletes the root `codecov.yml`, its `.gitattributes` `export-ignore` entry, and the Codecov badge from `README.md`.
- Leaves the `@codeCoverageIgnore` annotation in `gp-includes/formats/format-php.php` untouched (it is a PHPUnit annotation, not a Codecov one) and the historical CHANGELOG entry intact.

## Test plan
- [x] PHPUnit workflow runs green on this PR without the Codecov step.
- [x] README renders without a broken badge.