### PR TITLE
Require approve permission to open the glossary edit form

### DIFF
--- a/gp-includes/routes/glossary.php
+++ b/gp-includes/routes/glossary.php
@@ -93,6 +93,11 @@ class GP_Route_Glossary extends GP_Route_Main {
 
 		if ( ! $glossary ) {
 			$this->redirect_with_error( __( 'Cannot find glossary.', 'glotpress' ) );
+			return;
+		}
+
+		if ( $this->cannot_edit_glossary_and_redirect( $glossary ) ) {
+			return;
 		}
 
 		$translation_set = GP::$translation_set->get( $glossary->translation_set_id );

--- a/gp-templates/glossary-view.php
+++ b/gp-templates/glossary-view.php
@@ -37,7 +37,9 @@ if ( 0 === $project->id ) {
 		);
 		?>
 	</h2>
-	<?php gp_link_glossary_edit( $glossary, $translation_set, null, array( 'class' => 'button is-small' ) ); ?>
+	<?php if ( $can_edit ) : ?>
+		<?php gp_link_glossary_edit( $glossary, $translation_set, null, array( 'class' => 'button is-small' ) ); ?>
+	<?php endif; ?>
 	<?php gp_link_glossary_delete( $glossary, $translation_set, null, array( 'class' => 'button is-small' ) ); ?>
 </div>
 

--- a/tests/phpunit/testcases/tests_routes/test_route_glossary.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_glossary.php
@@ -3,6 +3,80 @@
 class GP_Test_Route_Glossary extends GP_UnitTestCase_Route {
 	public $route_class = 'GP_Route_Glossary';
 
+	private function load_edit_form( $glossary_id ) {
+		$this->route->loaded_template = null;
+
+		$this->do_route_request(
+			function () use ( $glossary_id ) {
+				$this->route->edit_get( $glossary_id );
+			}
+		);
+
+		return $this->route->loaded_template;
+	}
+
+	/**
+	 * The edit form is offered to the users who may act on it.
+	 */
+	function test_edit_form_is_shown_to_a_validator_of_the_glossary_set() {
+		$set      = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create( array( 'translation_set_id' => $set->id ) );
+
+		$this->become_validator_for_set( $set );
+
+		$this->assertSame( 'glossary-edit', $this->load_edit_form( $glossary->id ) );
+	}
+
+	/**
+	 * A validator of an unrelated set is not offered the form.
+	 */
+	function test_edit_form_is_not_shown_to_a_validator_of_another_set() {
+		$set       = $this->factory->translation_set->create_with_project_and_locale();
+		$other_set = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary  = GP::$glossary->create( array( 'translation_set_id' => $set->id ) );
+
+		$this->become_validator_for_set( $other_set );
+
+		$this->assertNull( $this->load_edit_form( $glossary->id ) );
+	}
+
+	/**
+	 * A glossary reached from a sub-project set still belongs to the parent set,
+	 * so the form follows that set rather than the one in the URL.
+	 */
+	function test_edit_form_is_not_shown_to_a_validator_of_a_sub_project_set() {
+		$parent_set      = $this->factory->translation_set->create_with_project_and_locale();
+		$parent_glossary = GP::$glossary->create( array( 'translation_set_id' => $parent_set->id ) );
+
+		$child_project = $this->factory->project->create( array( 'parent_project_id' => $parent_set->project->id ) );
+		$child_set     = $this->factory->translation_set->create(
+			array(
+				'project_id' => $child_project->id,
+				'locale'     => $parent_set->locale,
+				'slug'       => $parent_set->slug,
+			)
+		);
+		$child_set->project = $child_project;
+		$child_set->locale  = $parent_set->locale;
+		$child_set->slug    = $parent_set->slug;
+
+		$this->become_validator_for_set( $child_set );
+
+		$this->assertNull( $this->load_edit_form( $parent_glossary->id ) );
+	}
+
+	/**
+	 * Visitors without a session are not offered the form either.
+	 */
+	function test_edit_form_is_not_shown_to_a_visitor_without_a_session() {
+		$set      = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create( array( 'translation_set_id' => $set->id ) );
+
+		wp_set_current_user( 0 );
+
+		$this->assertNull( $this->load_edit_form( $glossary->id ) );
+	}
+
 	/**
 	 * Editing a glossary must not move it into another translation set via a
 	 * client-supplied translation_set_id.


### PR DESCRIPTION
`GP_Route_Glossary::edit_get()` was the only glossary route without a permission check. `delete_get()` right beside it has one, and `edit_post()` that the form submits to has one, so the form itself was reachable by anyone who knew a glossary id. It now runs the same check `edit_post()` uses, and the missing-glossary guard returns instead of falling through into a dereference.

The Edit button needed the same treatment to stay in step. `gp_link_glossary_edit_get()` gates on the translation set from the URL, while the route gates on the set the glossary belongs to. Those differ for a glossary inherited from a parent project, so a validator of a sub-project set would have been offered a button the route then refused. The template now uses the `$can_edit` verdict `glossary_entries_get()` already computes for the entry editing UI, which is derived from the glossary's own set.

Four tests: the form opens for a validator of the glossary's set, and stays closed for a validator of an unrelated set, a validator of a sub-project set, and a request without a session.

Not touched here: `gp_link_glossary_delete_get()` has the same URL-set versus glossary-set mismatch. Since `delete_get()` has always checked the glossary's set, that one is a button that leads nowhere rather than a gap, but it belongs in the same cleanup if you want it.