### PR TITLE
Scope the project permission delete route to its project

### DIFF
--- a/gp-includes/router.php
+++ b/gp-includes/router.php
@@ -112,7 +112,7 @@ class GP_Router {
 
 			"get:/$project/-permissions"                      => array( 'GP_Route_Project', 'permissions_get' ),
 			"post:/$project/-permissions"                     => array( 'GP_Route_Project', 'permissions_post' ),
-			"get:/$project/-permissions/-delete/$dir"         => array( 'GP_Route_Project', 'permissions_delete' ),
+			"post:/$project/-permissions/-delete/$dir"        => array( 'GP_Route_Project', 'permissions_delete' ),
 
 			"get:/$project/-mass-create-sets"                 => array( 'GP_Route_Project', 'mass_create_sets_get' ),
 			"post:/$project/-mass-create-sets"                => array( 'GP_Route_Project', 'mass_create_sets_post' ),

--- a/gp-includes/router.php
+++ b/gp-includes/router.php
@@ -112,7 +112,7 @@ class GP_Router {
 
 			"get:/$project/-permissions"                      => array( 'GP_Route_Project', 'permissions_get' ),
 			"post:/$project/-permissions"                     => array( 'GP_Route_Project', 'permissions_post' ),
-			"post:/$project/-permissions/-delete/$dir"        => array( 'GP_Route_Project', 'permissions_delete' ),
+			"post:/$project/-permissions/-delete/$dir"        => array( 'GP_Route_Project', 'permissions_delete_post' ),
 
 			"get:/$project/-mass-create-sets"                 => array( 'GP_Route_Project', 'mass_create_sets_get' ),
 			"post:/$project/-mass-create-sets"                => array( 'GP_Route_Project', 'mass_create_sets_post' ),

--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -426,7 +426,7 @@ class GP_Route_Project extends GP_Route_Main {
 		$this->redirect( gp_url_current() );
 	}
 
-	public function permissions_delete( $project_path, $permission_id ) {
+	public function permissions_delete_post( $project_path, $permission_id ) {
 		$project = GP::$project->by_path( $project_path );
 
 		if ( ! $project ) {

--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -427,22 +427,22 @@ class GP_Route_Project extends GP_Route_Main {
 	}
 
 	public function permissions_delete( $project_path, $permission_id ) {
-		if ( $this->invalid_nonce_and_redirect( 'delete-project-permission_' . $permission_id ) ) {
-			return;
-		}
-
 		$project = GP::$project->by_path( $project_path );
 
 		if ( ! $project ) {
-			$this->die_with_404();
+			return $this->die_with_404();
+		}
+
+		if ( $this->invalid_nonce_and_redirect( 'delete-project-permission_' . $project->id . '_' . $permission_id ) ) {
+			return;
 		}
 
 		if ( $this->cannot_and_redirect( 'write', 'project', $project->id ) ) {
 			return;
 		}
 
-		$permission = GP::$permission->get( $permission_id );
-		if ( $permission ) {
+		$permission = GP::$validator_permission->get( $permission_id );
+		if ( $permission && (int) $permission->project_id === (int) $project->id ) {
 			if ( $permission->delete() ) {
 				$this->notices[] = __( 'Permission was deleted.', 'glotpress' );
 			} else {

--- a/gp-templates/project-permissions.php
+++ b/gp-templates/project-permissions.php
@@ -43,7 +43,12 @@ gp_tmpl_header();
 					<td><?php echo esc_html( $permission->action ); ?></td>
 					<td><?php echo esc_html( $permission->locale_slug ); ?></td>
 					<td><?php echo esc_html( $permission->set_slug ); ?></td>
-					<td><a href="<?php echo esc_url( gp_route_nonce_url( gp_url_join( gp_url_current(), '-delete/' . $permission->id ), 'delete-project-permission_' . $permission->id ) ); ?>" class="action delete"><?php _e( 'Delete', 'glotpress' ); ?></a></td>
+					<td>
+						<form action="<?php echo esc_url( gp_url_join( gp_url_current(), '-delete/' . $permission->id ) ); ?>" method="post">
+							<?php gp_route_nonce_field( 'delete-project-permission_' . $project->id . '_' . $permission->id ); ?>
+							<button type="submit" class="button is-link action delete"><?php _e( 'Delete', 'glotpress' ); ?></button>
+						</form>
+					</td>
 				</tr>
 			<?php endforeach; ?>
 		</tbody>

--- a/tests/phpunit/testcases/tests_routes/test_route_project.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_project.php
@@ -206,7 +206,7 @@ class GP_Test_Route_Project extends GP_UnitTestCase_Route {
 
 		$this->do_route_request(
 			function () use ( $project, $permission_id ) {
-				$this->route->permissions_delete( $project->path, $permission_id );
+				$this->route->permissions_delete_post( $project->path, $permission_id );
 			}
 		);
 

--- a/tests/phpunit/testcases/tests_routes/test_route_project.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_project.php
@@ -184,4 +184,115 @@ class GP_Test_Route_Project extends GP_UnitTestCase_Route {
 		$this->assertNotFalse( GP::$translation_set->get( $target_set->id ), 'The existing set must survive without delete permission.' );
 		$this->assertCount( 2, GP::$translation_set->by_project_id( $target_set->project->id ), 'The addition is applied while the removal is skipped.' );
 	}
+
+	private function become_writer_for_project( $project ) {
+		$user_id = $this->set_normal_user_as_current();
+
+		GP::$permission->create(
+			array(
+				'user_id'     => $user_id,
+				'action'      => 'write',
+				'object_type' => 'project',
+				'object_id'   => $project->id,
+			)
+		);
+
+		return $user_id;
+	}
+
+	private function delete_permission( $project, $permission_id, $nonce_project_id = null ) {
+		$nonce_project_id            = null === $nonce_project_id ? $project->id : $nonce_project_id;
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'delete-project-permission_' . $nonce_project_id . '_' . $permission_id );
+
+		$this->do_route_request(
+			function () use ( $project, $permission_id ) {
+				$this->route->permissions_delete( $project->path, $permission_id );
+			}
+		);
+
+		unset( $_REQUEST['_gp_route_nonce'] );
+	}
+
+	private function create_validator_permission( $project ) {
+		return GP::$validator_permission->create(
+			array(
+				'user_id'     => $this->factory->user->create(),
+				'action'      => 'approve',
+				'project_id'  => $project->id,
+				'locale_slug' => 'bg',
+				'set_slug'    => 'default',
+			)
+		);
+	}
+
+	public function test_permissions_delete_removes_a_validator_of_the_project() {
+		$project = $this->factory->project->create( array( 'name' => 'Owned', 'slug' => 'owned-permissions' ) );
+		$this->become_writer_for_project( $project );
+
+		$permission = $this->create_validator_permission( $project );
+
+		$this->delete_permission( $project, $permission->id );
+
+		$this->assertFalse( GP::$permission->get( $permission->id ), 'A validator of the project is deleted.' );
+	}
+
+	public function test_permissions_delete_leaves_a_validator_of_another_project() {
+		$project       = $this->factory->project->create( array( 'name' => 'Owned', 'slug' => 'owned-validators' ) );
+		$other_project = $this->factory->project->create( array( 'name' => 'Other', 'slug' => 'other-validators' ) );
+		$this->become_writer_for_project( $project );
+
+		$permission = $this->create_validator_permission( $other_project );
+
+		$this->delete_permission( $project, $permission->id );
+
+		$this->assertNotFalse( GP::$permission->get( $permission->id ), 'A validator of another project is not deleted.' );
+	}
+
+	public function test_permissions_delete_leaves_a_site_wide_admin_permission() {
+		$project = $this->factory->project->create( array( 'name' => 'Owned', 'slug' => 'owned-admins' ) );
+		$this->become_writer_for_project( $project );
+
+		$other_user = $this->factory->user->create();
+		$permission = GP::$permission->create(
+			array(
+				'user_id' => $other_user,
+				'action'  => 'admin',
+			)
+		);
+
+		$this->delete_permission( $project, $permission->id );
+
+		$this->assertNotFalse( GP::$permission->get( $permission->id ), 'A site-wide admin permission is not deleted.' );
+		$this->assertTrue( GP::$permission->user_can( $other_user, 'admin' ), 'The other user keeps the admin permission.' );
+	}
+
+	public function test_permissions_delete_leaves_a_project_write_permission() {
+		$project = $this->factory->project->create( array( 'name' => 'Owned', 'slug' => 'owned-writers' ) );
+		$this->become_writer_for_project( $project );
+
+		$permission = GP::$permission->create(
+			array(
+				'user_id'     => $this->factory->user->create(),
+				'action'      => 'write',
+				'object_type' => 'project',
+				'object_id'   => $project->id,
+			)
+		);
+
+		$this->delete_permission( $project, $permission->id );
+
+		$this->assertNotFalse( GP::$permission->get( $permission->id ), 'This route only removes validators, so a write permission is not deleted.' );
+	}
+
+	public function test_permissions_delete_rejects_a_nonce_issued_for_another_project() {
+		$project       = $this->factory->project->create( array( 'name' => 'Owned', 'slug' => 'owned-nonces' ) );
+		$other_project = $this->factory->project->create( array( 'name' => 'Other', 'slug' => 'other-nonces' ) );
+		$this->become_writer_for_project( $project );
+
+		$permission = $this->create_validator_permission( $project );
+
+		$this->delete_permission( $project, $permission->id, $other_project->id );
+
+		$this->assertNotFalse( GP::$permission->get( $permission->id ), 'A nonce issued for another project does not authorize the request.' );
+	}
 }


### PR DESCRIPTION
The delete action on a project's permissions screen resolved the permission by id alone. It never checked that the row belongs to the project in the URL, and because it went through `GP::$permission`, the lookup also reached rows the screen never lists: another project's validators, project `write`/`delete` rows, and the site-wide `admin` rows. The route now resolves the row through `GP_Validator_Permission` and requires it to belong to that project, so it only ever acts on what the screen actually offers.

While in there, the route is brought in line with the other delete routes:

- it answers a `POST` instead of a state-changing `GET`, and the screen submits a form rather than a link (`.button.is-link` keeps the existing look, so no CSS change)
- the nonce is bound to the project as well as the permission, which required resolving the project before verifying it, matching the order `permissions_post` already uses
- the handler is renamed to `permissions_delete_post`, the suffix its neighbours `permissions_post` and `delete_post` carry

Two notes for review. Any permissions page rendered before this deploy carries the old nonce, so an open tab needs a reload before the delete works. And the handler rename means a subclass overriding `permissions_delete` would no longer be reached by the router, which seemed worth the consistency given route classes are not a documented extension point.

Tests cover the intended deletion plus the four cases that must be left alone, and the route was additionally exercised over HTTP since the router mapping and the template are outside the PHPUnit harness.