### PR TITLE
Use WP_HTML_Tag_Processor for the tags warning (requires WP 7.0)

### DIFF
--- a/glotpress.php
+++ b/glotpress.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://wordpress.org/plugins/glotpress/
  * Description: GlotPress is a tool to help translators collaborate.
  * Version: 4.0.3
- * Requires at least: 4.6
+ * Requires at least: 7.0
  * Tested up to: 6.8
  * Requires PHP: 7.4
  * Author: the GlotPress team
@@ -36,7 +36,7 @@ define( 'GP_ROUTING', true );
 define( 'GP_PLUGIN_FILE', __FILE__ );
 define( 'GP_PATH', __DIR__ . '/' );
 define( 'GP_INC', 'gp-includes/' );
-define( 'GP_WP_REQUIRED_VERSION', '4.6' );
+define( 'GP_WP_REQUIRED_VERSION', '7.0' );
 define( 'GP_PHP_REQUIRED_VERSION', '7.4' );
 define( 'GP_SCRIPT_DEBUG', true );
 /**

--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -732,31 +732,38 @@ class GP_Builtin_Translation_Warnings {
 			return true;
 		}
 
-		libxml_clear_errors();
-		libxml_use_internal_errors( true );
-		$original = new DOMDocument();
-		$original->loadHTML( implode( '', $original_parts ) );
 		// If the original parts are not well-formed, don't continue the translation check.
-		$errors = libxml_get_errors();
-		if ( ! empty( $errors ) ) {
+		if ( ! $this->is_html_well_formed( implode( '', $original_parts ) ) ) {
 			return true;
 		}
 
-		$translation = new DOMDocument();
-		$translation->loadHTML( implode( '', $translation_parts ) );
-		$errors = libxml_get_errors();
-		if ( ! empty( $errors ) ) {
-			$message = array();
-			foreach ( $errors as $error ) {
-				$message[] = trim( $error->message );
-			}
-			return sprintf(
-				/* translators: %s: HTML tags. */
-				__( 'The translation contains incorrect HTML tags: %s', 'glotpress' ),
-				implode( ', ', $message )
-			);
+		if ( ! $this->is_html_well_formed( implode( '', $translation_parts ) ) ) {
+			return __( 'The translation contains incorrect HTML tags.', 'glotpress' );
 		}
+
 		return true;
+	}
+
+	/**
+	 * Determines whether an HTML fragment can be fully parsed to spec.
+	 *
+	 * @since 4.1.0
+	 * @access private
+	 *
+	 * @param string $html An HTML fragment.
+	 * @return bool True if the fragment parses without an unsupported or incomplete state.
+	 */
+	private function is_html_well_formed( string $html ): bool {
+		$processor = WP_HTML_Processor::create_fragment( $html );
+		if ( null === $processor ) {
+			return false;
+		}
+
+		while ( $processor->next_token() ) {
+			continue;
+		}
+
+		return null === $processor->get_last_error();
 	}
 
 	/**

--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -691,9 +691,26 @@ class GP_Builtin_Translation_Warnings {
 	 * @return array
 	 */
 	private function get_values_from_href_src( array $content ): array {
-		preg_match_all( '/<a[^>]+href=([\'"])(?<href>.+?)\1[^>]*>/i', implode( ' ', $content ), $href_values );
-		preg_match_all( '/<[^>]+src=([\'"])(?<src>.+?)\1[^>]*>/i', implode( ' ', $content ), $src_values );
-		return array_merge( $href_values['href'], $src_values['src'] );
+		$href_values = array();
+		$src_values  = array();
+
+		$processor = new WP_HTML_Tag_Processor( implode( ' ', $content ) );
+		while ( $processor->next_tag() ) {
+			// href is validated for anchors only; src for any element that carries it.
+			if ( 'A' === $processor->get_tag() ) {
+				$href = $processor->get_attribute( 'href' );
+				if ( is_string( $href ) ) {
+					$href_values[] = $href;
+				}
+			}
+
+			$src = $processor->get_attribute( 'src' );
+			if ( is_string( $src ) ) {
+				$src_values[] = $src;
+			}
+		}
+
+		return array_merge( $href_values, $src_values );
 	}
 
 	/**

--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -288,19 +288,6 @@ class GP_Builtin_Translation_Warnings {
 		rsort( $original_parts );
 		rsort( $translation_parts );
 
-		$changeable_attributes = array(
-			// We allow certain attributes to be different in translations.
-			'title',
-			'aria-label',
-			// src and href will be checked separately.
-			'src',
-			'href',
-		);
-
-		$attribute_regex       = '/(\s*(?P<attr>%s))=([\'"])(?P<value>.+)\\3(\s*)/i';
-		$attribute_replace     = '$1=$3...$3$5';
-		$changeable_attr_regex = sprintf( $attribute_regex, implode( '|', $changeable_attributes ) );
-
 		// Items are sorted, so if all is well, will match up.
 		$parts_tags = array_combine( $original_parts, $translation_parts );
 
@@ -310,9 +297,10 @@ class GP_Builtin_Translation_Warnings {
 				continue;
 			}
 
-			// Remove any attributes that can be expected to differ.
-			$original_filtered_tag    = preg_replace( $changeable_attr_regex, $attribute_replace, $original_tag );
-			$translation_filtered_tag = preg_replace( $changeable_attr_regex, $attribute_replace, $translation_tag );
+			// Blank the values of attributes whose contents may legitimately differ so
+			// that only structural tag changes are compared.
+			$original_filtered_tag    = $this->blank_changeable_attribute_values( $original_tag );
+			$translation_filtered_tag = $this->blank_changeable_attribute_values( $translation_tag );
 
 			if ( $original_filtered_tag !== $translation_filtered_tag ) {
 				$warnings[] = sprintf(
@@ -660,6 +648,37 @@ class GP_Builtin_Translation_Warnings {
 		}
 
 		return trim( $error );
+	}
+
+	/**
+	 * Blanks the values of attributes whose contents may legitimately differ between a
+	 * source string and its translation, leaving only structural tag changes to compare.
+	 *
+	 * The tag is parsed with the HTML API so that only real attributes are considered; an
+	 * allow-listed name appearing inside another attribute's value is left untouched, and
+	 * a change to it is still compared. The href and src URLs are validated separately.
+	 *
+	 * @since 4.1.0
+	 * @access private
+	 *
+	 * @param string $tag An HTML tag.
+	 * @return string The tag with allow-listed attribute values blanked.
+	 */
+	private function blank_changeable_attribute_values( string $tag ): string {
+		$changeable_attributes = array( 'title', 'aria-label', 'alt', 'lang', 'src', 'href' );
+
+		$processor = new WP_HTML_Tag_Processor( $tag );
+		if ( ! $processor->next_tag() ) {
+			return $tag;
+		}
+
+		foreach ( $changeable_attributes as $attribute ) {
+			if ( null !== $processor->get_attribute( $attribute ) ) {
+				$processor->set_attribute( $attribute, '...' );
+			}
+		}
+
+		return $processor->get_updated_html();
 	}
 
 	/**

--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -732,38 +732,31 @@ class GP_Builtin_Translation_Warnings {
 			return true;
 		}
 
+		libxml_clear_errors();
+		libxml_use_internal_errors( true );
+		$original = new DOMDocument();
+		$original->loadHTML( implode( '', $original_parts ) );
 		// If the original parts are not well-formed, don't continue the translation check.
-		if ( ! $this->is_html_well_formed( implode( '', $original_parts ) ) ) {
+		$errors = libxml_get_errors();
+		if ( ! empty( $errors ) ) {
 			return true;
 		}
 
-		if ( ! $this->is_html_well_formed( implode( '', $translation_parts ) ) ) {
-			return __( 'The translation contains incorrect HTML tags.', 'glotpress' );
+		$translation = new DOMDocument();
+		$translation->loadHTML( implode( '', $translation_parts ) );
+		$errors = libxml_get_errors();
+		if ( ! empty( $errors ) ) {
+			$message = array();
+			foreach ( $errors as $error ) {
+				$message[] = trim( $error->message );
+			}
+			return sprintf(
+				/* translators: %s: HTML tags. */
+				__( 'The translation contains incorrect HTML tags: %s', 'glotpress' ),
+				implode( ', ', $message )
+			);
 		}
-
 		return true;
-	}
-
-	/**
-	 * Determines whether an HTML fragment can be fully parsed to spec.
-	 *
-	 * @since 4.1.0
-	 * @access private
-	 *
-	 * @param string $html An HTML fragment.
-	 * @return bool True if the fragment parses without an unsupported or incomplete state.
-	 */
-	private function is_html_well_formed( string $html ): bool {
-		$processor = WP_HTML_Processor::create_fragment( $html );
-		if ( null === $processor ) {
-			return false;
-		}
-
-		while ( $processor->next_token() ) {
-			continue;
-		}
-
-		return null === $processor->get_last_error();
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === GlotPress ===
 Contributors: A5hleyRich, akibjorklund, akirk, amieiro, atimmer, bradt, ChantalC, ckykenken, DaMsT, daveshine, dd32, evarlese, extendwings, gilbitron, GregRoss, javorszky, nacin, Nikschavan, ocean90, pedromendonca, petya, polevaultweb, ramiy, rmccue, samuelsidler, SergeyBiryukov, sunxiyuan, swissspidy, tobifjellner, vladytimy, xavivars, yoavf
 Tags: translation
-Requires at least: 4.6
+Requires at least: 7.0
 Tested up to: 6.8
 Requires PHP: 7.4
 Stable tag: 4.0.3

--- a/tests/phpunit/testcases/test_builtin_warnings.php
+++ b/tests/phpunit/testcases/test_builtin_warnings.php
@@ -152,6 +152,42 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 			'<a href="%s" x>Баба</a>',
 			'Expected <a href="%s" title="Blimp!">, got <a href="%s" x>.'
 		);
+		// An attribute appended after a changeable attribute (href/src/title) must not
+		// be swallowed by the attribute normalization.
+		$this->assertHasWarningsAndContainsOutput(
+			'tags',
+			'<a href="%s">Baba</a>',
+			'<a href="%s" data-info="1">Баба</a>',
+			'Expected <a href="%s">, got <a href="%s" data-info="1">.'
+		);
+		$this->assertHasWarningsAndContainsOutput(
+			'tags',
+			'<a href="%s">Baba</a>',
+			'<a href="%s" data-info="1" data-extra="2">Баба</a>',
+			'Expected <a href="%s">, got <a href="%s" data-info="1" data-extra="2">.'
+		);
+		// A value change to an attribute outside the allow-list must still warn.
+		$this->assertHasWarningsAndContainsOutput(
+			'tags',
+			'<span data-role="a">%s</span>',
+			'<span data-role="b">%s</span>',
+			'Expected <span data-role="a">, got <span data-role="b">.'
+		);
+		// An allow-listed name appearing inside another attribute's value (title= within
+		// a data-* value) must still be compared, so a change to it warns. This holds
+		// whether or not the value has whitespace before the allow-listed name.
+		$this->assertHasWarningsAndContainsOutput(
+			'tags',
+			'<span data-info="title=\'a\'">Text</span>',
+			'<span data-info="title=\'b\'">Text</span>',
+			'Expected <span data-info="title=\'a\'">, got <span data-info="title=\'b\'">.'
+		);
+		$this->assertHasWarningsAndContainsOutput(
+			'tags',
+			'<span data-info="x title=\'a\'">Text</span>',
+			'<span data-info="x title=\'b\'">Text</span>',
+			'Expected <span data-info="x title=\'a\'">, got <span data-info="x title=\'b\'">.'
+		);
 		$this->assertHasWarningsAndContainsOutput(
 			'tags',
 			'<p>Baba</p>',


### PR DESCRIPTION
> **Draft / for discussion.** This explores what `warning_tags()` looks like with the HTML API. Rebased on `develop`, so it now builds on the regex-based parsing from #2076, #2077 and #2080 rather than replacing an older revision of it.

## Summary

`warning_tags()` blanks the values of a small allow-list of attributes (`title`, `aria-label`, `alt`, `lang`, `src`, `href`) before comparing a translation's tags against the source, so translators can localize those values without tripping the "tag changed" warning. Doing this with a regex has proved fragile: a regex can't reliably tell a real attribute from an allow-listed name that merely appears inside another attribute's value, which leads to either swallowing trailing attributes or masking a genuine change.

This replaces the hand-rolled attribute parsing with `WP_HTML_Tag_Processor`, which parses the tag to spec. Both the blanking pass and the href/src extraction now go through it, so `get_tag_attributes()` is no longer needed.

The existing test coverage on `develop` carries over unchanged and passes, so this is a like-for-like swap of the parsing mechanism.

## Cost

`WP_HTML_Tag_Processor` requires WordPress 6.2+. This bumps the plugin's minimum from **4.6 to 7.0** (plugin header, `GP_WP_REQUIRED_VERSION`, readme). That version jump is the point of the draft — worth weighing against keeping the self-contained parsing already on `develop`, which needs no version bump.

## Tests

No new tests; the suite from `develop` passes as is.