### PR TITLE
Bind a submitted translation to the original the request authorizes

### DIFF
--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -260,6 +260,8 @@ class GP_Route_Translation extends GP_Route_Main {
 			return $this->die_with_error( __( 'An error has occurred. Please try again.', 'glotpress' ), 403 );
 		}
 
+		$authorized_original_id = (int) $original_id;
+
 		$translation_set = GP::$translation_set->by_project_id_slug_and_locale( $project->id, $translation_set_slug, $locale_slug );
 
 		if ( ! $translation_set ) {
@@ -270,11 +272,23 @@ class GP_Route_Translation extends GP_Route_Main {
 
 		$glossary = $this->get_extended_glossary( $translation_set, $project );
 
+		$can_write = $this->can( 'write', 'project', $project->id );
+
 		$output = array();
 		foreach ( gp_post( 'translation', array() ) as $original_id => $translations ) {
+			// The nonce covers a single original, which is the only one this request may write to.
+			if ( (int) $original_id !== $authorized_original_id ) {
+				continue;
+			}
+
 			$original = GP::$original->get( $original_id );
 
 			if ( ! $this->original_belongs_to_project( $original, $project ) ) {
+				continue;
+			}
+
+			// Hidden originals are left out of the listings of users without write permission.
+			if ( (int) $original->priority <= -2 && ! $can_write ) {
 				continue;
 			}
 
@@ -297,7 +311,7 @@ class GP_Route_Translation extends GP_Route_Main {
 
 			$data['status'] = 'waiting';
 
-			if ( $this->can( 'approve', 'translation-set', $translation_set->id ) || $this->can( 'write', 'project', $project->id ) ) {
+			if ( $this->can( 'approve', 'translation-set', $translation_set->id ) || $can_write ) {
 				$set_status = 'current';
 			} else {
 				$set_status = 'waiting';

--- a/tests/phpunit/testcases/tests_routes/test_route_translation.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_translation.php
@@ -176,6 +176,88 @@ class GP_Test_Route_Translation extends GP_UnitTestCase_Route {
 		$this->assertFalse( GP::$translation->find_one( array( 'original_id' => $foreign_original->id ) ), 'A translation must not be created for another project\'s original.' );
 	}
 
+	private function submit_translation( $set, $nonce_original_id, $submitted_original_id, $text ) {
+		$_POST['original_id']        = $nonce_original_id;
+		$_POST['translation']        = array( $submitted_original_id => array( $text ) );
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'add-translation_' . $nonce_original_id );
+
+		$this->do_route_request(
+			function () use ( $set ) {
+				$this->route->translations_post( $set->project->path, $set->locale, $set->slug );
+			}
+		);
+
+		unset( $_POST['original_id'], $_POST['translation'], $_REQUEST['_gp_route_nonce'] );
+	}
+
+	/**
+	 * A submitted translation is stored for the original the request is authorized for.
+	 */
+	function test_translations_post_stores_a_translation_for_the_submitted_original() {
+		$set      = $this->factory->translation_set->create_with_project_and_locale();
+		$original = $this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => 'Plain' ) );
+
+		$this->become_validator_for_set( $set );
+
+		$this->submit_translation( $set, $original->id, $original->id, 'Stored' );
+
+		$translation = GP::$translation->find_one( array( 'original_id' => $original->id ) );
+		$this->assertNotFalse( $translation, 'A translation is created for the submitted original.' );
+		$this->assertSame( 'current', $translation->status );
+	}
+
+	/**
+	 * The originals a request may write to are limited to the one it carries a nonce for.
+	 */
+	function test_translations_post_ignores_an_original_the_request_is_not_authorized_for() {
+		$set   = $this->factory->translation_set->create_with_project_and_locale();
+		$first = $this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => 'First' ) );
+		$other = $this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => 'Other' ) );
+
+		$this->become_validator_for_set( $set );
+
+		$this->submit_translation( $set, $first->id, $other->id, 'Elsewhere' );
+
+		$this->assertFalse( GP::$translation->find_one( array( 'original_id' => $other->id ) ), 'Only the original the nonce covers is written to.' );
+	}
+
+	/**
+	 * Originals that are kept out of the listings stay out of reach of the submit route too.
+	 */
+	function test_translations_post_ignores_a_hidden_original_without_write_permission() {
+		$set    = $this->factory->translation_set->create_with_project_and_locale();
+		$hidden = $this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => 'Not listed', 'priority' => -2 ) );
+
+		$user_id = $this->become_validator_for_set( $set );
+		$this->assertFalse( (bool) GP::$permission->user_can( $user_id, 'write', 'project', $set->project->id ) );
+
+		$this->submit_translation( $set, $hidden->id, $hidden->id, 'Should not be stored' );
+
+		$this->assertFalse( GP::$translation->find_one( array( 'original_id' => $hidden->id ) ), 'A hidden original is not written to without write permission.' );
+	}
+
+	/**
+	 * A user with write permission still sees and edits hidden originals.
+	 */
+	function test_translations_post_stores_a_hidden_original_with_write_permission() {
+		$set    = $this->factory->translation_set->create_with_project_and_locale();
+		$hidden = $this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => 'Not listed', 'priority' => -2 ) );
+
+		$user_id = $this->set_normal_user_as_current();
+		GP::$permission->create(
+			array(
+				'user_id'     => $user_id,
+				'action'      => 'write',
+				'object_type' => 'project',
+				'object_id'   => $set->project->id,
+			)
+		);
+
+		$this->submit_translation( $set, $hidden->id, $hidden->id, 'Stored by a writer' );
+
+		$this->assertNotFalse( GP::$translation->find_one( array( 'original_id' => $hidden->id ) ), 'A writer can still translate a hidden original.' );
+	}
+
 	/**
 	 * The tightened filter must still act on a legitimate in-project translated row.
 	 */


### PR DESCRIPTION
`translations_post()` verifies its nonce against the top-level `original_id`, then loops over the keys of the `translation[…]` array to decide what to write. Nothing tied the two together, so a submission could name a different original than the one the nonce covers. On top of that, the loop had no equivalent of the visibility rule the listings apply: `GP_Translation::for_translation()` hides originals with priority `-2` from users without project `write`, but the submit path would happily store a translation for one.

The loop now skips any original other than the authorized one, and skips hidden originals unless the user holds `write` on the project.

Two things for review. The editor only ever posts a single original per request (`original_id` plus the matching `translation[<id>][]`), so the binding does not narrow anything the UI does today; a client that batched several originals into one request would now have only the nonce-covered one applied. And the `write` lookup is hoisted out of the loop, which also replaces the second identical `can()` call in the status decision.

Four tests: the normal submission still stores and approves, a non-authorized original is ignored, a hidden original is ignored without write permission, and a writer can still translate a hidden original.