### PR TITLE
Require permission to create locale glossaries

### DIFF
--- a/gp-includes/misc.php
+++ b/gp-includes/misc.php
@@ -758,3 +758,22 @@ function gp_is_valid_utf8( $string ) {
 
 	return 1 === preg_match( '//u', $string );
 }
+
+/**
+ * Determines whether the current user may create the locale glossary for a locale and set slug.
+ *
+ * A locale glossary lives on the virtual locale project (id 0), so it is authorized
+ * the same way its translations are: with the `approve` permission on the set, which
+ * covers GlotPress administrators and the locale's approvers.
+ *
+ * @param string $locale_slug The locale slug. E.g. "de".
+ * @param string $set_slug    The translation set slug. E.g. "default".
+ * @return bool Whether the current user may create the locale glossary.
+ */
+function gp_can_create_locale_glossary( $locale_slug, $set_slug ) {
+	return GP::$permission->current_user_can(
+		'approve',
+		GP::$validator_permission->object_type,
+		GP::$validator_permission->object_id( 0, $locale_slug, $set_slug )
+	);
+}

--- a/gp-includes/router.php
+++ b/gp-includes/router.php
@@ -81,6 +81,7 @@ class GP_Router {
 			"get:(/languages)/$locale/$dir/glossary"          => array( 'GP_Route_Glossary_Entry', 'glossary_entries_get' ),
 			"post:(/languages)/$locale/$dir/glossary"         => array( 'GP_Route_Glossary_Entry', 'glossary_entries_post' ),
 			"post:(/languages)/$locale/$dir/glossary/-new"    => array( 'GP_Route_Glossary_Entry', 'glossary_entry_add_post' ),
+			"post:(/languages)/$locale/$dir/glossary/-create" => array( 'GP_Route_Glossary_Entry', 'glossary_create_post' ),
 			"post:(/languages)/$locale/$dir/glossary/-delete" => array( 'GP_Route_Glossary_Entry', 'glossary_entry_delete_post' ),
 			"get:(/languages)/$locale/$dir/glossary/-export"  => array( 'GP_Route_Glossary_Entry', 'export_glossary_entries_get' ),
 			"get:(/languages)/$locale/$dir/glossary/-import"  => array( 'GP_Route_Glossary_Entry', 'import_glossary_entries_get' ),

--- a/gp-includes/routes/glossary-entry.php
+++ b/gp-includes/routes/glossary-entry.php
@@ -118,6 +118,55 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 		}
 	}
 
+	public function glossary_create_post( $project_path, $locale_slug, $translation_set_slug ) {
+		$project = GP::$project->by_path( $project_path );
+		$locale  = GP_Locales::by_slug( $locale_slug );
+
+		// The locale glossary lives on the virtual locale project (id 0).
+		if ( ! $project || ! $locale || 0 !== $project->id ) {
+			return $this->die_with_404();
+		}
+
+		if ( $this->invalid_nonce_and_redirect( 'create-locale-glossary_' . $locale_slug . $translation_set_slug ) ) {
+			return;
+		}
+
+		if ( $this->cannot_and_redirect( 'approve', GP::$validator_permission->object_type, GP::$validator_permission->object_id( $project->id, $locale_slug, $translation_set_slug ) ) ) {
+			return;
+		}
+
+		$translation_set = GP::$translation_set->by_project_id_slug_and_locale( $project->id, $translation_set_slug, $locale_slug );
+		if ( ! $translation_set ) {
+			$translation_set = GP::$translation_set->create(
+				array(
+					'project_id' => $project->id,
+					'name'       => $locale->english_name,
+					'slug'       => $translation_set_slug,
+					'locale'     => $locale_slug,
+				)
+			);
+		}
+
+		if ( ! $translation_set ) {
+			$this->errors[] = __( 'Error in creating the locale glossary!', 'glotpress' );
+			$this->redirect( gp_url_join( gp_url( '/languages' ), $locale_slug ) );
+			return;
+		}
+
+		$glossary = GP::$glossary->by_set_id( $translation_set->id );
+		if ( ! $glossary ) {
+			$glossary = GP::$glossary->create( array( 'translation_set_id' => $translation_set->id ) );
+		}
+
+		if ( ! $glossary ) {
+			$this->errors[] = __( 'Error in creating the locale glossary!', 'glotpress' );
+			$this->redirect( gp_url_join( gp_url( '/languages' ), $locale_slug ) );
+			return;
+		}
+
+		$this->redirect( gp_url_join( gp_url( '/languages' ), $locale_slug, $translation_set_slug, 'glossary' ) );
+	}
+
 	public function glossary_entries_post( $project_path, $locale_slug, $translation_set_slug ) {
 		$ge_post = gp_post( 'glossary_entry' );
 		if ( ! is_array( $ge_post ) ) {

--- a/gp-includes/routes/glossary-entry.php
+++ b/gp-includes/routes/glossary-entry.php
@@ -131,7 +131,8 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 			return;
 		}
 
-		if ( $this->cannot_and_redirect( 'approve', GP::$validator_permission->object_type, GP::$validator_permission->object_id( $project->id, $locale_slug, $translation_set_slug ) ) ) {
+		if ( ! gp_can_create_locale_glossary( $locale_slug, $translation_set_slug ) ) {
+			$this->redirect_with_error( __( 'You are not allowed to do that!', 'glotpress' ) );
 			return;
 		}
 

--- a/gp-includes/routes/locale.php
+++ b/gp-includes/routes/locale.php
@@ -131,9 +131,9 @@ class GP_Route_Locale extends GP_Route_Main {
 			}
 		}
 
-		$can_create_locale_glossary      = GP::$permission->current_user_can( 'admin' );
+		$can_create_locale_glossary      = gp_can_create_locale_glossary( $locale_slug, $current_set_slug );
 		$locale_glossary_translation_set = GP::$translation_set->by_project_id_slug_and_locale( 0, $current_set_slug, $locale_slug );
-		$locale_glossary                 = GP::$glossary->by_set_id( $locale_glossary_translation_set->id );
+		$locale_glossary                 = $locale_glossary_translation_set ? GP::$glossary->by_set_id( $locale_glossary_translation_set->id ) : null;
 
 		$this->tmpl( 'locale', get_defined_vars() );
 	}

--- a/gp-includes/things/glossary.php
+++ b/gp-includes/things/glossary.php
@@ -66,21 +66,20 @@ class GP_Glossary extends GP_Thing {
 	public function by_set_or_parent_project( $translation_set, $project ) {
 		$glossary = $this->by_set_id( $translation_set->id );
 
-		if ( ! $glossary ) {
-			if ( 0 === $project->id ) {
-				// Auto-create the Locale Glossary.
-				$glossary = $this->create( array( 'translation_set_id' => $translation_set->id ) );
-			} elseif ( $project->parent_project_id ) {
-				$locale = $translation_set->locale;
-				$slug   = $translation_set->slug;
+		if ( ! $glossary && $project->parent_project_id ) {
+			$locale = $translation_set->locale;
+			$slug   = $translation_set->slug;
 
-				while ( ! $glossary && $project->parent_project_id ) {
-					$project         = GP::$project->get( $project->parent_project_id );
-					$translation_set = GP::$translation_set->by_project_id_slug_and_locale( $project->id, $slug, $locale );
+			while ( ! $glossary && $project->parent_project_id ) {
+				$project = GP::$project->get( $project->parent_project_id );
+				if ( ! $project ) {
+					break;
+				}
 
-					if ( $translation_set ) {
-						$glossary = $this->by_set_id( $translation_set->id );
-					}
+				$translation_set = GP::$translation_set->by_project_id_slug_and_locale( $project->id, $slug, $locale );
+
+				if ( $translation_set ) {
+					$glossary = $this->by_set_id( $translation_set->id );
 				}
 			}
 		}

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -220,26 +220,13 @@ class GP_Translation_Set extends GP_Thing {
 	}
 
 	public function by_project_id_slug_and_locale( $project_id, $slug, $locale_slug ) {
-		$result = $this->one(
+		return $this->one(
 			"SELECT * FROM $this->table
 			WHERE slug = %s AND project_id= %d AND locale = %s",
 			$slug,
 			$project_id,
 			$locale_slug
 		);
-
-		if ( ! $result && 0 === $project_id ) {
-			$result = $this->create(
-				array(
-					'project_id' => $project_id,
-					'name'       => GP_Locales::by_slug( $locale_slug )->english_name,
-					'slug'       => $slug,
-					'locale'     => $locale_slug,
-				)
-			);
-		}
-
-		return $result;
 	}
 
 	public function by_locale( $locale_slug ) {

--- a/gp-templates/locale-glossary-link.php
+++ b/gp-templates/locale-glossary-link.php
@@ -1,0 +1,10 @@
+<?php
+if ( $locale_glossary ) : ?>
+	<a href="<?php echo esc_url( gp_url_join( gp_url( '/languages' ), $locale->slug, $set_slug, 'glossary' ) ); ?>" class="glossary-link"><?php _e( 'Locale Glossary', 'glotpress' ); ?></a>
+<?php elseif ( $can_create_locale_glossary ) : ?>
+	<form action="<?php echo esc_url( gp_url_join( gp_url( '/languages' ), $locale->slug, $set_slug, 'glossary', '-create' ) ); ?>" method="post" class="glossary-link">
+		<?php gp_route_nonce_field( 'create-locale-glossary_' . $locale->slug . $set_slug ); ?>
+		<button type="submit" class="button is-link"><?php _e( 'Create Locale Glossary', 'glotpress' ); ?></button>
+	</form>
+<?php
+endif;

--- a/gp-templates/locale.php
+++ b/gp-templates/locale.php
@@ -30,11 +30,17 @@ gp_tmpl_header();
 		?>
 	</h2>
 	<div class="glossary-links">
-		<?php if ( $locale_glossary ) : ?>
-			<a href="<?php echo esc_url( gp_url_join( gp_url( '/languages' ), $locale->slug, $current_set_slug, 'glossary' ) ); ?>" class="glossary-link"><?php _e( 'Locale Glossary', 'glotpress' ); ?></a>
-		<?php elseif ( $can_create_locale_glossary ) : ?>
-			<a href="<?php echo esc_url( gp_url_join( gp_url( '/languages' ), $locale->slug, $current_set_slug, 'glossary' ) ); ?>" class="glossary-link"><?php _e( 'Create Locale Glossary', 'glotpress' ); ?></a>
-		<?php endif; ?>
+		<?php
+		gp_tmpl_load(
+			'locale-glossary-link',
+			array(
+				'locale'                     => $locale,
+				'set_slug'                   => $current_set_slug,
+				'locale_glossary'            => $locale_glossary,
+				'can_create_locale_glossary' => $can_create_locale_glossary,
+			)
+		);
+		?>
 	</div>
 </div>
 

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -59,20 +59,20 @@ $i = 0;
 	<?php gp_link_set_delete( $translation_set, $project, null, array( 'class' => 'button is-small' ) ); ?>
 	<div class="glossary-links">
 		<?php
-		$can_create_locale_glossary      = GP::$permission->current_user_can( 'admin' );
+		$can_create_locale_glossary      = gp_can_create_locale_glossary( $translation_set->locale, $translation_set->slug );
 		$locale_glossary_translation_set = GP::$translation_set->by_project_id_slug_and_locale( 0, $translation_set->slug, $translation_set->locale );
-		$locale_glossary                 = GP::$glossary->by_set_id( $locale_glossary_translation_set->id );
+		$locale_glossary                 = $locale_glossary_translation_set ? GP::$glossary->by_set_id( $locale_glossary_translation_set->id ) : null;
 
 		// Locale Glossary link.
-		if ( $locale_glossary ) {
-			?>
-			<a href="<?php echo esc_url( gp_url_join( gp_url( '/languages' ), $locale->slug, $translation_set->slug, 'glossary' ) ); ?>" class="glossary-link"><?php _e( 'Locale Glossary', 'glotpress' ); ?></a>
-			<?php
-		} elseif ( $can_create_locale_glossary ) {
-			?>
-			<a href="<?php echo esc_url( gp_url_join( gp_url( '/languages' ), $locale->slug, $translation_set->slug, 'glossary' ) ); ?>" class="glossary-link"><?php _e( 'Create Locale Glossary', 'glotpress' ); ?></a>
-			<?php
-		}
+		gp_tmpl_load(
+			'locale-glossary-link',
+			array(
+				'locale'                     => $locale,
+				'set_slug'                   => $translation_set->slug,
+				'locale_glossary'            => $locale_glossary,
+				'can_create_locale_glossary' => $can_create_locale_glossary,
+			)
+		);
 
 		// Show separator if both links are shown.
 		if ( ( $locale_glossary || $can_create_locale_glossary ) && ( ( $glossary && $glossary->translation_set_id === $translation_set->id ) || $can_approve ) ) {

--- a/tests/phpunit/testcases/tests_routes/test_route_glossary_entry.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_glossary_entry.php
@@ -82,4 +82,135 @@ class GP_Test_Route_Glossary_Entry extends GP_UnitTestCase_Route {
 		$this->assertEquals( 'edited', $reloaded->term );
 		$this->assertCount( 0, GP::$glossary_entry->by_glossary_id( $other_glossary->id ) );
 	}
+
+	/**
+	 * Reading a locale glossary that does not exist must not create it; only an
+	 * explicit, authorized action may.
+	 */
+	function test_reading_a_missing_locale_glossary_does_not_create_it() {
+		$locale = $this->factory->locale->create();
+
+		$this->do_route_request(
+			function () use ( $locale ) {
+				$this->route->glossary_entries_get( '/languages', $locale->slug, 'aaaatest' );
+			}
+		);
+
+		$this->assertEmpty(
+			GP::$translation_set->by_project_id_slug_and_locale( 0, 'aaaatest', $locale->slug ),
+			'Reading a missing locale glossary must not create a translation set.'
+		);
+	}
+
+	/**
+	 * A locale approver (the permission GTEs/locale managers hold on wordpress.org,
+	 * granted through a filter rather than a stored row) can create the locale
+	 * glossary through the explicit action.
+	 */
+	function test_a_locale_approver_can_create_the_locale_glossary() {
+		$locale    = $this->factory->locale->create();
+		$object_id = '0|' . $locale->slug . '|default';
+
+		add_filter(
+			'gp_pre_can_user',
+			function ( $verdict, $args ) use ( $object_id ) {
+				if ( 'approve' === $args['action'] && $object_id === $args['object_id'] ) {
+					return true;
+				}
+				return $verdict;
+			},
+			10,
+			2
+		);
+		$this->set_normal_user_as_current();
+
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'create-locale-glossary_' . $locale->slug . 'default' );
+
+		$this->do_route_request(
+			function () use ( $locale ) {
+				$this->route->glossary_create_post( '/languages', $locale->slug, 'default' );
+			}
+		);
+
+		$set = GP::$translation_set->by_project_id_slug_and_locale( 0, 'default', $locale->slug );
+		$this->assertNotEmpty( $set, 'A locale approver can create the locale glossary.' );
+		$this->assertNotEmpty( GP::$glossary->by_set_id( $set->id ) );
+	}
+
+	/**
+	 * A user without approve on the locale must not create the locale glossary.
+	 */
+	function test_a_non_approver_cannot_create_the_locale_glossary() {
+		$locale = $this->factory->locale->create();
+
+		$this->set_normal_user_as_current();
+
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'create-locale-glossary_' . $locale->slug . 'default' );
+
+		$this->do_route_request(
+			function () use ( $locale ) {
+				$this->route->glossary_create_post( '/languages', $locale->slug, 'default' );
+			}
+		);
+
+		$this->assertEmpty(
+			GP::$translation_set->by_project_id_slug_and_locale( 0, 'default', $locale->slug ),
+			'A user without approve on the locale must not create the locale glossary.'
+		);
+	}
+
+	/**
+	 * An anonymous request must not create the locale glossary.
+	 */
+	function test_an_anonymous_user_cannot_create_the_locale_glossary() {
+		$locale = $this->factory->locale->create();
+		wp_set_current_user( 0 );
+
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'create-locale-glossary_' . $locale->slug . 'default' );
+
+		$this->do_route_request(
+			function () use ( $locale ) {
+				$this->route->glossary_create_post( '/languages', $locale->slug, 'default' );
+			}
+		);
+
+		$this->assertEmpty(
+			GP::$translation_set->by_project_id_slug_and_locale( 0, 'default', $locale->slug ),
+			'An anonymous user must not create the locale glossary.'
+		);
+	}
+
+	/**
+	 * A missing nonce must block creation even for a locale approver.
+	 */
+	function test_a_missing_nonce_blocks_locale_glossary_creation() {
+		$locale    = $this->factory->locale->create();
+		$object_id = '0|' . $locale->slug . '|default';
+
+		add_filter(
+			'gp_pre_can_user',
+			function ( $verdict, $args ) use ( $object_id ) {
+				if ( 'approve' === $args['action'] && $object_id === $args['object_id'] ) {
+					return true;
+				}
+				return $verdict;
+			},
+			10,
+			2
+		);
+		$this->set_normal_user_as_current();
+
+		unset( $_REQUEST['_gp_route_nonce'] );
+
+		$this->do_route_request(
+			function () use ( $locale ) {
+				$this->route->glossary_create_post( '/languages', $locale->slug, 'default' );
+			}
+		);
+
+		$this->assertEmpty(
+			GP::$translation_set->by_project_id_slug_and_locale( 0, 'default', $locale->slug ),
+			'A missing nonce must block locale glossary creation.'
+		);
+	}
 }


### PR DESCRIPTION
## Summary

The locale glossary lives on the virtual locale project (id 0), and its
translation set and glossary were created as a side effect of *reading* it:
`GP_Translation_Set::by_project_id_slug_and_locale()` and
`GP_Glossary::by_set_or_parent_project()` inserted rows on a miss for project
id 0. Because the `/languages/<locale>/<slug>/glossary` routes are public GETs,
any visitor could insert an unbounded number of translation-set and glossary
rows, one per distinct URL slug, with no capability check.

## Changes

- Make the two model methods pure reads (no more auto-create).
- Add an explicit, nonce-protected create action
  (`POST /languages/<locale>/<slug>/glossary/-create` →
  `GP_Route_Glossary_Entry::glossary_create_post()`), gated by `approve` on the
  locale set (`0|<locale>|<slug>`) — the permission GlotPress administrators and
  a locale's approvers (GTEs / locale managers on translate.wordpress.org) hold.
  This replaces the previous `current_user_can( 'admin' )` UI gate, which
  excluded those approvers.
- `gp_can_create_locale_glossary()` drives both the button visibility and the
  route gate, so they cannot drift.
- The "Create Locale Glossary" buttons are now POST forms (shared
  `locale-glossary-link` partial); read paths treat a missing locale glossary as
  "no glossary" instead of creating one.
- Harden the parent-project walk against a dangling `parent_project_id`.

## Tests

`tests_routes/test_route_glossary_entry.php`:

- reading a missing locale glossary creates nothing;
- a locale approver can create it, a normal user and an anonymous request cannot;
- a missing nonce blocks creation.

Full suite green.
