### PR TITLE
Prevent bulk approve from promoting translations with warnings

### DIFF
--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -531,6 +531,15 @@ class GP_Route_Translation extends GP_Route_Main {
 			if ( ! $translation ) {
 				continue;
 			}
+			if ( 'current' === $new_status && ! empty( $translation->warnings ) ) {
+				++$error;
+				$this->errors[] = sprintf(
+					/* translators: %d: Translation ID. */
+					__( 'Translation %d has warnings and was not approved.', 'glotpress' ),
+					(int) $translation->id
+				);
+				continue;
+			}
 			if ( $translation->set_status( $new_status ) ) {
 				++$ok;
 			} else {

--- a/tests/phpunit/testcases/tests_routes/test_route_translation.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_translation.php
@@ -279,4 +279,34 @@ class GP_Test_Route_Translation extends GP_UnitTestCase_Route {
 
 		$this->assertEquals( 'fuzzy', GP::$translation->get( $translation->id )->status, 'A legitimate in-project translated row must still be acted on.' );
 	}
+
+	/**
+	 * Bulk approving a waiting translation that has stored warnings must not
+	 * promote it to current. See issue #1994.
+	 */
+	function test_bulk_approve_does_not_promote_a_translation_with_warnings() {
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$this->become_validator_for_set( $set );
+
+		$original = $this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => 'A string with %s' ) );
+		$translation = $this->factory->translation->create( array(
+			'translation_set_id' => $set->id,
+			'original_id'        => $original->id,
+			'status'             => 'waiting',
+			'translations'       => array( 'No Placeholder' ),
+			'warnings'           => array( 0 => array( 'placeholders' => 'Missing %s placeholder in translation.' ) ),
+		) );
+
+		$_POST['bulk'] = array(
+			'action'      => 'approve',
+			'row-ids'     => $original->id . '-' . $translation->id,
+			'redirect_to' => '/',
+		);
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'bulk-actions' );
+
+		$this->route->bulk_post( $set->project->path, $set->locale, $set->slug );
+
+		$this->assertEquals( 'waiting', GP::$translation->get( $translation->id )->status, 'A waiting translation with warnings must not be promoted to current by bulk approve.' );
+		$this->assertNotEmpty( $this->route->errors, 'An error must be recorded for the skipped warning-laden row.' );
+	}
 }


### PR DESCRIPTION
Fixes #1994

## Problem

Bulk approving a waiting translation that had stored warnings (e.g. a missing or extra PHP-style placeholder) promoted it to `current` without any notice. The single-row approve path already rejects these, but the bulk loop called `set_status()` directly, so a validator could mark a placeholder-broken row current by ticking the checkbox and clicking &#34;Approve&#34;.

## Solution

In `GP_Route_Translation::_bulk_approve()`, skip the status change for any row whose translation has a non-empty `warnings` property and record a localized error per skipped row. The row stays `waiting` and the validator sees why it was not approved.

The guard fires only when `$new_status === &#39;current&#39;`, so the other bulk actions (`reject`, `changesrequested`) are not affected, and `fuzzy` is dispatched to a separate `_bulk_fuzzy()` that this change does not touch.

The check uses the already-stored `$translation-&gt;warnings` array, the same value the UI shows in the Warnings column. No re-run of `GP_Translation_Warnings::check()` per row.

## To-do

None.

## Testing Instructions

1. Start a fresh wp-env (`npm run env:start`) and install GlotPress from this branch.
2. Create or open a project with an active original that has a placeholder in the source, for example `A string with %s`.
3. As a contributor, submit a translation that drops the placeholder, e.g. `No Placeholder`. The row should be `waiting` and show a Warnings indicator.
4. As a validator/approver, open the waiting list, tick the row, and use the bulk action &#34;Approve&#34;.
5. Expected: the row stays `waiting`, the page shows an error notice per row, and no &#34;N translations were approved&#34; success notice is rendered.
6. Run the unit test that covers this case: `npm run env:phpunit -- --filter test_bulk_approve_does_not_promote_a_translation_with_warnings`. The full suite also passes (`npm run env:phpunit`, `npm run env:phpunit -- --group locales`).
7. Regression checks: bulk rejecting or requesting changes on the same row still works, bulk fuzzing a row still works, and bulk approving a row that has no warnings still promotes it to `current`. The single-row approve path (PR #2017) is unchanged.

## Screenshots or screencast

Not applicable (no visible UI change, only a behaviour fix).

## Use of AI Tools

- AI assistance: Yes
- Tool(s): Claude Code (CLI)
- Model(s): GLM 5.3
- Used for: implementation and test writing, reviewed and edited by me
