### PR TITLE
Escape carriage returns in the properties export

### DIFF
--- a/gp-includes/formats/format-properties.php
+++ b/gp-includes/formats/format-properties.php
@@ -49,7 +49,8 @@ class GP_Format_Properties extends GP_Format {
 				$translation = $entry->translations[0];
 			}
 
-			$translation = str_replace( "\n", "\\n", $translation );
+			// A bare CR terminates a logical line in this format, so it has to be escaped like LF.
+			$translation = str_replace( array( "\r", "\n" ), array( '\\r', '\\n' ), $translation );
 			$translation = $this->utf8_uni_encode( $translation );
 
 			if ( empty( $entry->context ) ) {
@@ -58,7 +59,7 @@ class GP_Format_Properties extends GP_Format {
 				$original = $entry->context;
 			}
 
-			$original = str_replace( "\n", "\\n", $original );
+			$original = str_replace( array( "\r", "\n" ), array( '\\r', '\\n' ), $original );
 
 			$comment = preg_replace( '/(^\s+)|(\s+$)/us', '', $entry->extracted_comments );
 
@@ -66,7 +67,7 @@ class GP_Format_Properties extends GP_Format {
 				$comment = 'No comment provided.';
 			}
 
-			$comment_lines = explode( "\n", $comment );
+			$comment_lines = preg_split( '/\r\n|\r|\n/', $comment );
 
 			foreach ( $comment_lines as $line ) {
 				$result .= "# $line\n";

--- a/tests/phpunit/testcases/tests_formats/test_format_properties.php
+++ b/tests/phpunit/testcases/tests_formats/test_format_properties.php
@@ -44,6 +44,27 @@ class GP_Test_Format_Properties extends GP_UnitTestCase {
 		$this->assertEquals( $file_contents, $exported );
 	}
 
+	function test_export_escapes_carriage_returns() {
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$project = $set->project;
+		$locale = $this->factory->locale->create();
+
+		$entries_for_export = array(
+			(object) array(
+				'context' => 'some.key',
+				'singular' => 'Some key',
+				'translations' => array( "ok\r" . 'app.update.url=https://example.org' ),
+				'extracted_comments' => "first\rsecond",
+			),
+		);
+
+		$exported = $this->properties->print_exported_file( $project, $locale, $set, $entries_for_export );
+
+		$this->assertStringNotContainsString( "\r", $exported );
+		$this->assertStringContainsString( 'some.key = ok\rapp.update.url=https://example.org' . "\n", $exported );
+		$this->assertStringContainsString( "# first\n# second\n", $exported );
+	}
+
 	function test_read_originals() {
 		$translations = $this->properties->read_originals_from_file( GP_DIR_TESTDATA . '/originals.properties' );
 

--- a/tests/phpunit/testcases/tests_formats/test_format_properties.php
+++ b/tests/phpunit/testcases/tests_formats/test_format_properties.php
@@ -51,7 +51,7 @@ class GP_Test_Format_Properties extends GP_UnitTestCase {
 
 		$entries_for_export = array(
 			(object) array(
-				'context' => 'some.key',
+				'context' => "some\rkey",
 				'singular' => 'Some key',
 				'translations' => array( "ok\r" . 'app.update.url=https://example.org' ),
 				'extracted_comments' => "first\rsecond",
@@ -61,7 +61,7 @@ class GP_Test_Format_Properties extends GP_UnitTestCase {
 		$exported = $this->properties->print_exported_file( $project, $locale, $set, $entries_for_export );
 
 		$this->assertStringNotContainsString( "\r", $exported );
-		$this->assertStringContainsString( 'some.key = ok\rapp.update.url=https://example.org' . "\n", $exported );
+		$this->assertStringContainsString( 'some\rkey = ok\rapp.update.url=https://example.org' . "\n", $exported );
 		$this->assertStringContainsString( "# first\n# second\n", $exported );
 	}
 


### PR DESCRIPTION
`print_exported_file()` folds line feeds into `\n` escapes but passes carriage returns through unchanged. A lone CR terminates a logical line in the Java properties format, so a translation or key containing one is split across physical lines and everything after it is read back as a separate entry.

CR is now escaped alongside LF in both the value and the key, and comments are split on all three line endings.