### PR TITLE
Accept a single value for the priority filter

### DIFF
--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -405,7 +405,7 @@ class GP_Translation extends GP_Thing {
 		if ( $priorities ) {
 			$valid_priorities = array_keys( GP::$original->get_static( 'priorities' ) );
 			$priorities       = array_filter(
-				gp_array_get( $filters, 'priority' ),
+				(array) $priorities,
 				function ( $p ) use ( $valid_priorities ) {
 					return in_array( intval( $p ), $valid_priorities, true );
 				}

--- a/tests/phpunit/testcases/tests_things/test_thing_translation.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_translation.php
@@ -212,6 +212,18 @@ class GP_Test_Thing_Translation extends GP_UnitTestCase {
 		$this->assertEquals( null, $for_translation[0]->id );
 	}
 
+	function test_for_translation_accepts_a_scalar_priority_filter() {
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+
+		$original = $this->factory->original->create( array( 'project_id' => $set->project_id, 'priority' => 1 ) );
+		$this->factory->original->create( array( 'project_id' => $set->project_id, 'priority' => 0 ) );
+
+		$for_translation = GP::$translation->for_translation( $set->project, $set, 0, array( 'priority' => '1' ) );
+
+		$this->assertEquals( 1, count( $for_translation ) );
+		$this->assertEquals( $original->id, $for_translation[0]->original_id );
+	}
+
 	function test_for_translation_should_include_untranslated_by_default() {
 		$set = $this->factory->translation_set->create_with_project_and_locale();
 


### PR DESCRIPTION
`GP_Translation::for_translation()` hands `filters[priority]` straight to `array_filter()`, which requires an array. Both routes reading that filter narrow it to scalars beforehand, so a single priority in the query string raises a TypeError on PHP 8 and aborts the request.

The value is now cast before filtering.