### PR TITLE
Compare all attribute values in the translation tags warning

### DIFF
--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -288,18 +288,12 @@ class GP_Builtin_Translation_Warnings {
 		rsort( $original_parts );
 		rsort( $translation_parts );
 
-		$changeable_attributes = array(
-			// We allow certain attributes to be different in translations.
-			'title',
-			'aria-label',
-			// src and href will be checked separately.
-			'src',
-			'href',
-		);
-
-		$attribute_regex       = '/(\s*(?P<attr>%s))=([\'"])(?P<value>.+)\\3(\s*)/i';
-		$attribute_replace     = '$1=$3...$3$5';
-		$changeable_attr_regex = sprintf( $attribute_regex, implode( '|', $changeable_attributes ) );
+		// An attribute value may legitimately differ between a source string and its
+		// translation (title, aria-label, alt, lang, and the href/src URLs, which are
+		// checked separately below). Blank every attribute value before comparing the
+		// tag structure, so only added, removed, or renamed attributes differ.
+		$attribute_regex   = '/(\s*[\w-]+)=([\'"]).*?\2/i';
+		$attribute_replace = '$1=$2...$2';
 
 		// Items are sorted, so if all is well, will match up.
 		$parts_tags = array_combine( $original_parts, $translation_parts );
@@ -311,8 +305,8 @@ class GP_Builtin_Translation_Warnings {
 			}
 
 			// Remove any attributes that can be expected to differ.
-			$original_filtered_tag    = preg_replace( $changeable_attr_regex, $attribute_replace, $original_tag );
-			$translation_filtered_tag = preg_replace( $changeable_attr_regex, $attribute_replace, $translation_tag );
+			$original_filtered_tag    = preg_replace( $attribute_regex, $attribute_replace, $original_tag );
+			$translation_filtered_tag = preg_replace( $attribute_regex, $attribute_replace, $translation_tag );
 
 			if ( $original_filtered_tag !== $translation_filtered_tag ) {
 				$warnings[] = sprintf(

--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -292,9 +292,12 @@ class GP_Builtin_Translation_Warnings {
 		// source string and its translation (translatable text and locale markers; the
 		// href/src URLs are compared separately below). A value change to any other
 		// attribute, or an attribute the source did not have, then still differs.
+		// The leading whitespace anchors the match to a real attribute position, so an
+		// allow-listed name appearing inside another attribute's value (e.g. href= in an
+		// onclick handler) is left intact and a change to it is still compared.
 		$changeable_attributes = array( 'title', 'aria-label', 'alt', 'lang', 'src', 'href' );
-		$attribute_regex       = '/(?<![\w-])(' . implode( '|', $changeable_attributes ) . ')=([\'"]).*?\2/is';
-		$attribute_replace     = '$1=$2...$2';
+		$attribute_regex       = '/(\s)(' . implode( '|', $changeable_attributes ) . ')=([\'"]).*?\3/is';
+		$attribute_replace     = '$1$2=$3...$3';
 
 		// Items are sorted, so if all is well, will match up.
 		$parts_tags = array_combine( $original_parts, $translation_parts );
@@ -305,10 +308,8 @@ class GP_Builtin_Translation_Warnings {
 				continue;
 			}
 
-			// Collapse whitespace so cosmetic spacing differences are not compared,
-			// then blank the changeable attribute values.
-			$original_filtered_tag    = preg_replace( $attribute_regex, $attribute_replace, preg_replace( '/\s+/', ' ', $original_tag ) );
-			$translation_filtered_tag = preg_replace( $attribute_regex, $attribute_replace, preg_replace( '/\s+/', ' ', $translation_tag ) );
+			$original_filtered_tag    = preg_replace( $attribute_regex, $attribute_replace, $original_tag );
+			$translation_filtered_tag = preg_replace( $attribute_regex, $attribute_replace, $translation_tag );
 
 			if ( $original_filtered_tag !== $translation_filtered_tag ) {
 				$warnings[] = sprintf(

--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -288,12 +288,13 @@ class GP_Builtin_Translation_Warnings {
 		rsort( $original_parts );
 		rsort( $translation_parts );
 
-		// An attribute value may legitimately differ between a source string and its
-		// translation (title, aria-label, alt, lang, and the href/src URLs, which are
-		// checked separately below). Blank every attribute value before comparing the
-		// tag structure, so only added, removed, or renamed attributes differ.
-		$attribute_regex   = '/(\s*[\w-]+)=([\'"]).*?\2/i';
-		$attribute_replace = '$1=$2...$2';
+		// Blank the values of attributes whose contents legitimately differ between a
+		// source string and its translation (translatable text and locale markers; the
+		// href/src URLs are compared separately below). A value change to any other
+		// attribute, or an attribute the source did not have, then still differs.
+		$changeable_attributes = array( 'title', 'aria-label', 'alt', 'lang', 'src', 'href' );
+		$attribute_regex       = '/(?<![\w-])(' . implode( '|', $changeable_attributes ) . ')=([\'"]).*?\2/is';
+		$attribute_replace     = '$1=$2...$2';
 
 		// Items are sorted, so if all is well, will match up.
 		$parts_tags = array_combine( $original_parts, $translation_parts );
@@ -304,9 +305,10 @@ class GP_Builtin_Translation_Warnings {
 				continue;
 			}
 
-			// Remove any attributes that can be expected to differ.
-			$original_filtered_tag    = preg_replace( $attribute_regex, $attribute_replace, $original_tag );
-			$translation_filtered_tag = preg_replace( $attribute_regex, $attribute_replace, $translation_tag );
+			// Collapse whitespace so cosmetic spacing differences are not compared,
+			// then blank the changeable attribute values.
+			$original_filtered_tag    = preg_replace( $attribute_regex, $attribute_replace, preg_replace( '/\s+/', ' ', $original_tag ) );
+			$translation_filtered_tag = preg_replace( $attribute_regex, $attribute_replace, preg_replace( '/\s+/', ' ', $translation_tag ) );
 
 			if ( $original_filtered_tag !== $translation_filtered_tag ) {
 				$warnings[] = sprintf(

--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -288,17 +288,6 @@ class GP_Builtin_Translation_Warnings {
 		rsort( $original_parts );
 		rsort( $translation_parts );
 
-		// Blank the values of attributes whose contents legitimately differ between a
-		// source string and its translation (translatable text and locale markers; the
-		// href/src URLs are compared separately below). A value change to any other
-		// attribute, or an attribute the source did not have, then still differs.
-		// The leading whitespace anchors the match to a real attribute position, so an
-		// allow-listed name appearing inside another attribute's value (e.g. href= in an
-		// onclick handler) is left intact and a change to it is still compared.
-		$changeable_attributes = array( 'title', 'aria-label', 'alt', 'lang', 'src', 'href' );
-		$attribute_regex       = '/(\s)(' . implode( '|', $changeable_attributes ) . ')=([\'"]).*?\3/is';
-		$attribute_replace     = '$1$2=$3...$3';
-
 		// Items are sorted, so if all is well, will match up.
 		$parts_tags = array_combine( $original_parts, $translation_parts );
 
@@ -308,8 +297,10 @@ class GP_Builtin_Translation_Warnings {
 				continue;
 			}
 
-			$original_filtered_tag    = preg_replace( $attribute_regex, $attribute_replace, $original_tag );
-			$translation_filtered_tag = preg_replace( $attribute_regex, $attribute_replace, $translation_tag );
+			// Blank the values of attributes whose contents may legitimately differ so
+			// that only structural tag changes are compared.
+			$original_filtered_tag    = $this->blank_changeable_attribute_values( $original_tag );
+			$translation_filtered_tag = $this->blank_changeable_attribute_values( $translation_tag );
 
 			if ( $original_filtered_tag !== $translation_filtered_tag ) {
 				$warnings[] = sprintf(
@@ -657,6 +648,38 @@ class GP_Builtin_Translation_Warnings {
 		}
 
 		return trim( $error );
+	}
+
+	/**
+	 * Blanks the values of attributes whose contents may legitimately differ between a
+	 * source string and its translation, leaving only structural tag changes to compare.
+	 *
+	 * Each attribute is matched as a whole name="value" unit and only allow-listed names
+	 * are blanked. Consuming the quoted value as a unit means an allow-listed name that
+	 * appears inside another attribute's value is skipped, so a change to it is still
+	 * compared. The href and src URLs are validated separately.
+	 *
+	 * @since 4.1.0
+	 * @access private
+	 *
+	 * @param string $tag An HTML tag.
+	 * @return string The tag with allow-listed attribute values blanked.
+	 */
+	private function blank_changeable_attribute_values( string $tag ): string {
+		$changeable_attributes = array( 'title', 'aria-label', 'alt', 'lang', 'src', 'href' );
+
+		return preg_replace_callback(
+			'/(\s)([\w-]+)=("[^"]*"|\'[^\']*\')/',
+			static function ( $matches ) use ( $changeable_attributes ) {
+				if ( ! in_array( strtolower( $matches[2] ), $changeable_attributes, true ) ) {
+					return $matches[0];
+				}
+
+				$quote = $matches[3][0];
+				return $matches[1] . $matches[2] . '=' . $quote . '...' . $quote;
+			},
+			$tag
+		);
 	}
 
 	/**

--- a/tests/phpunit/testcases/test_builtin_warnings.php
+++ b/tests/phpunit/testcases/test_builtin_warnings.php
@@ -179,8 +179,14 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 			'<button onclick="evil()">%s</button>',
 			'Expected <button onclick="a()">, got <button onclick="evil()">.'
 		);
-		// Cosmetic whitespace differences between attributes must not warn.
-		$this->assertNoWarnings( 'tags', '<img src="a" alt="x">', '<img  src="a" alt="x">' );
+		// An allow-listed name appearing inside another attribute's value (title= within
+		// an onclick handler) must still be compared, so a change to it warns.
+		$this->assertHasWarningsAndContainsOutput(
+			'tags',
+			'<a onclick="this.title=\'a\'">Link</a>',
+			'<a onclick="this.title=\'hacked\'">Link</a>',
+			'Expected <a onclick="this.title=\'a\'">, got <a onclick="this.title=\'hacked\'">.'
+		);
 		$this->assertHasWarningsAndContainsOutput(
 			'tags',
 			'<p>Baba</p>',

--- a/tests/phpunit/testcases/test_builtin_warnings.php
+++ b/tests/phpunit/testcases/test_builtin_warnings.php
@@ -152,6 +152,20 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 			'<a href="%s" x>Баба</a>',
 			'Expected <a href="%s" title="Blimp!">, got <a href="%s" x>.'
 		);
+		// Attributes appended after a changeable attribute (href/src/title) must not
+		// be swallowed by the attribute normalization.
+		$this->assertHasWarningsAndContainsOutput(
+			'tags',
+			'<a href="%s">Baba</a>',
+			'<a href="%s" onmouseover="alert(1)">Баба</a>',
+			'Expected <a href="%s">, got <a href="%s" onmouseover="alert(1)">.'
+		);
+		$this->assertHasWarningsAndContainsOutput(
+			'tags',
+			'<a href="%s">Baba</a>',
+			'<a href="%s" style="animation:x 1s" onanimationstart="alert(1)">Баба</a>',
+			'Expected <a href="%s">, got <a href="%s" style="animation:x 1s" onanimationstart="alert(1)">.'
+		);
 		$this->assertHasWarningsAndContainsOutput(
 			'tags',
 			'<p>Baba</p>',

--- a/tests/phpunit/testcases/test_builtin_warnings.php
+++ b/tests/phpunit/testcases/test_builtin_warnings.php
@@ -166,6 +166,21 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 			'<a href="%s" style="animation:x 1s" onanimationstart="alert(1)">Баба</a>',
 			'Expected <a href="%s">, got <a href="%s" style="animation:x 1s" onanimationstart="alert(1)">.'
 		);
+		// A value change to an attribute outside the allow-list must still warn.
+		$this->assertHasWarningsAndContainsOutput(
+			'tags',
+			'<span style="color:red">%s</span>',
+			'<span style="color:red;background:url(//evil)">%s</span>',
+			'Expected <span style="color:red">, got <span style="color:red;background:url(//evil)">.'
+		);
+		$this->assertHasWarningsAndContainsOutput(
+			'tags',
+			'<button onclick="a()">%s</button>',
+			'<button onclick="evil()">%s</button>',
+			'Expected <button onclick="a()">, got <button onclick="evil()">.'
+		);
+		// Cosmetic whitespace differences between attributes must not warn.
+		$this->assertNoWarnings( 'tags', '<img src="a" alt="x">', '<img  src="a" alt="x">' );
 		$this->assertHasWarningsAndContainsOutput(
 			'tags',
 			'<p>Baba</p>',

--- a/tests/phpunit/testcases/test_builtin_warnings.php
+++ b/tests/phpunit/testcases/test_builtin_warnings.php
@@ -174,12 +174,19 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 			'Expected <span data-role="a">, got <span data-role="b">.'
 		);
 		// An allow-listed name appearing inside another attribute's value (title= within
-		// a data-* value) must still be compared, so a change to it warns.
+		// a data-* value) must still be compared, so a change to it warns. This holds
+		// whether or not the value has whitespace before the allow-listed name.
 		$this->assertHasWarningsAndContainsOutput(
 			'tags',
 			'<span data-info="title=\'a\'">Text</span>',
 			'<span data-info="title=\'b\'">Text</span>',
 			'Expected <span data-info="title=\'a\'">, got <span data-info="title=\'b\'">.'
+		);
+		$this->assertHasWarningsAndContainsOutput(
+			'tags',
+			'<span data-info="x title=\'a\'">Text</span>',
+			'<span data-info="x title=\'b\'">Text</span>',
+			'Expected <span data-info="x title=\'a\'">, got <span data-info="x title=\'b\'">.'
 		);
 		$this->assertHasWarningsAndContainsOutput(
 			'tags',

--- a/tests/phpunit/testcases/test_builtin_warnings.php
+++ b/tests/phpunit/testcases/test_builtin_warnings.php
@@ -157,35 +157,29 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 		$this->assertHasWarningsAndContainsOutput(
 			'tags',
 			'<a href="%s">Baba</a>',
-			'<a href="%s" onmouseover="alert(1)">Баба</a>',
-			'Expected <a href="%s">, got <a href="%s" onmouseover="alert(1)">.'
+			'<a href="%s" data-info="1">Баба</a>',
+			'Expected <a href="%s">, got <a href="%s" data-info="1">.'
 		);
 		$this->assertHasWarningsAndContainsOutput(
 			'tags',
 			'<a href="%s">Baba</a>',
-			'<a href="%s" style="animation:x 1s" onanimationstart="alert(1)">Баба</a>',
-			'Expected <a href="%s">, got <a href="%s" style="animation:x 1s" onanimationstart="alert(1)">.'
+			'<a href="%s" data-info="1" data-extra="2">Баба</a>',
+			'Expected <a href="%s">, got <a href="%s" data-info="1" data-extra="2">.'
 		);
 		// A value change to an attribute outside the allow-list must still warn.
 		$this->assertHasWarningsAndContainsOutput(
 			'tags',
-			'<span style="color:red">%s</span>',
-			'<span style="color:red;background:url(//evil)">%s</span>',
-			'Expected <span style="color:red">, got <span style="color:red;background:url(//evil)">.'
-		);
-		$this->assertHasWarningsAndContainsOutput(
-			'tags',
-			'<button onclick="a()">%s</button>',
-			'<button onclick="evil()">%s</button>',
-			'Expected <button onclick="a()">, got <button onclick="evil()">.'
+			'<span data-role="a">%s</span>',
+			'<span data-role="b">%s</span>',
+			'Expected <span data-role="a">, got <span data-role="b">.'
 		);
 		// An allow-listed name appearing inside another attribute's value (title= within
-		// an onclick handler) must still be compared, so a change to it warns.
+		// a data-* value) must still be compared, so a change to it warns.
 		$this->assertHasWarningsAndContainsOutput(
 			'tags',
-			'<a onclick="this.title=\'a\'">Link</a>',
-			'<a onclick="this.title=\'hacked\'">Link</a>',
-			'Expected <a onclick="this.title=\'a\'">, got <a onclick="this.title=\'hacked\'">.'
+			'<span data-info="title=\'a\'">Text</span>',
+			'<span data-info="title=\'b\'">Text</span>',
+			'Expected <span data-info="title=\'a\'">, got <span data-info="title=\'b\'">.'
 		);
 		$this->assertHasWarningsAndContainsOutput(
 			'tags',


### PR DESCRIPTION
## Summary

`GP_Builtin_Translation_Warnings::warning_tags()` compares the HTML tags of a
translation against the source. Before comparing, it blanks the values of
attributes whose contents may legitimately be translated. The normalization regex
used a greedy `(?P<value>.+)`, so on a tag like `<a href="X" onmouseover="Y">` the
match ran from `href="` to the last quote in the tag, swallowing every attribute
after `href`/`src`/`title`/`aria-label`. A translation that appended attributes
(`onmouseover`, `style`, …) to such a tag therefore normalized to the same string
as the source, and the warning meant to flag a changed tag stayed silent.

## Changes

- Blank only the values of the attributes whose contents legitimately differ
  between a source and its translation — `title`, `aria-label`, `alt`, `lang`,
  `src`, `href` (URLs are also compared separately). Each attribute is matched as a
  whole `name="value"` unit and only allow-listed names are blanked, so an
  allow-listed name that appears inside another attribute's value is left intact
  and a change to it is still compared. A value change to any other attribute, or
  an attribute the source did not have, is flagged.

## Tests

`test_builtin_warnings.php::test_tags`:

- appending an attribute to a tag now warns;
- a value change to a non-allow-list attribute now warns;
- an allow-listed name appearing inside another attribute's value is still
  compared, with or without whitespace before it;
- translated `title`/`alt`/`lang`/`aria-label` values still don't warn.

Full suite green.
