### PR TITLE
Keep import log messages to a single line

### DIFF
--- a/gp-includes/format.php
+++ b/gp-includes/format.php
@@ -10,6 +10,15 @@ abstract class GP_Format {
 	public $alt_extensions   = array();
 	public $filename_pattern = '%s-%s';
 
+	/**
+	 * Maximum length of a single value included in a log message.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @var int
+	 */
+	const LOG_VALUE_MAX_LENGTH = 200;
+
 	abstract public function print_exported_file( $project, $locale, $translation_set, $entries );
 	abstract public function read_originals_from_file( $file_name );
 
@@ -38,12 +47,23 @@ abstract class GP_Format {
 	protected function sanitize_for_log( $value ) {
 		$value = (string) $value;
 
-		// Falls back to the byte-wise class when the value is not valid UTF-8.
-		$collapsed = preg_replace( '/\s+/u', ' ', $value );
-		$value     = null === $collapsed ? preg_replace( '/\s+/', ' ', $value ) : $collapsed;
+		// A value read from an uploaded file is not guaranteed to be valid UTF-8. Both
+		// steps use the byte-wise functions when it is not, so that neither depends on
+		// an encoding the value does not have.
+		if ( preg_match( '//u', $value ) ) {
+			$value = preg_replace( '/\s+/u', ' ', $value );
 
-		if ( mb_strlen( $value ) > 200 ) {
-			$value = mb_substr( $value, 0, 200 ) . '…';
+			if ( mb_strlen( $value ) > self::LOG_VALUE_MAX_LENGTH ) {
+				$value = mb_substr( $value, 0, self::LOG_VALUE_MAX_LENGTH ) . '…';
+			}
+
+			return $value;
+		}
+
+		$value = preg_replace( '/\s+/', ' ', $value );
+
+		if ( strlen( $value ) > self::LOG_VALUE_MAX_LENGTH ) {
+			$value = substr( $value, 0, self::LOG_VALUE_MAX_LENGTH ) . '...';
 		}
 
 		return $value;

--- a/gp-includes/format.php
+++ b/gp-includes/format.php
@@ -24,6 +24,31 @@ abstract class GP_Format {
 		return array_merge( array( $this->extension ), $this->alt_extensions );
 	}
 
+	/**
+	 * Prepares a value read from an uploaded file for inclusion in a log message.
+	 *
+	 * Whitespace is collapsed and the length is capped so that the value stays on one
+	 * readable line whatever the file contained.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param string $value The value to prepare.
+	 * @return string The prepared value.
+	 */
+	protected function sanitize_for_log( $value ) {
+		$value = (string) $value;
+
+		// Falls back to the byte-wise class when the value is not valid UTF-8.
+		$collapsed = preg_replace( '/\s+/u', ' ', $value );
+		$value     = null === $collapsed ? preg_replace( '/\s+/', ' ', $value ) : $collapsed;
+
+		if ( mb_strlen( $value ) > 200 ) {
+			$value = mb_substr( $value, 0, 200 ) . '…';
+		}
+
+		return $value;
+	}
+
 	public function read_translations_from_file( $file_name, $project = null ) {
 		if ( is_null( $project ) ) {
 			return false;
@@ -61,7 +86,7 @@ abstract class GP_Format {
 					sprintf(
 						/* translators: 1: Context. 2: Project ID. */
 						__( 'Missing context %1$s in project #%2$d', 'glotpress' ),
-						$entry->context,
+						$this->sanitize_for_log( $entry->context ),
 						$project->id
 					)
 				);

--- a/gp-includes/formats/format-properties.php
+++ b/gp-includes/formats/format-properties.php
@@ -346,7 +346,7 @@ class GP_Format_Properties extends GP_Format {
 					sprintf(
 						/* translators: 1: Context. 2: Project ID. */
 						__( 'Missing context %1$s in project #%2$d', 'glotpress' ),
-						$entry->context,
+						$this->sanitize_for_log( $entry->context ),
 						$project->id
 					)
 				);

--- a/tests/phpunit/testcases/tests_formats/test_format_log.php
+++ b/tests/phpunit/testcases/tests_formats/test_format_log.php
@@ -1,0 +1,92 @@
+<?php
+
+class GP_Test_Format_Log extends GP_UnitTestCase {
+
+	/**
+	 * @var Testable_GP_Format_Log
+	 */
+	private $format;
+
+	function setUp(): void {
+		parent::setUp();
+		$this->format = new Testable_GP_Format_Log();
+	}
+
+	function test_sanitize_for_log_collapses_whitespace() {
+		$this->assertEquals( 'one two', $this->format->sanitize_for_log( "one\ntwo" ) );
+		$this->assertEquals( 'one two', $this->format->sanitize_for_log( "one\r\ntwo" ) );
+		$this->assertEquals( 'one two', $this->format->sanitize_for_log( "one\rtwo" ) );
+		$this->assertEquals( 'one two', $this->format->sanitize_for_log( "one \t\n two" ) );
+	}
+
+	function test_sanitize_for_log_leaves_a_plain_value_untouched() {
+		$this->assertEquals( 'some.key', $this->format->sanitize_for_log( 'some.key' ) );
+		$this->assertEquals( '', $this->format->sanitize_for_log( '' ) );
+		$this->assertEquals( '', $this->format->sanitize_for_log( null ) );
+	}
+
+	function test_sanitize_for_log_caps_the_length() {
+		$sanitized = $this->format->sanitize_for_log( str_repeat( 'a', 250 ) );
+
+		$this->assertEquals( str_repeat( 'a', GP_Format::LOG_VALUE_MAX_LENGTH ) . '…', $sanitized );
+	}
+
+	function test_sanitize_for_log_counts_multibyte_characters_not_bytes() {
+		$sanitized = $this->format->sanitize_for_log( str_repeat( 'ä', 250 ) );
+
+		$this->assertEquals( str_repeat( 'ä', GP_Format::LOG_VALUE_MAX_LENGTH ) . '…', $sanitized );
+	}
+
+	function test_sanitize_for_log_handles_invalid_utf8() {
+		$invalid = "one\ntwo" . chr( 0xC3 );
+
+		$this->assertEquals( 'one two' . chr( 0xC3 ), $this->format->sanitize_for_log( $invalid ) );
+	}
+
+	function test_sanitize_for_log_caps_the_length_of_invalid_utf8() {
+		$invalid   = chr( 0xC3 ) . str_repeat( 'a', 250 );
+		$sanitized = $this->format->sanitize_for_log( $invalid );
+
+		$this->assertEquals( GP_Format::LOG_VALUE_MAX_LENGTH + 3, strlen( $sanitized ) );
+		$this->assertEquals( substr( $invalid, 0, GP_Format::LOG_VALUE_MAX_LENGTH ) . '...', $sanitized );
+	}
+}
+
+/**
+ * Class used to test private/protected and/or override methods.
+ *
+ * @method string sanitize_for_log( string $value )
+ */
+class Testable_GP_Format_Log extends GP_Format {
+
+	/**
+	 * List of private/protected methods.
+	 *
+	 * @var array
+	 */
+	private $non_accessible_methods = array(
+		'sanitize_for_log',
+	);
+
+	/**
+	 * Make private/protected methods reachable for tests.
+	 *
+	 * @param string $name      Method to call.
+	 * @param array  $arguments Arguments to pass when calling.
+	 * @return mixed|bool Return value of the callback, false otherwise.
+	 */
+	public function __call( $name, $arguments ) {
+		if ( in_array( $name, $this->non_accessible_methods, true ) ) {
+			return $this->$name( ...$arguments );
+		}
+		return false;
+	}
+
+	public function print_exported_file( $project, $locale, $translation_set, $entries ) {
+		return '';
+	}
+
+	public function read_originals_from_file( $file_name ) {
+		return false;
+	}
+}


### PR DESCRIPTION
When an imported entry has no matching original, its context is written to the error log verbatim. A context carrying line breaks or a lot of text spreads that one message across the log and makes it unreadable.

Adds a shared `GP_Format` helper that collapses whitespace and caps the length, used by both import paths that emit this message.