### PR TITLE
Reject and strip control characters that break exports

### DIFF
--- a/gp-includes/errors.php
+++ b/gp-includes/errors.php
@@ -170,6 +170,35 @@ class GP_Builtin_Translation_Errors {
 	}
 
 	/**
+	 * Adds an error for a translation containing forbidden control characters.
+	 *
+	 * These characters break exported files. 0x04 is the context separator
+	 * of the gettext formats, so msgfmt rejects a catalog that contains it
+	 * in a string, and XML 1.0 cannot represent any C0 control character
+	 * apart from tab, line feed and carriage return, which makes the
+	 * Android and .NET exports invalid documents. Tab, line feed and
+	 * carriage return themselves are legitimate and stay allowed.
+	 *
+	 * @since 4.1.0
+	 * @access public
+	 *
+	 * @param string $original    The source string.
+	 * @param string $translation The translation.
+	 * @return string|true True if check is OK, otherwise error message.
+	 */
+	public function error_control_characters( $original, $translation ) {
+		if ( preg_match( '/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', $translation, $match ) ) {
+			return sprintf(
+				/* translators: %s: Code point of the control character, e.g. U+0004. */
+				__( 'The translation contains the control character %s, which would break exported files.', 'glotpress' ),
+				sprintf( 'U+%04X', ord( $match[0] ) )
+			);
+		}
+
+		return true;
+	}
+
+	/**
 	 * Registers all methods starting with `error_` as built-in errors.
 	 *
 	 * @since 4.0.0

--- a/gp-includes/misc.php
+++ b/gp-includes/misc.php
@@ -470,6 +470,23 @@ function gp_is_starting_and_ending_with_a_word_character( $value ) {
 }
 
 /**
+ * Strips the control characters that cannot appear in exported files.
+ *
+ * Keeps tab, line feed and carriage return, which are legitimate in
+ * translations, and removes the remaining C0 control characters and DEL.
+ * 0x04 in particular is the context separator of the gettext formats,
+ * and XML 1.0 cannot represent any of these characters at all.
+ *
+ * @since 4.1.0
+ *
+ * @param string $text The text to strip.
+ * @return string The text without forbidden control characters.
+ */
+function gp_strip_forbidden_control_characters( $text ) {
+	return (string) preg_replace( '/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', '', (string) $text );
+}
+
+/**
  * Acts the same as core PHP setcookie() but its arguments are run through the gp_set_cookie filter.
  *
  * If the filter returns false, setcookie() isn't called.

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -301,7 +301,28 @@ class GP_Translation extends GP_Thing {
 	}
 
 	public function for_export( $project, $translation_set, $filters = null ) {
-		return GP::$translation->for_translation( $project, $translation_set, 'no-limit', $filters ? $filters : array( 'status' => 'current_or_untranslated' ) );
+		$entries = GP::$translation->for_translation( $project, $translation_set, 'no-limit', $filters ? $filters : array( 'status' => 'current_or_untranslated' ) );
+
+		// Strings that entered through an import were never checked by the
+		// blocking errors, so they can carry control characters that break
+		// the exported file (see GH#1975). Strip them on the way out, here
+		// rather than in the export route, so the WP-CLI export goes through
+		// the same treatment. Originals get the same stripping because a
+		// control character in a msgid breaks the file just as fatally.
+		foreach ( $entries as $entry ) {
+			foreach ( array( 'singular', 'plural', 'context' ) as $field ) {
+				if ( isset( $entry->{$field} ) && is_string( $entry->{$field} ) ) {
+					$entry->{$field} = gp_strip_forbidden_control_characters( $entry->{$field} );
+				}
+			}
+			foreach ( $entry->translations as $i => $form ) {
+				if ( is_string( $form ) ) {
+					$entry->translations[ $i ] = gp_strip_forbidden_control_characters( $form );
+				}
+			}
+		}
+
+		return $entries;
 	}
 
 	public function for_translation( $project, $translation_set, $page, $filters = array(), $sort = array() ) {

--- a/tests/phpunit/testcases/test_builtin_errors.php
+++ b/tests/phpunit/testcases/test_builtin_errors.php
@@ -118,4 +118,15 @@ class GP_Test_Builtin_Translation_Errors extends GP_UnitTestCase {
 			'The translation contains the following unexpected placeholders: 00%'
 		);
 	}
+
+	function test_error_control_characters() {
+		$this->assertNoErrors( 'control_characters', 'Original', 'A clean translation' );
+		$this->assertNoErrors( 'control_characters', 'Original', "Tabs\tnewlines\nand\rreturns are fine" );
+
+		$this->assertHasErrorsAndContainsOutput( 'control_characters', 'Original', "EOT\x04here", null, 'U+0004' );
+		$this->assertHasErrorsAndContainsOutput( 'control_characters', 'Original', "SOH\x01here", null, 'U+0001' );
+		$this->assertHasErrorsAndContainsOutput( 'control_characters', 'Original', "Bell\x07here", null, 'U+0007' );
+		$this->assertHasErrorsAndContainsOutput( 'control_characters', 'Original', "Escape\x1Bhere", null, 'U+001B' );
+		$this->assertHasErrorsAndContainsOutput( 'control_characters', 'Original', "Delete\x7Fhere", null, 'U+007F' );
+	}
 }

--- a/tests/phpunit/testcases/test_misc.php
+++ b/tests/phpunit/testcases/test_misc.php
@@ -62,4 +62,11 @@ class GP_Test_Misc extends GP_UnitTestCase {
 		$this->assertFalse( gp_is_valid_utf8( "\xED\xB0\x80" ) );
 		$this->assertFalse( gp_is_valid_utf8( "B\xFCch" ) );
 	}
+
+	function test_gp_strip_forbidden_control_characters() {
+		$this->assertSame( 'Guardaralteracoes', gp_strip_forbidden_control_characters( "Guardar\x04alteracoes" ) );
+		$this->assertSame( 'ABC', gp_strip_forbidden_control_characters( "\x01A\x02B\x07C\x7F" ) );
+		$this->assertSame( "Keep\ttabs\nnewlines\rreturns", gp_strip_forbidden_control_characters( "Keep\ttabs\nnewlines\rreturns" ) );
+		$this->assertSame( 'unchanged', gp_strip_forbidden_control_characters( 'unchanged' ) );
+	}
 }

--- a/tests/phpunit/testcases/tests_routes/test_route_translation.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_translation.php
@@ -197,4 +197,25 @@ class GP_Test_Route_Translation extends GP_UnitTestCase_Route {
 
 		$this->assertEquals( 'fuzzy', GP::$translation->get( $translation->id )->status, 'A legitimate in-project translated row must still be acted on.' );
 	}
+
+	function test_export_strips_control_characters() {
+		$set      = $this->factory->translation_set->create_with_project_and_locale();
+		$original = $this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => 'Save changes' ) );
+
+		// Created directly, the way an import does, so no blocking error runs.
+		$translation = $this->factory->translation->create( array(
+			'translation_set_id' => $set->id,
+			'original_id'        => $original->id,
+			'status'             => 'current',
+			'translation_0'      => "Guardar\x04alteracoes",
+		) );
+		$translation->set_as_current();
+
+		ob_start();
+		$this->route->export_translations_get( $set->project->path, $set->locale, $set->slug );
+		$po = ob_get_clean();
+
+		$this->assertStringNotContainsString( "\x04", $po );
+		$this->assertStringContainsString( 'Guardaralteracoes', $po );
+	}
 }

--- a/tests/phpunit/testcases/tests_things/test_thing_translation.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_translation.php
@@ -642,4 +642,43 @@ class GP_Test_Thing_Translation extends GP_UnitTestCase {
 		$this->assertEquals( 2, count( $waiting_translations ) );
 		$this->assertEquals( 1, count( $old_translations ) );
 	}
+
+	function test_for_export_strips_control_characters() {
+		$set      = $this->factory->translation_set->create_with_project_and_locale();
+		$original = $this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => 'Save changes' ) );
+
+		// Created directly, the way an import does, so no blocking error runs.
+		$translation = $this->factory->translation->create( array(
+			'translation_set_id' => $set->id,
+			'original_id'        => $original->id,
+			'status'             => 'current',
+			'translation_0'      => "Guardar\x04alteracoes",
+		) );
+		$translation->set_as_current();
+
+		// for_export() is the shared path of the web export route and the
+		// WP-CLI export command, so stripping here covers both.
+		$entries = GP::$translation->for_export( $set->project, $set, array( 'status' => 'current' ) );
+
+		$this->assertCount( 1, $entries );
+		$this->assertSame( 'Guardaralteracoes', $entries[0]->translations[0] );
+	}
+
+	function test_for_export_strips_control_characters_from_originals() {
+		$set      = $this->factory->translation_set->create_with_project_and_locale();
+		$original = $this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => "Bad\x04original" ) );
+
+		$translation = $this->factory->translation->create( array(
+			'translation_set_id' => $set->id,
+			'original_id'        => $original->id,
+			'status'             => 'current',
+			'translation_0'      => 'Uma traducao limpa',
+		) );
+		$translation->set_as_current();
+
+		$entries = GP::$translation->for_export( $set->project, $set, array( 'status' => 'current' ) );
+
+		$this->assertCount( 1, $entries );
+		$this->assertSame( 'Badoriginal', $entries[0]->singular );
+	}
 }


### PR DESCRIPTION
Fixes #1975

Control characters like 0x04 can enter translations through an import, which never runs the blocking errors. On export they make msgfmt fail on the .po file with "context separator <EOT> within string", and they turn the Android and .NET exports into invalid XML documents, since XML 1.0 cannot represent these characters at all. The full per-format breakdown is in the issue.

This implements both halves suggested there:

1. A new blocking error, error_control_characters, rejects [\x00-\x08\x0B\x0C\x0E-\x1F\x7F] when a translation is saved through the UI, and names the offending character in the message, for example U+0004. Tab, line feed and carriage return stay allowed since they are legitimate in translations.

2. GP_Translation::for_export() strips the same characters on the way out. The strip lives there rather than in the export route so that the WP-CLI export command, which calls for_export() directly, goes through the same treatment. Originals (singular, plural, context) get the same stripping, because a control character in a msgid breaks the file just as fatally as one in a translation.

The stored data is not modified. The strip happens only on the exported copy, so nothing destructive runs against the database.

Testing done:

- New tests: the blocking error (each character class rejected, tab and newlines allowed), the strip helper, the web export route end to end with a poisoned translation, for_export() directly since that is the path WP-CLI shares, and a poisoned original.
- Full PHPUnit suite passes. Mutation checked: reverting only the source changes makes exactly the new tests fail.
- Verified live on a site with poisoned data: all ten export formats produce clean files, msgfmt and xmllint accept the previously broken po, android and resx exports, and the same is confirmed through wp glotpress translation-set export for the CLI path.
- The blocking error was also verified through GP_Translation_Errors::check() integration: it fires with the right message, does not fire on multiline or tabbed translations, and coexists with the existing sprintf error.
- phpcs is clean on all changed files.

Considered and left out on purpose: the C1 range (0x80 to 0x9F), since the report and the broken tools are about C0 characters, and an import-time warning, since the export-time strip already covers strings that entered that way. Both are easy follow-ups if wanted.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus
Used for: Root cause investigation, the implementation and tests, running the test suite and the manual verification, and drafting this description. I reviewed the reasoning and every result before opening the PR and take responsibility for the contribution.
