### PR TITLE
Allow glossary terms with non-word-character boundaries

### DIFF
--- a/gp-includes/things/glossary-entry.php
+++ b/gp-includes/things/glossary-entry.php
@@ -102,7 +102,6 @@ class GP_Glossary_Entry extends GP_Thing {
 	public function restrict_fields( $rules ) {
 		$rules->term_should_not_be( 'empty' );
 		$rules->term_should_be( 'consisting_only_of_ASCII_characters' );
-		$rules->term_should_be( 'starting_and_ending_with_a_word_character' );
 		$rules->part_of_speech_should_not_be( 'empty' );
 		$rules->part_of_speech_should_be( 'one_of', array_keys( $this->parts_of_speech ) );
 		$rules->glossary_id_should_be( 'positive_int' );

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -552,15 +552,19 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary 
 		ksort( $regex_group );
 
 		// Build the regular expression.
+		// Terms are bounded with lookarounds instead of \b because \b inverts
+		// its meaning next to a non-word character: a term like `note:` or
+		// `are you sure...?` could never match. For terms with word-character
+		// edges the lookarounds behave exactly like \b.
 		$placeholders_search = '%(?:(?:\d+\$)?(?:\d+)?)?[bcdefglosuxEFGX%@]';
-		$terms_search        = '(?:(\b|' . $placeholders_search . ')(';
+		$terms_search        = '(?:((?<!\w)|' . $placeholders_search . ')(';
 		foreach ( $regex_group as $suffix => $terms ) {
 			$terms_search .= '(?:' . implode( '|', $terms ) . ')' . $suffix . '|';
 		}
 
 		// Remove the trailing |.
 		$terms_search  = rtrim( $terms_search, '|' );
-		$terms_search .= ')\b)|(' . $placeholders_search . ')';
+		$terms_search .= ')(?!\w))|(' . $placeholders_search . ')';
 	}
 	// Split the singular string on glossary terms boundaries.
 	$singular_split = preg_split( '/' . $terms_search . '/i', $translation->singular, 0, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE );

--- a/tests/phpunit/testcases/test_template_helper_functions.php
+++ b/tests/phpunit/testcases/test_template_helper_functions.php
@@ -8,7 +8,8 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 	function test_map_glossary_entries_to_translation_originals_with_ampersand_in_glossary() {
 		$test_string = 'This string, <code>&lt;/body&gt;</code>, should not have the code tags mangled.';
 		$orig = '';
-		$expected_result = 'This string, &lt;code&gt;&amp;lt;/body<span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;&amp;amp;&quot;,&quot;pos&quot;:&quot;interjection&quot;,&quot;comment&quot;:null,&quot;locale_entry&quot;:&quot;&quot;}]">&amp;</span>gt;&lt;/code&gt;, should not have the code tags mangled.';
+		// The `&` glossary term must not match the `&` inside the `&lt;`/`&gt;` HTML entities.
+		$expected_result = 'This string, &lt;code&gt;&amp;lt;/body&amp;gt;&lt;/code&gt;, should not have the code tags mangled.';
 
 		$entry = new Translation_Entry( array( 'singular' => $test_string, ) );
 
@@ -19,6 +20,114 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 			'term' => '&',
 			'part_of_speech' => 'interjection',
 			'translation' => '&amp;',
+			'glossary_id' => $glossary->id,
+		);
+
+		GP::$glossary_entry->create_and_select( $glossary_entry );
+
+		$orig = map_glossary_entries_to_translation_originals( $entry, $glossary );
+
+		$this->assertEquals( $orig->singular_glossary_markup, $expected_result );
+	}
+
+	/**
+	 * Expects matching a standalone ampersand term [&].
+	 */
+	function test_map_glossary_entries_to_translation_originals_with_standalone_ampersand_in_glossary() {
+		$test_string = 'Categories & Tags';
+		$orig = '';
+		$expected_result = 'Categories ' . $this->glossary_match( 'e', 'conjunction', '&amp;' ) . ' Tags';
+
+		$entry = new Translation_Entry( array( 'singular' => $test_string, ) );
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
+
+		$glossary_entry = array(
+			'term' => '&',
+			'part_of_speech' => 'conjunction',
+			'translation' => 'e',
+			'glossary_id' => $glossary->id,
+		);
+
+		GP::$glossary_entry->create_and_select( $glossary_entry );
+
+		$orig = map_glossary_entries_to_translation_originals( $entry, $glossary );
+
+		$this->assertEquals( $orig->singular_glossary_markup, $expected_result );
+	}
+
+	/**
+	 * Expects matching a term ending in a non-word character [note:].
+	 */
+	function test_map_glossary_entries_to_translation_originals_with_trailing_colon_in_glossary() {
+		$test_string = 'Add a note: for the reviewer.';
+		$orig = '';
+		$expected_result = 'Add a ' . $this->glossary_match( 'nota:', 'noun', 'note:' ) . ' for the reviewer.';
+
+		$entry = new Translation_Entry( array( 'singular' => $test_string, ) );
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
+
+		$glossary_entry = array(
+			'term' => 'note:',
+			'part_of_speech' => 'noun',
+			'translation' => 'nota:',
+			'glossary_id' => $glossary->id,
+		);
+
+		GP::$glossary_entry->create_and_select( $glossary_entry );
+
+		$orig = map_glossary_entries_to_translation_originals( $entry, $glossary );
+
+		$this->assertEquals( $orig->singular_glossary_markup, $expected_result );
+	}
+
+	/**
+	 * Expects matching an expression term ending in punctuation [are you sure...?].
+	 */
+	function test_map_glossary_entries_to_translation_originals_with_punctuation_expression_in_glossary() {
+		$test_string = 'The prompt are you sure...? is shown once.';
+		$orig = '';
+		$expected_result = 'The prompt ' . $this->glossary_match( 'sigur ...?', 'expression', 'are you sure...?' ) . ' is shown once.';
+
+		$entry = new Translation_Entry( array( 'singular' => $test_string, ) );
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
+
+		$glossary_entry = array(
+			'term' => 'are you sure...?',
+			'part_of_speech' => 'expression',
+			'translation' => 'sigur ...?',
+			'glossary_id' => $glossary->id,
+		);
+
+		GP::$glossary_entry->create_and_select( $glossary_entry );
+
+		$orig = map_glossary_entries_to_translation_originals( $entry, $glossary );
+
+		$this->assertEquals( $orig->singular_glossary_markup, $expected_result );
+	}
+
+	/**
+	 * Expects matching a term containing brackets [display [location]].
+	 */
+	function test_map_glossary_entries_to_translation_originals_with_brackets_in_glossary() {
+		$test_string = 'The display [location] option.';
+		$orig = '';
+		$expected_result = 'The ' . $this->glossary_match( 'exibir [local]', 'expression', 'display [location]' ) . ' option.';
+
+		$entry = new Translation_Entry( array( 'singular' => $test_string, ) );
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
+
+		$glossary_entry = array(
+			'term' => 'display [location]',
+			'part_of_speech' => 'expression',
+			'translation' => 'exibir [local]',
 			'glossary_id' => $glossary->id,
 		);
 

--- a/tests/phpunit/testcases/tests_routes/test_route_glossary_entry_csv.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_glossary_entry_csv.php
@@ -42,6 +42,43 @@ class GP_Test_Route_Glossary_Entry_Csv extends GP_UnitTestCase_Route {
 		$this->assertStringNotContainsString( "\tplus", $csv );
 	}
 
+	function test_import_accepts_terms_with_non_word_character_boundaries() {
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+
+		$set      = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create( array( 'translation_set_id' => $set->id ) );
+
+		$file = tempnam( sys_get_temp_dir(), 'gp-glossary' );
+		$f    = fopen( $file, 'w' );
+		fputcsv( $f, array( 'Term', $set->locale, 'Part of speech', 'Comments' ), ',', '"', '' );
+		fputcsv( $f, array( 'are you sure...?', 'sigur ...?', 'expression', '' ), ',', '"', '' );
+		fputcsv( $f, array( 'note:', 'nota:', 'noun', '' ), ',', '"', '' );
+		fputcsv( $f, array( 'display [location]', 'exibir [local]', 'expression', '' ), ',', '"', '' );
+		fputcsv( $f, array( 'bogus', 'bogus', 'not-a-part-of-speech', '' ), ',', '"', '' );
+		fclose( $f );
+
+		$method = new ReflectionMethod( GP_Route_Glossary_Entry::class, 'read_glossary_entries_from_file' );
+		$method->setAccessible( true );
+		$count = $method->invoke( new GP_Route_Glossary_Entry(), $file, $glossary->id, $set->locale );
+
+		unlink( $file );
+
+		// The three punctuation-edged terms import; the invalid part of speech row is still skipped.
+		$this->assertSame( 3, $count );
+
+		$entry = GP::$glossary_entry->find_one( array( 'glossary_id' => $glossary->id, 'term' => 'are you sure...?' ) );
+		$this->assertSame( 'sigur ...?', $entry->translation );
+
+		$entry = GP::$glossary_entry->find_one( array( 'glossary_id' => $glossary->id, 'term' => 'note:' ) );
+		$this->assertSame( 'nota:', $entry->translation );
+
+		$entry = GP::$glossary_entry->find_one( array( 'glossary_id' => $glossary->id, 'term' => 'display [location]' ) );
+		$this->assertSame( 'exibir [local]', $entry->translation );
+
+		$this->assertEmpty( GP::$glossary_entry->find_one( array( 'glossary_id' => $glossary->id, 'term' => 'bogus' ) ) );
+	}
+
 	function test_import_reverses_the_formula_escape() {
 		$route = new Testable_GP_Route_Glossary_Entry_Csv();
 

--- a/tests/phpunit/testcases/tests_things/test_thing_glossary_entry.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_glossary_entry.php
@@ -44,6 +44,27 @@ class GP_Test_Glossary_Entry extends GP_UnitTestCase {
 		$this->assertFalse( $verdict );
 	}
 
+	function test_term_with_trailing_punctuation() {
+		$glossary_entry = GP::$glossary_entry->create( array( 'glossary_id' => '1', 'term' => 'note:', 'part_of_speech' => 'noun', 'last_edited_by' =>'1' ) );
+		$verdict = $glossary_entry->validate();
+
+		$this->assertTrue( $verdict );
+	}
+
+	function test_term_with_punctuation_expression() {
+		$glossary_entry = GP::$glossary_entry->create( array( 'glossary_id' => '1', 'term' => 'are you sure...?', 'part_of_speech' => 'expression', 'last_edited_by' =>'1' ) );
+		$verdict = $glossary_entry->validate();
+
+		$this->assertTrue( $verdict );
+	}
+
+	function test_term_with_brackets() {
+		$glossary_entry = GP::$glossary_entry->create( array( 'glossary_id' => '1', 'term' => 'display [location]', 'part_of_speech' => 'expression', 'last_edited_by' =>'1' ) );
+		$verdict = $glossary_entry->validate();
+
+		$this->assertTrue( $verdict );
+	}
+
 	function test_by_glossary_id() {
 		$glossary_entry_1 = GP::$glossary_entry->create( array( 'glossary_id' => '1', 'term' => 'term', 'part_of_speech' => 'verb', 'last_edited_by' =>'1' ) );
 		$glossary_entry_2 = GP::$glossary_entry->create( array( 'glossary_id' => '2', 'term' => 'term', 'part_of_speech' => 'verb', 'last_edited_by' =>'1' ) );


### PR DESCRIPTION
Fixes #2006
Fixes #1996

Both issues have one root cause. The glossary tooltip matcher wraps every term in \b word boundaries, and \b inverts its meaning next to a non-word character. A term like `note:` or `are you sure...?` can never match real text, because \b after the final punctuation demands a word character to follow. The validation rule `starting_and_ending_with_a_word_character` exists only to block terms the matcher would lose. That is why such entries fail on manual entry and get silently dropped on CSV import, including entries that already exist in the wordpress.org Romanian glossary.

The fix repairs the matcher first, then removes the gate:

- The built regex now bounds terms with lookarounds, `(?<!\w)` and `(?!\w)`, instead of \b. For terms with word-character edges this behaves exactly like before. For punctuation-edged terms it now works.
- The `starting_and_ending_with_a_word_character` rule is removed from glossary entry validation. The validator function itself stays registered for backward compatibility. The ASCII-only rule stays, since terms remain English.

Behaviour notes:

- A `&` term previously matched only when glued between word characters, which means inside HTML entities like `body&gt;`, and missed a standalone `Categories & Tags`. The lookarounds fix both directions. One existing test expectation was updated for this and a standalone `&` test was added.
- The old rule incidentally rejected terms with leading or trailing whitespace, or punctuation-only terms like `.`. Such terms now save. This is user-created junk data rather than a correctness issue. A narrower guard, for example requiring at least one letter or digit, can be a follow-up if wanted.
- CSV import still skips rows that fail other validation, for example an invalid part of speech, without feedback. A skipped-rows notice would be a good follow-up for the "silently" part of #2006.

Testing done:

- 4 new matcher tests: `note:`, `are you sure...?`, `display [location]`, standalone `&`
- 3 new validation tests for punctuation-edged terms
- New CSV import regression test covering the exact #2006 case, including one invalid row that is still skipped
- Full PHPUnit suite passes (502 tests), phpcs clean on changed files
- Verified end to end in wp-env: both terms save through the glossary UI form, a CSV with punctuation-edged terms imports with the correct count, the terms show underlined in the translation editor and the hover tooltip shows the translation

---

Related: #1765

This uses the same lookarounds as pedro-mendonca's draft #1766, arrived at independently. On top of the matcher change, this PR removes the `starting_and_ending_with_a_word_character` validation gate and adds CSV import and entry-level tests, which is what closes #2006 and #1996.

On #1765 itself: the reported false positive on named character references is fixed and asserted in this PR's tests. The `&` term no longer matches inside `&lt;`/`&gt;`, and a standalone `&` (`Categories & Tags`) still matches. Numeric character references still false-positive (`&#38;`, `&#8212;`, `&#x26;`), because the character after `&` is `#`, which is not a word character. That class needs entity-aware matching rather than boundary tuning, so this PR does not claim to fix #1765.


## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus
Used for: Root cause investigation, the implementation and tests, running the test suite and the manual verification, and drafting this description. I reviewed the reasoning and every result before opening the PR and take responsibility for the contribution.
