### PR TITLE
Use Plural_Forms to resolve the plural form index

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -223,9 +223,22 @@ class GP_Locale {
 	 */
 	public function index_for_number( $number ) {
 		if ( ! isset( $this->_index_for_number ) ) {
-			$gettext = new Gettext_Translations;
-			$expression = $gettext->parenthesize_plural_exression( $this->plural_expression );
-			$this->_index_for_number = $gettext->make_plural_form_function( $this->nplurals, $expression );
+			if ( class_exists( 'Plural_Forms' ) ) {
+				try {
+					$plural_forms = new Plural_Forms( rtrim( $this->plural_expression, ';' ) );
+				} catch ( Exception $e ) {
+					// Fall back to the default plural form, same as Gettext_Translations::make_plural_form_function().
+					$plural_forms = new Plural_Forms( 'n != 1' );
+				}
+
+				$this->_index_for_number = array( $plural_forms, 'get' );
+			} else {
+				// WordPress versions before 4.9 have no Plural_Forms class. There the expression
+				// is evaluated directly, so it still needs the ternary parts parenthesized.
+				$gettext                 = new Gettext_Translations();
+				$expression              = $gettext->parenthesize_plural_exression( $this->plural_expression );
+				$this->_index_for_number = $gettext->make_plural_form_function( $this->nplurals, $expression );
+			}
 		}
 
 		$f = $this->_index_for_number;

--- a/tests/phpunit/testcases/test_locale.php
+++ b/tests/phpunit/testcases/test_locale.php
@@ -11,5 +11,70 @@ class GP_Test_Locale extends GP_UnitTestCase {
 		$this->assertTrue( $locale->rtl );
 	}
 
+	/**
+	 * Data provider of plural expressions and the index expected for each number.
+	 *
+	 * Nested ternaries are the interesting cases, because they are the reason the
+	 * expression used to be parenthesized before being evaluated.
+	 */
+	function provide_plural_expressions() {
+		return array(
+			'no plurals (japanese)' => array(
+				1,
+				'0',
+				array( 0 => 0, 1 => 0, 2 => 0, 100 => 0 ),
+			),
+			'two forms (english)'   => array(
+				2,
+				'n != 1',
+				array( 0 => 1, 1 => 0, 2 => 1, 21 => 1 ),
+			),
+			'two forms (french)'    => array(
+				2,
+				'n > 1',
+				array( 0 => 0, 1 => 0, 2 => 1, 21 => 1 ),
+			),
+			'three forms (russian)' => array(
+				3,
+				'(n%10==1 && n%100!=11) ? 0 : ((n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20)) ? 1 : 2)',
+				array( 0 => 2, 1 => 0, 2 => 1, 5 => 2, 11 => 2, 21 => 0, 22 => 1, 25 => 2 ),
+			),
+			'three forms (polish)'  => array(
+				3,
+				'(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2)',
+				array( 1 => 0, 2 => 1, 5 => 2, 12 => 2, 22 => 1, 25 => 2 ),
+			),
+			'six forms (arabic)'    => array(
+				6,
+				'n == 0 ? 0 : n == 1 ? 1 : n == 2 ? 2 : n % 100 >= 3 && n % 100 <= 10 ? 3 : n % 100 >= 11 && n % 100 <= 99 ? 4 : 5',
+				array( 0 => 0, 1 => 1, 2 => 2, 5 => 3, 15 => 4, 100 => 5 ),
+			),
+		);
+	}
 
+	/**
+	 * @dataProvider provide_plural_expressions
+	 */
+	function test_index_for_number( $nplurals, $plural_expression, $expected ) {
+		$locale                    = $this->factory->locale->create();
+		$locale->nplurals          = $nplurals;
+		$locale->plural_expression = $plural_expression;
+
+		foreach ( $expected as $number => $index ) {
+			$this->assertSame( $index, $locale->index_for_number( $number ), "number {$number}" );
+		}
+	}
+
+	/**
+	 * An expression which cannot be parsed falls back to the default plural form.
+	 */
+	function test_index_for_number_with_invalid_expression() {
+		$locale                    = $this->factory->locale->create();
+		$locale->nplurals          = 2;
+		$locale->plural_expression = 'this is not an expression';
+
+		$this->assertSame( 1, $locale->index_for_number( 0 ) );
+		$this->assertSame( 0, $locale->index_for_number( 1 ) );
+		$this->assertSame( 1, $locale->index_for_number( 2 ) );
+	}
 }


### PR DESCRIPTION
Fixes #1836

`GP_Locale::index_for_number()` calls `Gettext_Translations::parenthesize_plural_exression()`, which WordPress deprecated in 6.5 in favour of the `Plural_Forms` class.

Core's `make_plural_form_function()` already builds a `Plural_Forms` object internally, so on WordPress 4.9 and later this change just calls it directly and drops the parenthesizing step, which is only needed for the older evaluation approach. Behaviour is unchanged.

WordPress versions before 4.9 have no `Plural_Forms` class, and `GP_WP_REQUIRED_VERSION` is still 4.6, so the previous code stays behind a `class_exists()` check. The method is not deprecated on those versions, so nothing is lost there. That branch can be deleted whenever the minimum WordPress version is raised to 4.9 or higher.

Testing done:

- New tests for `index_for_number()` covering single form (Japanese), two forms (English, French), three forms (Russian, Polish) and six forms (Arabic), plus a test that an unparsable expression falls back to the default plural form. Nested ternaries are the interesting cases here, since they are the reason the expression used to be parenthesized.
- Ran every one of the 250 shipped locales through both branches of the guard for n = 0 to 299, which is 75000 comparisons. No mismatches between the two branches, no expression that `Plural_Forms` fails to parse, and no index outside the range of the locale's `nplurals`.
- Full suite and the `locales` group pass, phpcs clean.
- Checked in the browser as well: the plural number hints in the translation editor for Russian still show 1, 21, 31 and 2, 3, 4 and 0, 5, 6. This matters because `index_for_number()` also feeds `numbers_for_index()`, which is used by the translation warnings and errors, not only by the editor template.

One thing worth noting separately: an empty plural expression throws an exception from `Plural_Forms`, but that is the case on develop today as well, with the same message, so it is not introduced here. Every shipped locale has an expression and the class default is `n != 1`, so it is not reachable in normal use.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus
Used for: Root cause investigation, the implementation and tests, running the test suite and the manual verification, and drafting this description. I reviewed the reasoning and every result before opening the PR and take responsibility for the contribution.
