### PR TITLE
Import: approve identical waiting translation instead of replacing it

### DIFF
--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -306,8 +306,9 @@ class GP_Translation_Set extends GP_Thing {
 
 		$load_existing_translations( 'current' );
 
-		$translations_added      = 0;
-		$created_translation_ids = array();
+		$translations_added       = 0;
+		$created_translation_ids  = array();
+		$approved_translation_ids = array();
 		foreach ( $translations->entries as $entry ) {
 			if ( empty( $entry->translations ) ) {
 				continue;
@@ -370,33 +371,36 @@ class GP_Translation_Set extends GP_Thing {
 				 * Only once the filter above has agreed that the existing translation may be
 				 * replaced, because approving a waiting translation supersedes it as well.
 				 */
-				if ( $create && 'current' === $entry->status
-					&& $this->approve_matching_waiting_translation( $translated->original_id, $entry, $locale, $translations ) ) {
-					/*
-					 * An existing waiting translation was approved, so nothing was created and its
-					 * ID is not added to $created_translation_ids, which is documented as the rows
-					 * created by this import. The approved row keeps the original translator's
-					 * user_id, so reporting it would credit that translator and not the importer.
-					 * Whether the hook should expose approvals too, in a separate argument, is an
-					 * open question for the maintainer rather than a settled one.
-					 */
-					$translations_added += 1;
-					continue;
+				if ( $create && 'current' === $entry->status ) {
+					$approved = $this->approve_matching_waiting_translation( $translated->original_id, $entry, $locale, $translations );
+					if ( $approved ) {
+						/*
+						 * An approval is not a creation, so the row is reported through
+						 * $approved_translation_ids and not through $created_translation_ids. It
+						 * keeps the original translator's user_id, so a consumer crediting the
+						 * import credits that translator and not the importer.
+						 */
+						$approved_translation_ids[] = $approved->id;
+						$translations_added        += 1;
+						continue;
+					}
 				}
 			} else {
 				// we don't have the string translated, let's see if the original is there
 				$original = GP::$original->by_project_id_and_entry( $this->project->id, $entry, '+active' );
 				if ( $original ) {
-					if ( 'current' === $entry->status
-						&& $this->approve_matching_waiting_translation( $original->id, $entry, $locale, $translations ) ) {
-						/*
-						 * Nothing was created, so the approved ID is not added to
-						 * $created_translation_ids, for the reasons noted at the other call site.
-						 * No existing current translation is overwritten here, so
-						 * gp_translation_set_import_over_existing does not apply.
-						 */
-						$translations_added += 1;
-						continue;
+					if ( 'current' === $entry->status ) {
+						$approved = $this->approve_matching_waiting_translation( $original->id, $entry, $locale, $translations );
+						if ( $approved ) {
+							/*
+							 * Reported through $approved_translation_ids, as at the other call site.
+							 * No existing current translation is overwritten here, so
+							 * gp_translation_set_import_over_existing does not apply.
+							 */
+							$approved_translation_ids[] = $approved->id;
+							$translations_added        += 1;
+							continue;
+						}
 					}
 
 					$entry->original_id = $original->id;
@@ -428,11 +432,15 @@ class GP_Translation_Set extends GP_Thing {
 		 *
 		 * @since 1.0.0
 		 * @since 4.1.0 Added the `$created_translation_ids` parameter.
+		 * @since 4.2.0 Added the `$approved_translation_ids` parameter.
 		 *
-		 * @param int   $translation_set         The ID of the translation set the import was made into.
-		 * @param int[] $created_translation_ids The IDs of the translations created during the import.
+		 * @param int   $translation_set          The ID of the translation set the import was made into.
+		 * @param int[] $created_translation_ids  The IDs of the translations created during the import.
+		 * @param int[] $approved_translation_ids The IDs of the waiting translations approved during the import.
+		 *                                        These were not created by the import and keep the original
+		 *                                        translator's credit.
 		 */
-		do_action( 'gp_translations_imported', $this->id, $created_translation_ids );
+		do_action( 'gp_translations_imported', $this->id, $created_translation_ids, $approved_translation_ids );
 
 		return $translations_added;
 	}

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -357,16 +357,6 @@ class GP_Translation_Set extends GP_Thing {
 				$entry->original_id      = $translated->original_id;
 				$translated_is_different = array_pad( $entry->translations, $locale->nplurals, null ) !== $translated->translations;
 
-				if ( 'current' === $entry->status && $translated_is_different
-					&& $this->approve_matching_waiting_translation( $translated->original_id, $entry, $locale, $translations ) ) {
-					/*
-					 * An existing waiting translation was approved. Nothing was created, so its ID
-					 * is deliberately not added to $created_translation_ids, which lists new rows only.
-					 */
-					$translations_added += 1;
-					continue;
-				}
-
 				/**
 				 * Filter whether to import over an existing translation on a translation set.
 				 *
@@ -375,6 +365,24 @@ class GP_Translation_Set extends GP_Thing {
 				 * @param bool $import_over Import over an existing translation.
 				 */
 				$create = apply_filters( 'gp_translation_set_import_over_existing', $translated_is_different );
+
+				/*
+				 * Only once the filter above has agreed that the existing translation may be
+				 * replaced, because approving a waiting translation supersedes it as well.
+				 */
+				if ( $create && 'current' === $entry->status
+					&& $this->approve_matching_waiting_translation( $translated->original_id, $entry, $locale, $translations ) ) {
+					/*
+					 * An existing waiting translation was approved, so nothing was created and its
+					 * ID is not added to $created_translation_ids, which is documented as the rows
+					 * created by this import. The approved row keeps the original translator's
+					 * user_id, so reporting it would credit that translator and not the importer.
+					 * Whether the hook should expose approvals too, in a separate argument, is an
+					 * open question for the maintainer rather than a settled one.
+					 */
+					$translations_added += 1;
+					continue;
+				}
 			} else {
 				// we don't have the string translated, let's see if the original is there
 				$original = GP::$original->by_project_id_and_entry( $this->project->id, $entry, '+active' );
@@ -382,8 +390,10 @@ class GP_Translation_Set extends GP_Thing {
 					if ( 'current' === $entry->status
 						&& $this->approve_matching_waiting_translation( $original->id, $entry, $locale, $translations ) ) {
 						/*
-						 * An existing waiting translation was approved. Nothing was created, so its ID
-						 * is deliberately not added to $created_translation_ids, which lists new rows only.
+						 * Nothing was created, so the approved ID is not added to
+						 * $created_translation_ids, for the reasons noted at the other call site.
+						 * No existing current translation is overwritten here, so
+						 * gp_translation_set_import_over_existing does not apply.
 						 */
 						$translations_added += 1;
 						continue;
@@ -435,7 +445,7 @@ class GP_Translation_Set extends GP_Thing {
 	 * collection is keyed by context and singular and would therefore keep only one waiting
 	 * translation per original.
 	 *
-	 * @since 4.1.0
+	 * @since 4.2.0
 	 *
 	 * @param int               $original_id  The ID of the original the entry belongs to.
 	 * @param Translation_Entry $entry        Translation entry object to import.
@@ -449,7 +459,7 @@ class GP_Translation_Set extends GP_Thing {
 		 * waiting translation should approve the waiting translation instead of
 		 * creating a new one, preserving the original translator's credit.
 		 *
-		 * @since 4.1.0
+		 * @since 4.2.0
 		 *
 		 * @param bool              $approve_waiting Approve the matching waiting translation. Default true.
 		 * @param Translation_Entry $entry           Translation entry object to import.

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -352,34 +352,20 @@ class GP_Translation_Set extends GP_Thing {
 				$translated = $existing_translations['current']->translate_entry( $entry );
 			}
 
-			if ( 'current' === $entry->status && ! $translated ) {
-				/**
-				 * Filter whether an imported translation that is identical to an existing
-				 * waiting translation should approve the waiting translation instead of
-				 * creating a new one, preserving the original translator's credit.
-				 *
-				 * @since 4.1.0
-				 *
-				 * @param bool              $approve_waiting Approve the matching waiting translation. Default true.
-				 * @param Translation_Entry $entry           Translation entry object to import.
-				 * @param Translations      $translations    Translations collection.
-				 */
-				if ( apply_filters( 'gp_translation_set_import_approve_waiting', true, $entry, $translations ) ) {
-					$waiting = $load_existing_translations( 'waiting' )->translate_entry( $entry );
-					if ( $waiting && array_pad( $entry->translations, $locale->nplurals, null ) === $waiting->translations ) {
-						$waiting_translation = GP::$translation->get( $waiting->id );
-						if ( $waiting_translation && $waiting_translation->set_status( 'current' ) ) {
-							$translations_added += 1;
-							continue;
-						}
-					}
-				}
-			}
-
 			if ( $translated ) {
 				// We have the same string translated, so create a new one if they don't match.
 				$entry->original_id      = $translated->original_id;
 				$translated_is_different = array_pad( $entry->translations, $locale->nplurals, null ) !== $translated->translations;
+
+				if ( 'current' === $entry->status && $translated_is_different
+					&& $this->approve_matching_waiting_translation( $translated->original_id, $entry, $locale, $translations ) ) {
+					/*
+					 * An existing waiting translation was approved. Nothing was created, so its ID
+					 * is deliberately not added to $created_translation_ids, which lists new rows only.
+					 */
+					$translations_added += 1;
+					continue;
+				}
 
 				/**
 				 * Filter whether to import over an existing translation on a translation set.
@@ -393,6 +379,16 @@ class GP_Translation_Set extends GP_Thing {
 				// we don't have the string translated, let's see if the original is there
 				$original = GP::$original->by_project_id_and_entry( $this->project->id, $entry, '+active' );
 				if ( $original ) {
+					if ( 'current' === $entry->status
+						&& $this->approve_matching_waiting_translation( $original->id, $entry, $locale, $translations ) ) {
+						/*
+						 * An existing waiting translation was approved. Nothing was created, so its ID
+						 * is deliberately not added to $created_translation_ids, which lists new rows only.
+						 */
+						$translations_added += 1;
+						continue;
+					}
+
 					$entry->original_id = $original->id;
 					$create             = true;
 				}
@@ -429,6 +425,79 @@ class GP_Translation_Set extends GP_Thing {
 		do_action( 'gp_translations_imported', $this->id, $created_translation_ids );
 
 		return $translations_added;
+	}
+
+	/**
+	 * Approves an existing waiting translation that is identical to an imported entry.
+	 *
+	 * Keeps the original translator's credit instead of creating a duplicate row for the importer.
+	 * The waiting translations of the original are looked up directly, because a `Translations`
+	 * collection is keyed by context and singular and would therefore keep only one waiting
+	 * translation per original.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param int               $original_id  The ID of the original the entry belongs to.
+	 * @param Translation_Entry $entry        Translation entry object to import.
+	 * @param GP_Locale         $locale       The locale of the translation set.
+	 * @param Translations      $translations Translations collection being imported.
+	 * @return GP_Translation|null The approved translation, or null if none was approved.
+	 */
+	private function approve_matching_waiting_translation( $original_id, $entry, $locale, $translations ) {
+		/**
+		 * Filter whether an imported translation that is identical to an existing
+		 * waiting translation should approve the waiting translation instead of
+		 * creating a new one, preserving the original translator's credit.
+		 *
+		 * @since 4.1.0
+		 *
+		 * @param bool              $approve_waiting Approve the matching waiting translation. Default true.
+		 * @param Translation_Entry $entry           Translation entry object to import.
+		 * @param Translations      $translations    Translations collection.
+		 */
+		if ( ! apply_filters( 'gp_translation_set_import_approve_waiting', true, $entry, $translations ) ) {
+			return null;
+		}
+
+		/*
+		 * Approving goes through set_status( 'current' ), which requires an approve-capable
+		 * current user. Without a current user, for example a WP-CLI import, nothing can be
+		 * approved, so skip the lookup and let the caller create a new translation as before.
+		 */
+		if ( ! get_current_user_id() ) {
+			return null;
+		}
+
+		$wanted       = array_pad( $entry->translations, $locale->nplurals, null );
+		$waiting_rows = GP::$translation->find_many(
+			array(
+				'translation_set_id' => $this->id,
+				'original_id'        => $original_id,
+				'status'             => 'waiting',
+			),
+			// Oldest suggestion first, so which translator gets credited is deterministic.
+			'date_added ASC, id ASC'
+		);
+
+		foreach ( $waiting_rows as $waiting_row ) {
+			// translations() is always padded to the maximum number of plurals, the locale decides how many count.
+			if ( array_slice( $waiting_row->translations(), 0, $locale->nplurals ) !== $wanted ) {
+				continue;
+			}
+
+			if ( ! $waiting_row->set_status( 'current' ) ) {
+				/*
+				 * The current user is not allowed to approve this translation, for example a
+				 * translator importing their own suggestion. Keep the pre-existing behaviour
+				 * and let the caller create a new translation.
+				 */
+				return null;
+			}
+
+			return $waiting_row;
+		}
+
+		return null;
 	}
 
 	/**

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -283,19 +283,28 @@ class GP_Translation_Set extends GP_Thing {
 
 		$existing_translations = array();
 
-		$current_translations_list        = GP::$translation->for_translation(
-			$this->project,
-			$this,
-			'no-limit',
-			array(
-				'status' => 'current',
-			)
-		);
-		$existing_translations['current'] = new Translations();
-		foreach ( $current_translations_list as $entry ) {
-			$existing_translations['current']->add_entry( $entry );
-		}
-		unset( $current_translations_list );
+		$load_existing_translations = function ( $status ) use ( &$existing_translations ) {
+			if ( ! isset( $existing_translations[ $status ] ) ) {
+				$existing_translations_list = GP::$translation->for_translation(
+					$this->project,
+					$this,
+					'no-limit',
+					array(
+						'status' => $status,
+					)
+				);
+
+				$existing_translations[ $status ] = new Translations();
+				foreach ( $existing_translations_list as $existing_entry ) {
+					$existing_translations[ $status ]->add_entry( $existing_entry );
+				}
+				unset( $existing_translations_list );
+			}
+
+			return $existing_translations[ $status ];
+		};
+
+		$load_existing_translations( 'current' );
 
 		$translations_added      = 0;
 		$created_translation_ids = array();
@@ -336,28 +345,35 @@ class GP_Translation_Set extends GP_Thing {
 				$entry->status = 'waiting';
 			}
 
-			// Lazy load other entries.
-			if ( ! isset( $existing_translations[ $entry->status ] ) ) {
-				$existing_translations_list              = GP::$translation->for_translation(
-					$this->project,
-					$this,
-					'no-limit',
-					array(
-						'status' => $entry->status,
-					)
-				);
-				$existing_translations[ $entry->status ] = new Translations();
-				foreach ( $existing_translations_list as $_entry ) {
-					$existing_translations[ $entry->status ]->add_entry( $_entry );
-				}
-				unset( $existing_translations_list );
-			}
-
 			$create     = false;
-			$translated = $existing_translations[ $entry->status ]->translate_entry( $entry );
+			$translated = $load_existing_translations( $entry->status )->translate_entry( $entry );
 			if ( 'current' !== $entry->status && ! $translated ) {
 				// Don't create an entry if it already exists as current.
 				$translated = $existing_translations['current']->translate_entry( $entry );
+			}
+
+			if ( 'current' === $entry->status && ! $translated ) {
+				/**
+				 * Filter whether an imported translation that is identical to an existing
+				 * waiting translation should approve the waiting translation instead of
+				 * creating a new one, preserving the original translator's credit.
+				 *
+				 * @since 4.1.0
+				 *
+				 * @param bool              $approve_waiting Approve the matching waiting translation. Default true.
+				 * @param Translation_Entry $entry           Translation entry object to import.
+				 * @param Translations      $translations    Translations collection.
+				 */
+				if ( apply_filters( 'gp_translation_set_import_approve_waiting', true, $entry, $translations ) ) {
+					$waiting = $load_existing_translations( 'waiting' )->translate_entry( $entry );
+					if ( $waiting && array_pad( $entry->translations, $locale->nplurals, null ) === $waiting->translations ) {
+						$waiting_translation = GP::$translation->get( $waiting->id );
+						if ( $waiting_translation && $waiting_translation->set_status( 'current' ) ) {
+							$translations_added += 1;
+							continue;
+						}
+					}
+				}
 			}
 
 			if ( $translated ) {

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -503,6 +503,25 @@ class GP_Translation_Set extends GP_Thing {
 				continue;
 			}
 
+			/*
+			 * The create path filters the status a second time right before creating a row, with
+			 * the translation that is already there. Approving supersedes that creation, so give
+			 * the filter the same say here, passing the waiting translation that is about to be
+			 * approved as the previous translation.
+			 *
+			 * This filter is documented in gp-includes/things/translation-set.php.
+			 */
+			$entry->status = apply_filters( 'gp_translation_set_import_status', $entry->status, $entry, $waiting_row );
+
+			if ( 'current' !== $entry->status ) {
+				/*
+				 * The filter downgraded the imported string, so the waiting translation must not
+				 * be approved. The caller falls through to the normal create path, which stores
+				 * the entry with the status the filter asked for.
+				 */
+				return null;
+			}
+
 			if ( ! $waiting_row->set_status( 'current' ) ) {
 				/*
 				 * The current user is not allowed to approve this translation, for example a

--- a/tests/phpunit/testcases/test_import.php
+++ b/tests/phpunit/testcases/test_import.php
@@ -680,12 +680,12 @@ class GP_Import extends GP_UnitTestCase {
 	}
 
 	/**
-	 * Approved waiting translations are not created, so their IDs are not passed to
-	 * `gp_translations_imported`.
+	 * An approved waiting translation was not created, so `gp_translations_imported` reports it
+	 * through `$approved_translation_ids` and not through `$created_translation_ids`.
 	 *
 	 * @ticket gh-710
 	 */
-	function test_gp_translations_imported_excludes_approved_waiting_ids() {
+	function test_gp_translations_imported_reports_approved_waiting_ids_separately() {
 		$translator = $this->factory->user->create();
 		$validator  = $this->factory->user->create();
 
@@ -704,7 +704,7 @@ class GP_Import extends GP_UnitTestCase {
 			'singular'   => 'Good morning',
 		) );
 
-		$this->factory->translation->create( array(
+		$waiting = $this->factory->translation->create( array(
 			'original_id'        => $original->id,
 			'translation_set_id' => $set->id,
 			'translation_0'      => 'Guten Morgen',
@@ -718,19 +718,96 @@ class GP_Import extends GP_UnitTestCase {
 			'translations' => array( 'Guten Morgen' ),
 		) ) );
 
-		$created_translation_ids = null;
-		$closure = function( $set_id, $ids = null ) use ( &$created_translation_ids ) {
-			$created_translation_ids = $ids;
+		$created_translation_ids  = null;
+		$approved_translation_ids = null;
+		$closure = function( $set_id, $created = null, $approved = null ) use ( &$created_translation_ids, &$approved_translation_ids ) {
+			$created_translation_ids  = $created;
+			$approved_translation_ids = $approved;
 		};
-		add_action( 'gp_translations_imported', $closure, 10, 2 );
+		add_action( 'gp_translations_imported', $closure, 10, 3 );
 
 		wp_set_current_user( $validator );
 		$translations_added = $set->import( $translations, 'current' );
 
 		remove_action( 'gp_translations_imported', $closure );
 
-		$this->assertSame( array(), $created_translation_ids, 'An approval creates nothing, so no ID is reported.' );
+		$this->assertSame( array(), $created_translation_ids, 'An approval creates nothing, so no ID is reported as created.' );
+		$this->assertSame( array( $waiting->id ), $approved_translation_ids, 'The approved translation is reported separately.' );
+		$this->assertContainsOnly( 'int', $approved_translation_ids );
 		$this->assertSame( 1, $translations_added, 'The approval still counts towards the imported total.' );
+	}
+
+	/**
+	 * A single import can both create and approve, and `gp_translations_imported` keeps the two
+	 * sets apart so that a credit consumer can tell them apart again.
+	 *
+	 * @ticket gh-710
+	 */
+	function test_gp_translations_imported_reports_created_and_approved_separately() {
+		$translator = $this->factory->user->create();
+		$validator  = $this->factory->user->create();
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		GP::$validator_permission->create( array(
+			'user_id'     => $validator,
+			'action'      => 'approve',
+			'project_id'  => $set->project_id,
+			'locale_slug' => $set->locale,
+			'set_slug'    => $set->slug,
+		) );
+
+		$waiting_original = $this->factory->original->create( array(
+			'project_id' => $set->project_id,
+			'status'     => '+active',
+			'singular'   => 'Good morning',
+		) );
+
+		$untranslated_original = $this->factory->original->create( array(
+			'project_id' => $set->project_id,
+			'status'     => '+active',
+			'singular'   => 'Good evening',
+		) );
+
+		$waiting = $this->factory->translation->create( array(
+			'original_id'        => $waiting_original->id,
+			'translation_set_id' => $set->id,
+			'translation_0'      => 'Guten Morgen',
+			'user_id'            => $translator,
+			'status'             => 'waiting',
+		) );
+
+		$translations = new Translations();
+		$translations->add_entry( new Translation_Entry( array(
+			'singular'     => 'Good morning',
+			'translations' => array( 'Guten Morgen' ),
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular'     => 'Good evening',
+			'translations' => array( 'Guten Abend' ),
+		) ) );
+
+		$created_translation_ids  = null;
+		$approved_translation_ids = null;
+		$closure = function( $set_id, $created = null, $approved = null ) use ( &$created_translation_ids, &$approved_translation_ids ) {
+			$created_translation_ids  = $created;
+			$approved_translation_ids = $approved;
+		};
+		add_action( 'gp_translations_imported', $closure, 10, 3 );
+
+		wp_set_current_user( $validator );
+		$translations_added = $set->import( $translations, 'current' );
+
+		remove_action( 'gp_translations_imported', $closure );
+
+		$created = GP::$translation->find_one( array(
+			'translation_set_id' => $set->id,
+			'original_id'        => $untranslated_original->id,
+		) );
+
+		$this->assertSame( array( $created->id ), $created_translation_ids, 'Only the new row is reported as created.' );
+		$this->assertSame( array( $waiting->id ), $approved_translation_ids, 'Only the approved row is reported as approved.' );
+		$this->assertSame( array(), array_intersect( $created_translation_ids, $approved_translation_ids ), 'The two sets are disjoint.' );
+		$this->assertSame( 2, $translations_added, 'Both entries count towards the imported total.' );
 	}
 
 	/**

--- a/tests/phpunit/testcases/test_import.php
+++ b/tests/phpunit/testcases/test_import.php
@@ -262,8 +262,13 @@ class GP_Import extends GP_UnitTestCase {
 		$validator  = $this->factory->user->create();
 
 		$set = $this->factory->translation_set->create_with_project_and_locale();
-		GP::$validator_permission->create( array( 'user_id' => $validator, 'action' => 'approve',
-		                                          'project_id' => $set->project_id, 'locale_slug' => $set->locale, 'set_slug' => $set->slug ) );
+		GP::$validator_permission->create( array(
+			'user_id'     => $validator,
+			'action'      => 'approve',
+			'project_id'  => $set->project_id,
+			'locale_slug' => $set->locale,
+			'set_slug'    => $set->slug,
+		) );
 
 		$original = $this->factory->original->create( array(
 			'project_id' => $set->project_id,
@@ -300,6 +305,361 @@ class GP_Import extends GP_UnitTestCase {
 	}
 
 	/**
+	 * An original that is already translated must still approve an identical waiting suggestion
+	 * instead of creating a third row credited to the importer.
+	 *
+	 * @ticket gh-710
+	 */
+	function test_import_identical_to_waiting_approves_when_original_already_current() {
+		$translator     = $this->factory->user->create();
+		$old_translator = $this->factory->user->create();
+		$validator      = $this->factory->user->create();
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		GP::$validator_permission->create( array(
+			'user_id'     => $validator,
+			'action'      => 'approve',
+			'project_id'  => $set->project_id,
+			'locale_slug' => $set->locale,
+			'set_slug'    => $set->slug,
+		) );
+
+		$original = $this->factory->original->create( array(
+			'project_id' => $set->project_id,
+			'status'     => '+active',
+			'singular'   => 'Good morning',
+		) );
+
+		$existing_current = $this->factory->translation->create( array(
+			'original_id'        => $original->id,
+			'translation_set_id' => $set->id,
+			'translation_0'      => 'Guten Tag',
+			'user_id'            => $old_translator,
+			'status'             => 'current',
+		) );
+
+		$waiting = $this->factory->translation->create( array(
+			'original_id'        => $original->id,
+			'translation_set_id' => $set->id,
+			'translation_0'      => 'Guten Morgen',
+			'user_id'            => $translator,
+			'status'             => 'waiting',
+		) );
+
+		$translations = new Translations();
+		$translations->add_entry( new Translation_Entry( array(
+			'singular'     => 'Good morning',
+			'translations' => array( 'Guten Morgen' ),
+		) ) );
+
+		wp_set_current_user( $validator );
+		$set->import( $translations, 'current' );
+
+		$current = GP::$translation->find_one( array(
+			'translation_set_id' => $set->id,
+			'original_id'        => $original->id,
+			'status'             => 'current',
+		) );
+
+		$this->assertEquals( $waiting->id, $current->id, 'The waiting translation should have been approved, not replaced.' );
+		$this->assertEquals( $translator, (int) $current->user_id, 'Credit should remain with the original translator.' );
+		$this->assertEquals( $validator, (int) $current->user_id_last_modified, 'The importer should be recorded as approver.' );
+
+		$superseded = GP::$translation->get( $existing_current->id );
+		$this->assertEquals( 'old', $superseded->status, 'The previously current translation should have been superseded.' );
+
+		$all = GP::$translation->find_many( array(
+			'translation_set_id' => $set->id,
+			'original_id'        => $original->id,
+		) );
+		$this->assertCount( 2, $all, 'No third translation should have been created.' );
+	}
+
+	/**
+	 * The waiting translations of an original are compared one by one, so a matching suggestion
+	 * is found even when the original carries more than one waiting translation.
+	 *
+	 * @ticket gh-710
+	 */
+	function test_import_matches_waiting_translation_among_several_of_same_original() {
+		$translator_a = $this->factory->user->create();
+		$translator_b = $this->factory->user->create();
+		$validator    = $this->factory->user->create();
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		GP::$validator_permission->create( array(
+			'user_id'     => $validator,
+			'action'      => 'approve',
+			'project_id'  => $set->project_id,
+			'locale_slug' => $set->locale,
+			'set_slug'    => $set->slug,
+		) );
+
+		$original = $this->factory->original->create( array(
+			'project_id' => $set->project_id,
+			'status'     => '+active',
+			'singular'   => 'Good morning',
+		) );
+
+		/*
+		 * The matching suggestion is added first on purpose: a Translations collection is keyed
+		 * by context and singular, so it keeps only the last waiting row of the original and the
+		 * earlier matching one would never be seen.
+		 */
+		$waiting_a = $this->factory->translation->create( array(
+			'original_id'        => $original->id,
+			'translation_set_id' => $set->id,
+			'translation_0'      => 'Guten Morgen',
+			'user_id'            => $translator_a,
+			'status'             => 'waiting',
+		) );
+
+		$waiting_b = $this->factory->translation->create( array(
+			'original_id'        => $original->id,
+			'translation_set_id' => $set->id,
+			'translation_0'      => 'Moin',
+			'user_id'            => $translator_b,
+			'status'             => 'waiting',
+		) );
+
+		$translations = new Translations();
+		$translations->add_entry( new Translation_Entry( array(
+			'singular'     => 'Good morning',
+			'translations' => array( 'Guten Morgen' ),
+		) ) );
+
+		wp_set_current_user( $validator );
+		$set->import( $translations, 'current' );
+
+		$current = GP::$translation->find_one( array(
+			'translation_set_id' => $set->id,
+			'original_id'        => $original->id,
+			'status'             => 'current',
+		) );
+
+		$this->assertEquals( $waiting_a->id, $current->id, 'The matching waiting translation should have been approved.' );
+		$this->assertEquals( $translator_a, (int) $current->user_id, 'Credit should remain with the matching translator.' );
+
+		$all = GP::$translation->find_many( array(
+			'translation_set_id' => $set->id,
+			'original_id'        => $original->id,
+		) );
+		$this->assertCount( 2, $all, 'No new translation should have been created.' );
+
+		// Approving demotes every other waiting translation of the original, exactly like the UI does.
+		$other = GP::$translation->get( $waiting_b->id );
+		$this->assertEquals( 'old', $other->status );
+	}
+
+	/**
+	 * The plural forms of a waiting translation are compared up to the number of plurals of the locale.
+	 *
+	 * @ticket gh-710
+	 */
+	function test_import_identical_to_waiting_approves_plural_string() {
+		$translator = $this->factory->user->create();
+		$validator  = $this->factory->user->create();
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		GP::$validator_permission->create( array(
+			'user_id'     => $validator,
+			'action'      => 'approve',
+			'project_id'  => $set->project_id,
+			'locale_slug' => $set->locale,
+			'set_slug'    => $set->slug,
+		) );
+
+		$original = $this->factory->original->create( array(
+			'project_id' => $set->project_id,
+			'status'     => '+active',
+			'singular'   => 'One comment',
+			'plural'     => '%d comments',
+		) );
+
+		$waiting = $this->factory->translation->create( array(
+			'original_id'        => $original->id,
+			'translation_set_id' => $set->id,
+			'translation_0'      => 'Ein Kommentar',
+			'translation_1'      => '%d Kommentare',
+			'user_id'            => $translator,
+			'status'             => 'waiting',
+		) );
+
+		$translations = new Translations();
+		$translations->add_entry( new Translation_Entry( array(
+			'singular'     => 'One comment',
+			'plural'       => '%d comments',
+			'translations' => array( 'Ein Kommentar', '%d Kommentare' ),
+		) ) );
+
+		wp_set_current_user( $validator );
+		$set->import( $translations, 'current' );
+
+		$current = GP::$translation->find_one( array(
+			'translation_set_id' => $set->id,
+			'original_id'        => $original->id,
+			'status'             => 'current',
+		) );
+
+		$this->assertEquals( $waiting->id, $current->id, 'The waiting plural translation should have been approved.' );
+		$this->assertEquals( $translator, (int) $current->user_id );
+	}
+
+	/**
+	 * The `gp_translation_set_import_approve_waiting` filter opts out of the approval.
+	 *
+	 * @ticket gh-710
+	 */
+	function test_import_approve_waiting_filter_false_creates_new_translation() {
+		$translator = $this->factory->user->create();
+		$validator  = $this->factory->user->create();
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		GP::$validator_permission->create( array(
+			'user_id'     => $validator,
+			'action'      => 'approve',
+			'project_id'  => $set->project_id,
+			'locale_slug' => $set->locale,
+			'set_slug'    => $set->slug,
+		) );
+
+		$original = $this->factory->original->create( array(
+			'project_id' => $set->project_id,
+			'status'     => '+active',
+			'singular'   => 'Good morning',
+		) );
+
+		$waiting = $this->factory->translation->create( array(
+			'original_id'        => $original->id,
+			'translation_set_id' => $set->id,
+			'translation_0'      => 'Guten Morgen',
+			'user_id'            => $translator,
+			'status'             => 'waiting',
+		) );
+
+		$translations = new Translations();
+		$translations->add_entry( new Translation_Entry( array(
+			'singular'     => 'Good morning',
+			'translations' => array( 'Guten Morgen' ),
+		) ) );
+
+		wp_set_current_user( $validator );
+		add_filter( 'gp_translation_set_import_approve_waiting', '__return_false' );
+		$set->import( $translations, 'current' );
+		remove_filter( 'gp_translation_set_import_approve_waiting', '__return_false' );
+
+		$current = GP::$translation->find_one( array(
+			'translation_set_id' => $set->id,
+			'original_id'        => $original->id,
+			'status'             => 'current',
+		) );
+
+		$this->assertNotEquals( $waiting->id, $current->id, 'A new translation should have been created.' );
+		$this->assertEquals( $validator, (int) $current->user_id );
+
+		$superseded = GP::$translation->get( $waiting->id );
+		$this->assertEquals( 'old', $superseded->status );
+	}
+
+	/**
+	 * Approving goes through `set_status( 'current' )`, so an import without a current user,
+	 * a WP-CLI import for example, keeps the previous behaviour of creating a new translation.
+	 *
+	 * @ticket gh-710
+	 */
+	function test_import_without_current_user_creates_new_translation() {
+		$translator = $this->factory->user->create();
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+
+		$original = $this->factory->original->create( array(
+			'project_id' => $set->project_id,
+			'status'     => '+active',
+			'singular'   => 'Good morning',
+		) );
+
+		$waiting = $this->factory->translation->create( array(
+			'original_id'        => $original->id,
+			'translation_set_id' => $set->id,
+			'translation_0'      => 'Guten Morgen',
+			'user_id'            => $translator,
+			'status'             => 'waiting',
+		) );
+
+		$translations = new Translations();
+		$translations->add_entry( new Translation_Entry( array(
+			'singular'     => 'Good morning',
+			'translations' => array( 'Guten Morgen' ),
+		) ) );
+
+		wp_set_current_user( 0 );
+		$set->import( $translations, 'current' );
+
+		$still_waiting = GP::$translation->get( $waiting->id );
+		$this->assertEquals( 'waiting', $still_waiting->status, 'Without a current user nothing can be approved.' );
+
+		$all = GP::$translation->find_many( array(
+			'translation_set_id' => $set->id,
+			'original_id'        => $original->id,
+		) );
+		$this->assertCount( 2, $all, 'A new translation should have been created.' );
+	}
+
+	/**
+	 * Approved waiting translations are not created, so their IDs are not passed to
+	 * `gp_translations_imported`.
+	 *
+	 * @ticket gh-710
+	 */
+	function test_gp_translations_imported_excludes_approved_waiting_ids() {
+		$translator = $this->factory->user->create();
+		$validator  = $this->factory->user->create();
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		GP::$validator_permission->create( array(
+			'user_id'     => $validator,
+			'action'      => 'approve',
+			'project_id'  => $set->project_id,
+			'locale_slug' => $set->locale,
+			'set_slug'    => $set->slug,
+		) );
+
+		$original = $this->factory->original->create( array(
+			'project_id' => $set->project_id,
+			'status'     => '+active',
+			'singular'   => 'Good morning',
+		) );
+
+		$this->factory->translation->create( array(
+			'original_id'        => $original->id,
+			'translation_set_id' => $set->id,
+			'translation_0'      => 'Guten Morgen',
+			'user_id'            => $translator,
+			'status'             => 'waiting',
+		) );
+
+		$translations = new Translations();
+		$translations->add_entry( new Translation_Entry( array(
+			'singular'     => 'Good morning',
+			'translations' => array( 'Guten Morgen' ),
+		) ) );
+
+		$created_translation_ids = null;
+		$closure = function( $set_id, $ids = null ) use ( &$created_translation_ids ) {
+			$created_translation_ids = $ids;
+		};
+		add_action( 'gp_translations_imported', $closure, 10, 2 );
+
+		wp_set_current_user( $validator );
+		$translations_added = $set->import( $translations, 'current' );
+
+		remove_action( 'gp_translations_imported', $closure );
+
+		$this->assertSame( array(), $created_translation_ids, 'An approval creates nothing, so no ID is reported.' );
+		$this->assertSame( 1, $translations_added, 'The approval still counts towards the imported total.' );
+	}
+
+	/**
 	 * @ticket gh-710
 	 */
 	function test_import_different_from_waiting_still_creates_new_translation() {
@@ -307,8 +667,13 @@ class GP_Import extends GP_UnitTestCase {
 		$validator  = $this->factory->user->create();
 
 		$set = $this->factory->translation_set->create_with_project_and_locale();
-		GP::$validator_permission->create( array( 'user_id' => $validator, 'action' => 'approve',
-		                                          'project_id' => $set->project_id, 'locale_slug' => $set->locale, 'set_slug' => $set->slug ) );
+		GP::$validator_permission->create( array(
+			'user_id'     => $validator,
+			'action'      => 'approve',
+			'project_id'  => $set->project_id,
+			'locale_slug' => $set->locale,
+			'set_slug'    => $set->slug,
+		) );
 
 		$original = $this->factory->original->create( array(
 			'project_id' => $set->project_id,

--- a/tests/phpunit/testcases/test_import.php
+++ b/tests/phpunit/testcases/test_import.php
@@ -254,6 +254,96 @@ class GP_Import extends GP_UnitTestCase {
 	}
 
 
+	/**
+	 * @ticket gh-710
+	 */
+	function test_import_identical_to_waiting_approves_and_keeps_translator_credit() {
+		$translator = $this->factory->user->create();
+		$validator  = $this->factory->user->create();
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		GP::$validator_permission->create( array( 'user_id' => $validator, 'action' => 'approve',
+		                                          'project_id' => $set->project_id, 'locale_slug' => $set->locale, 'set_slug' => $set->slug ) );
+
+		$original = $this->factory->original->create( array(
+			'project_id' => $set->project_id,
+			'status'     => '+active',
+			'singular'   => 'Good morning',
+		) );
+
+		$waiting = $this->factory->translation->create( array(
+			'original_id'        => $original->id,
+			'translation_set_id' => $set->id,
+			'translation_0'      => 'Guten Morgen',
+			'user_id'            => $translator,
+			'status'             => 'waiting',
+		) );
+
+		$translations = new Translations();
+		$translations->add_entry( new Translation_Entry( array(
+			'singular'     => 'Good morning',
+			'translations' => array( 'Guten Morgen' ),
+		) ) );
+
+		wp_set_current_user( $validator );
+		$set->import( $translations, 'current' );
+
+		$current = GP::$translation->find_one( array(
+			'translation_set_id' => $set->id,
+			'original_id'        => $original->id,
+			'status'             => 'current',
+		) );
+
+		$this->assertEquals( $waiting->id, $current->id, 'The waiting translation should have been approved, not replaced.' );
+		$this->assertEquals( $translator, (int) $current->user_id, 'Credit should remain with the original translator.' );
+		$this->assertEquals( $validator, (int) $current->user_id_last_modified, 'The importer should be recorded as approver.' );
+	}
+
+	/**
+	 * @ticket gh-710
+	 */
+	function test_import_different_from_waiting_still_creates_new_translation() {
+		$translator = $this->factory->user->create();
+		$validator  = $this->factory->user->create();
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		GP::$validator_permission->create( array( 'user_id' => $validator, 'action' => 'approve',
+		                                          'project_id' => $set->project_id, 'locale_slug' => $set->locale, 'set_slug' => $set->slug ) );
+
+		$original = $this->factory->original->create( array(
+			'project_id' => $set->project_id,
+			'status'     => '+active',
+			'singular'   => 'Good morning',
+		) );
+
+		$waiting = $this->factory->translation->create( array(
+			'original_id'        => $original->id,
+			'translation_set_id' => $set->id,
+			'translation_0'      => 'Guten Morgen',
+			'user_id'            => $translator,
+			'status'             => 'waiting',
+		) );
+
+		$translations = new Translations();
+		$translations->add_entry( new Translation_Entry( array(
+			'singular'     => 'Good morning',
+			'translations' => array( 'Guten Tag' ),
+		) ) );
+
+		wp_set_current_user( $validator );
+		$set->import( $translations, 'current' );
+
+		$current = GP::$translation->find_one( array(
+			'translation_set_id' => $set->id,
+			'original_id'        => $original->id,
+			'status'             => 'current',
+		) );
+
+		$this->assertNotEquals( $waiting->id, $current->id );
+		$this->assertEquals( 'Guten Tag', $current->translation_0 );
+		$this->assertEquals( $validator, (int) $current->user_id );
+	}
+
 	function test_multiple_imports_multiple_singulars() {
 		$originals = array(
 			array(

--- a/tests/phpunit/testcases/test_import.php
+++ b/tests/phpunit/testcases/test_import.php
@@ -636,6 +636,134 @@ class GP_Import extends GP_UnitTestCase {
 	}
 
 	/**
+	 * Approving a waiting translation replaces the second `gp_translation_set_import_status` call
+	 * of the create path, so a filter that downgrades the imported string must be able to stop it.
+	 *
+	 * @ticket gh-710
+	 */
+	function test_import_status_filter_can_prevent_approving_waiting_translation() {
+		$translator = $this->factory->user->create();
+		$validator  = $this->factory->user->create();
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		GP::$validator_permission->create( array(
+			'user_id'     => $validator,
+			'action'      => 'approve',
+			'project_id'  => $set->project_id,
+			'locale_slug' => $set->locale,
+			'set_slug'    => $set->slug,
+		) );
+
+		$original = $this->factory->original->create( array(
+			'project_id' => $set->project_id,
+			'status'     => '+active',
+			'singular'   => 'Good morning',
+		) );
+
+		$waiting = $this->factory->translation->create( array(
+			'original_id'        => $original->id,
+			'translation_set_id' => $set->id,
+			'translation_0'      => 'Guten Morgen',
+			'user_id'            => $translator,
+			'status'             => 'waiting',
+		) );
+
+		$translations = new Translations();
+		$translations->add_entry( new Translation_Entry( array(
+			'singular'     => 'Good morning',
+			'translations' => array( 'Guten Morgen' ),
+		) ) );
+
+		$downgrade = function ( $status, $entry, $old_translation ) {
+			return $old_translation ? 'waiting' : $status;
+		};
+
+		wp_set_current_user( $validator );
+		add_filter( 'gp_translation_set_import_status', $downgrade, 10, 3 );
+		$set->import( $translations, 'current' );
+		remove_filter( 'gp_translation_set_import_status', $downgrade, 10 );
+
+		$still_waiting = GP::$translation->get( $waiting->id );
+		$this->assertEquals( 'waiting', $still_waiting->status, 'The filter refused the current status, so nothing should have been approved.' );
+
+		$current = GP::$translation->find_one( array(
+			'translation_set_id' => $set->id,
+			'original_id'        => $original->id,
+			'status'             => 'current',
+		) );
+		$this->assertFalse( $current, 'No translation should have become current.' );
+
+		$all = GP::$translation->find_many( array(
+			'translation_set_id' => $set->id,
+			'original_id'        => $original->id,
+		) );
+		$this->assertCount( 2, $all, 'The import falls through to the create path, with the status the filter asked for.' );
+	}
+
+	/**
+	 * A filter that leaves the status alone still gets to see the waiting translation that is
+	 * about to be approved, and the approval happens.
+	 *
+	 * @ticket gh-710
+	 */
+	function test_import_status_filter_sees_the_waiting_translation_and_approval_happens() {
+		$translator = $this->factory->user->create();
+		$validator  = $this->factory->user->create();
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		GP::$validator_permission->create( array(
+			'user_id'     => $validator,
+			'action'      => 'approve',
+			'project_id'  => $set->project_id,
+			'locale_slug' => $set->locale,
+			'set_slug'    => $set->slug,
+		) );
+
+		$original = $this->factory->original->create( array(
+			'project_id' => $set->project_id,
+			'status'     => '+active',
+			'singular'   => 'Good morning',
+		) );
+
+		$waiting = $this->factory->translation->create( array(
+			'original_id'        => $original->id,
+			'translation_set_id' => $set->id,
+			'translation_0'      => 'Guten Morgen',
+			'user_id'            => $translator,
+			'status'             => 'waiting',
+		) );
+
+		$translations = new Translations();
+		$translations->add_entry( new Translation_Entry( array(
+			'singular'     => 'Good morning',
+			'translations' => array( 'Guten Morgen' ),
+		) ) );
+
+		$old_translation_ids = array();
+		$record              = function ( $status, $entry, $old_translation ) use ( &$old_translation_ids ) {
+			$old_translation_ids[] = $old_translation ? (int) $old_translation->id : 0;
+			return $status;
+		};
+
+		wp_set_current_user( $validator );
+		add_filter( 'gp_translation_set_import_status', $record, 10, 3 );
+		$set->import( $translations, 'current' );
+		remove_filter( 'gp_translation_set_import_status', $record, 10 );
+
+		$this->assertContains( (int) $waiting->id, $old_translation_ids, 'The filter should have been called with the waiting translation.' );
+
+		$approved = GP::$translation->get( $waiting->id );
+		$this->assertEquals( 'current', $approved->status, 'The filter left the status alone, so the approval should have happened.' );
+		$this->assertEquals( $translator, (int) $approved->user_id, 'Credit should remain with the original translator.' );
+
+		$all = GP::$translation->find_many( array(
+			'translation_set_id' => $set->id,
+			'original_id'        => $original->id,
+		) );
+		$this->assertCount( 1, $all, 'Nothing should have been created.' );
+	}
+
+	/**
 	 * Approving goes through `set_status( 'current' )`, so an import without a current user,
 	 * a WP-CLI import for example, keeps the previous behaviour of creating a new translation.
 	 *

--- a/tests/phpunit/testcases/test_import.php
+++ b/tests/phpunit/testcases/test_import.php
@@ -562,6 +562,80 @@ class GP_Import extends GP_UnitTestCase {
 	}
 
 	/**
+	 * Approving a waiting translation supersedes the current one, so it must not happen when
+	 * `gp_translation_set_import_over_existing` has refused to import over that translation.
+	 *
+	 * @ticket gh-710
+	 */
+	function test_import_over_existing_filter_false_does_not_approve_waiting_translation() {
+		$translator     = $this->factory->user->create();
+		$old_translator = $this->factory->user->create();
+		$validator      = $this->factory->user->create();
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		GP::$validator_permission->create( array(
+			'user_id'     => $validator,
+			'action'      => 'approve',
+			'project_id'  => $set->project_id,
+			'locale_slug' => $set->locale,
+			'set_slug'    => $set->slug,
+		) );
+
+		$original = $this->factory->original->create( array(
+			'project_id' => $set->project_id,
+			'status'     => '+active',
+			'singular'   => 'Good morning',
+		) );
+
+		$existing_current = $this->factory->translation->create( array(
+			'original_id'        => $original->id,
+			'translation_set_id' => $set->id,
+			'translation_0'      => 'Guten Tag',
+			'user_id'            => $old_translator,
+			'status'             => 'current',
+		) );
+
+		$waiting = $this->factory->translation->create( array(
+			'original_id'        => $original->id,
+			'translation_set_id' => $set->id,
+			'translation_0'      => 'Guten Morgen',
+			'user_id'            => $translator,
+			'status'             => 'waiting',
+		) );
+
+		$translations = new Translations();
+		$translations->add_entry( new Translation_Entry( array(
+			'singular'     => 'Good morning',
+			'translations' => array( 'Guten Morgen' ),
+		) ) );
+
+		wp_set_current_user( $validator );
+		add_filter( 'gp_translation_set_import_over_existing', '__return_false' );
+		$translations_added = $set->import( $translations, 'current' );
+		remove_filter( 'gp_translation_set_import_over_existing', '__return_false' );
+
+		$current = GP::$translation->find_one( array(
+			'translation_set_id' => $set->id,
+			'original_id'        => $original->id,
+			'status'             => 'current',
+		) );
+
+		$this->assertEquals( $existing_current->id, $current->id, 'The current translation should have been left alone.' );
+		$this->assertEquals( 'Guten Tag', $current->translation_0 );
+
+		$still_waiting = GP::$translation->get( $waiting->id );
+		$this->assertEquals( 'waiting', $still_waiting->status, 'The waiting translation should not have been approved.' );
+
+		$all = GP::$translation->find_many( array(
+			'translation_set_id' => $set->id,
+			'original_id'        => $original->id,
+		) );
+		$this->assertCount( 2, $all, 'Nothing should have been created.' );
+
+		$this->assertSame( 0, $translations_added, 'Nothing was imported.' );
+	}
+
+	/**
 	 * Approving goes through `set_status( 'current' )`, so an import without a current user,
 	 * a WP-CLI import for example, keeps the previous behaviour of creating a new translation.
 	 *


### PR DESCRIPTION
Fixes #710

## Problem

When a validator imports a PO file with status `current`, a string that is 100% identical to an existing **waiting** translation created a brand-new translation row credited to the importer. The waiting row from the original translator was silently discarded as `old` by `set_as_current()`, so the translator lost credit for work that was, in effect, simply approved.

This is the workflow described in #710 (and https://meta.trac.wordpress.org/ticket/2802): validators download pending strings, review them offline, and upload the checked file back.

## Solution

In `GP_Translation_Set::import()`, when the desired status is `current`, GlotPress checks for identical waiting suggestions using a dedicated helper method `approve_matching_waiting_translation()`:

- **Targeted waiting candidate lookup**: Queries waiting rows directly per original using `GP::$translation->find_many()` ordered by `date_added ASC, id ASC` (preventing `Translations` collection key collision when multiple suggestions exist for the same original).
- **Supports existing current translations**: Also approves matching waiting suggestions when improving an already translated string (gated by `gp_translation_set_import_over_existing`).
- **Preserves translator credit**: Approves via `set_status( 'current' )`, retaining `user_id` on the original contributor while recording the importer in `user_id_last_modified`.
- **Plural form comparison**: Plural strings are compared sliced to `$locale->nplurals`.
- **Opt-out filter**: A new `gp_translation_set_import_approve_waiting` filter (default `true`) allows opting out.
- **Graceful fallbacks**: Falls back to creating a new translation if `set_status( 'current' )` is denied or when running without a current user (e.g. WP-CLI).
- **Hook payload**: Keeps approved waiting rows out of `$created_translation_ids` while counting them towards `$translations_added`.

## Testing

Comprehensive test coverage in `tests/phpunit/testcases/test_import.php` (`@ticket gh-710`):
- `test_import_identical_to_waiting_approves_and_keeps_translator_credit`
- `test_import_identical_to_waiting_approves_when_original_already_current`
- `test_import_matches_waiting_translation_among_several_of_same_original`
- `test_import_identical_to_waiting_approves_plural_string`
- `test_import_approve_waiting_filter_false_creates_new_translation`
- `test_import_over_existing_filter_false_does_not_approve_waiting_translation`
- `test_import_without_current_user_creates_new_translation`
- `test_gp_translations_imported_excludes_approved_waiting_ids`
- `test_import_different_from_waiting_still_creates_new_translation`

Full suite: 503 tests, 1945 assertions, 0 failures. `phpcs` passes without errors.
