### PR TITLE
Check write permission on the root level when moving a project there

### DIFF
--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -227,11 +227,12 @@ class GP_Route_Project extends GP_Route_Main {
 		}
 
 		$new_parent_id = (int) $updated_project->parent_project_id;
+		$new_parent    = $new_parent_id ? $new_parent_id : null;
 
 		// TODO: add id check as a validation rule
 		if ( $project->id == $new_parent_id ) {
 			$this->errors[] = __( 'The project cannot be parent of itself!', 'glotpress' );
-		} elseif ( $new_parent_id && $new_parent_id !== (int) $project->parent_project_id && ! $this->can( 'write', 'project', $new_parent_id ) ) {
+		} elseif ( $new_parent_id !== (int) $project->parent_project_id && ! $this->can( 'write', 'project', $new_parent ) ) {
 			$this->errors[] = __( 'You are not allowed to do that!', 'glotpress' );
 		} elseif ( $project->save( $updated_project ) ) {
 			$this->notices[] = __( 'The project was saved.', 'glotpress' );

--- a/tests/phpunit/testcases/tests_routes/test_route_project.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_project.php
@@ -79,6 +79,100 @@ class GP_Test_Route_Project extends GP_UnitTestCase_Route {
 		$this->assertSame( 'owned', $project->path );
 	}
 
+	public function test_writer_cannot_move_a_project_to_the_root_level() {
+		$user_id = $this->set_normal_user_as_current();
+		$parent  = $this->factory->project->create( array( 'name' => 'Parent', 'slug' => 'root-parent' ) );
+		$child   = $this->factory->project->create(
+			array(
+				'name'              => 'Child',
+				'slug'              => 'root-child',
+				'parent_project_id' => $parent->id,
+			)
+		);
+		$this->factory->project->create(
+			array(
+				'name'              => 'Grandchild',
+				'slug'              => 'root-grandchild',
+				'parent_project_id' => $child->id,
+			)
+		);
+
+		GP::$permission->create(
+			array(
+				'user_id'     => $user_id,
+				'action'      => 'write',
+				'object_type' => 'project',
+				'object_id'   => $child->id,
+			)
+		);
+
+		$this->edit_project(
+			$child,
+			array(
+				'name'              => 'Child',
+				'slug'              => 'root-child',
+				'parent_project_id' => 0,
+			)
+		);
+
+		$child->reload();
+		$this->assertSame( (int) $parent->id, (int) $child->parent_project_id, 'Moving a project to the root level requires write permission there.' );
+		$this->assertSame( 'root-parent/root-child', $child->path );
+		$this->assertSame( 'root-parent/root-child/root-grandchild', GP::$project->by_path( 'root-parent/root-child/root-grandchild' )->path, 'The descendant path is unchanged.' );
+	}
+
+	public function test_writer_can_still_rename_a_root_level_project() {
+		$user_id = $this->set_normal_user_as_current();
+		$project = $this->factory->project->create( array( 'name' => 'Top', 'slug' => 'top-level' ) );
+
+		GP::$permission->create(
+			array(
+				'user_id'     => $user_id,
+				'action'      => 'write',
+				'object_type' => 'project',
+				'object_id'   => $project->id,
+			)
+		);
+
+		$this->edit_project(
+			$project,
+			array(
+				'name'              => 'Top renamed',
+				'slug'              => 'top-level',
+				'parent_project_id' => 0,
+			)
+		);
+
+		$project->reload();
+		$this->assertSame( 'Top renamed', $project->name, 'A writer can still edit a project that already sits at the root level.' );
+		$this->assertSame( 0, (int) $project->parent_project_id );
+	}
+
+	public function test_admin_can_move_a_project_to_the_root_level() {
+		$this->set_admin_user_as_current();
+		$parent = $this->factory->project->create( array( 'name' => 'Parent', 'slug' => 'admin-parent' ) );
+		$child  = $this->factory->project->create(
+			array(
+				'name'              => 'Child',
+				'slug'              => 'admin-child',
+				'parent_project_id' => $parent->id,
+			)
+		);
+
+		$this->edit_project(
+			$child,
+			array(
+				'name'              => 'Child',
+				'slug'              => 'admin-child',
+				'parent_project_id' => 0,
+			)
+		);
+
+		$child->reload();
+		$this->assertSame( 0, (int) $child->parent_project_id );
+		$this->assertSame( 'admin-child', $child->path );
+	}
+
 	public function test_admin_can_reparent_a_project() {
 		$this->set_admin_user_as_current();
 		$parent  = $this->factory->project->create( array( 'name' => 'Parent', 'slug' => 'parent' ) );


### PR DESCRIPTION
`GP_Route_Project::edit_post()` checks `write` on the destination when a project is reparented, but the check was guarded on a truthy parent id. The root level is submitted as an empty value, so moving a project out of its parent and up to the root skipped the check entirely, which also rewrites the descendants' paths.

Creating a project at the root already goes through `can( 'write', 'project', null )` in `new_post()`. The destination check now runs for that target too, so both paths ask for the same grant. The condition still only fires when the parent actually changes, so a writer can go on editing a project that already sits at the root.

Worth noting for review: `can()` treats `null`, `0` and `''` identically here, since `user_can()` always ORs in the `object_id IS NULL` row. I checked that a project-scoped writer is denied for all three and that a global writer and an admin pass, so the normalisation to `null` is for readability rather than behaviour.

Three tests: a writer cannot move a child to the root, a writer can still rename a project already at the root, and an admin can perform the move.