### PR TITLE
Fix PHP 8.1+ null deprecations on the glossary view page

### DIFF
--- a/gp-includes/things/glossary.php
+++ b/gp-includes/things/glossary.php
@@ -51,9 +51,7 @@ class GP_Glossary extends GP_Thing {
 	 * @return array Normalized arguments for a glossary.
 	 */
 	public function normalize_fields( $args ) {
-		// The description column is nullable, but consumers pass it through WP
-		// string functions (the gp_glossary_description filter, esc_textarea),
-		// which deprecate null in PHP 8.1+.
+		// The description column is nullable; keep it a string for its consumers.
 		if ( array_key_exists( 'description', $args ) ) {
 			$args['description'] = (string) $args['description'];
 		}

--- a/gp-includes/things/glossary.php
+++ b/gp-includes/things/glossary.php
@@ -43,6 +43,25 @@ class GP_Glossary extends GP_Thing {
 	}
 
 	/**
+	 * Normalizes an array with key-value pairs representing a glossary.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param array $args Arguments for a glossary.
+	 * @return array Normalized arguments for a glossary.
+	 */
+	public function normalize_fields( $args ) {
+		// The description column is nullable, but consumers pass it through WP
+		// string functions (the gp_glossary_description filter, esc_textarea),
+		// which deprecate null in PHP 8.1+.
+		if ( array_key_exists( 'description', $args ) ) {
+			$args['description'] = (string) $args['description'];
+		}
+
+		return parent::normalize_fields( $args );
+	}
+
+	/**
 	 * Get the path to the glossary.
 	 *
 	 * @return string

--- a/tests/phpunit/testcases/tests_things/test_thing_glossary.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_glossary.php
@@ -48,6 +48,16 @@ class GP_Test_Glossary extends GP_UnitTestCase {
 
 	}
 
+	function test_description_defaults_to_empty_string() {
+		$set      = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
+
+		// Reload from the database so the nullable column goes through the load path.
+		$reloaded = GP::$glossary->get( $glossary->id );
+
+		$this->assertSame( '', $reloaded->description );
+	}
+
 	/**
 	 * @ticket gh-435
 	 */


### PR DESCRIPTION
## Summary

Opening a glossary whose `description` is empty (e.g. an auto-created locale
glossary at `/languages/<locale>/default/glossary/`) emits PHP 8.1+ deprecations:

> Deprecated: str_contains(): Passing null to parameter #1 ($haystack)…
> Deprecated: preg_split(): Passing null to parameter #2 ($subject)…

The `glossaries.description` column is `DEFAULT NULL`, so a glossary saved
without a description loads as `null`. The view page runs that value through the
`gp_glossary_description` filter chain (`wptexturize`, `make_clickable`,
`wpautop`, …) and the edit form through `esc_textarea()` — all WP string
functions that deprecate `null` under PHP 8.1+.

## Changes

- Coerce `description` to a string in `GP_Glossary::normalize_fields()`, so every
  read path (view, edit, export, API) gets a string instead of `null`. Fixing it
  once at the model layer avoids scattering casts across the templates.

## Tests

- `GP_Test_Glossary::test_description_defaults_to_empty_string`: a glossary
  created without a description reloads with `''`, not `null`.

Full glossary suite green.
