### PR TITLE
Compare href and src per parsed attribute in the tags warning

### DIFF
--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -683,7 +683,42 @@ class GP_Builtin_Translation_Warnings {
 	}
 
 	/**
+	 * Parses the quoted attributes of a single HTML tag.
+	 *
+	 * Each attribute is matched as a whole name="value" unit, so a name that appears
+	 * inside another attribute's value is not mistaken for an attribute of its own.
+	 * Where a name is repeated, the first occurrence wins, which is the one a browser
+	 * uses.
+	 *
+	 * @since 4.1.0
+	 * @access private
+	 *
+	 * @param string $tag An HTML tag.
+	 * @return array Attribute values keyed by lowercased attribute name.
+	 */
+	private function get_tag_attributes( string $tag ): array {
+		$attributes = array();
+
+		if ( ! preg_match_all( '/\s([\w-]+)=("[^"]*"|\'[^\']*\')/', $tag, $matches, PREG_SET_ORDER ) ) {
+			return $attributes;
+		}
+
+		foreach ( $matches as $match ) {
+			$name = strtolower( $match[1] );
+
+			if ( ! isset( $attributes[ $name ] ) ) {
+				$attributes[ $name ] = substr( $match[2], 1, -1 );
+			}
+		}
+
+		return $attributes;
+	}
+
+	/**
 	 * Returns the values from the href and the src
+	 *
+	 * Every tag carrying one of the two attributes is covered, so that the set of URLs
+	 * compared here matches the set blanked by blank_changeable_attribute_values().
 	 *
 	 * @since 3.0.0
 	 * @access private
@@ -692,9 +727,22 @@ class GP_Builtin_Translation_Warnings {
 	 * @return array
 	 */
 	private function get_values_from_href_src( array $content ): array {
-		preg_match_all( '/<a[^>]+href=([\'"])(?<href>.+?)\1[^>]*>/i', implode( ' ', $content ), $href_values );
-		preg_match_all( '/<[^>]+src=([\'"])(?<src>.+?)\1[^>]*>/i', implode( ' ', $content ), $src_values );
-		return array_merge( $href_values['href'], $src_values['src'] );
+		$href_values = array();
+		$src_values  = array();
+
+		foreach ( $content as $tag ) {
+			$attributes = $this->get_tag_attributes( $tag );
+
+			if ( isset( $attributes['href'] ) ) {
+				$href_values[] = $attributes['href'];
+			}
+
+			if ( isset( $attributes['src'] ) ) {
+				$src_values[] = $attributes['src'];
+			}
+		}
+
+		return array_merge( $href_values, $src_values );
 	}
 
 	/**

--- a/tests/phpunit/testcases/test_builtin_warnings.php
+++ b/tests/phpunit/testcases/test_builtin_warnings.php
@@ -195,6 +195,27 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 			'<span data-info="x title=\'b\'">Text</span>',
 			'Expected <span data-info="x title=\'a\'">, got <span data-info="x title=\'b\'">.'
 		);
+		// The URL compared is the tag's own href/src, not one that appears inside
+		// another attribute's value.
+		$this->assertHasWarningsAndContainsOutput(
+			'tags',
+			'<a href="https://www.example.org/docs">Docs</a>',
+			'<a href="https://www.example.com/?x=href=\'https://www.example.org/docs\'">Doku</a>',
+			'The translation appears to be missing the following URLs: https://www.example.org/docs'
+		);
+		$this->assertHasWarningsAndContainsOutput(
+			'tags',
+			'<img src="https://www.example.org/a.png" alt="A">',
+			'<img src="https://www.example.com/b.png?x=src=\'https://www.example.org/a.png\'" alt="B">',
+			'The translation appears to be missing the following URLs: https://www.example.org/a.png'
+		);
+		// href is compared on every tag that carries it, not only on <a>.
+		$this->assertHasWarningsAndContainsOutput(
+			'tags',
+			'<link href="https://www.example.org/style.css">',
+			'<link href="https://www.example.com/style.css">',
+			'The translation appears to be missing the following URLs: https://www.example.org/style.css'
+		);
 		$this->assertHasWarningsAndContainsOutput(
 			'tags',
 			'<p>Baba</p>',


### PR DESCRIPTION
`warning_tags()` picks the `href` and `src` values it compares out of the whole tag with a single regex, which can select a value from the wrong place when one attribute's value contains text resembling another attribute. The values are now read from a per-attribute parse of the tag, so the value compared is the one a browser would use.

This also extends the `href` comparison to every element carrying one rather than only `<a>`, matching the set of attributes `blank_changeable_attribute_values()` already normalises. Previously an `href` change on e.g. `<link>` was normalised away for the structural compare and then never URL-compared.

Alternative to #2079, which addresses the same parsing weakness with `WP_HTML_Tag_Processor` at the cost of raising the WordPress minimum to 7.0.