### PR TITLE
Read the locales list directly in by_field()

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -2866,7 +2866,7 @@ class GP_Locales {
 		$instance = GP_Locales::instance();
 		$result   = false;
 
-		foreach( $instance->locales() as $locale ) {
+		foreach( $instance->locales as $locale ) {
 			if ( isset( $locale->$field_name ) && $locale->$field_name == $field_value ) {
 				$result = $locale;
 				break;


### PR DESCRIPTION
`GP_Locales::by_field()` fetches the singleton and then calls the static `locales()` method through that instance, which fetches the same singleton again to return its `$locales` property. It now reads the property directly, the way `exists()` and `by_slug()` beside it already do.

No behaviour change: both paths resolve to the same object, so this is purely the redundant second lookup going away. Worth noting for review that `by_field()` has no callers or tests inside GlotPress, so the suite does not cover it; behaviour was checked by hand against the real locale list and against an emptied singleton with a factory-added locale, which is the shape the test helpers create.