### PR TITLE
Add filter for warnings when importing translations

### DIFF
--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -335,7 +335,15 @@ class GP_Translation_Set extends GP_Thing {
 			 */
 			$entry->status = apply_filters( 'gp_translation_set_import_status', $is_fuzzy ? 'fuzzy' : $desired_status, $entry, null );
 
-			$entry->warnings = maybe_unserialize( GP::$translation_warnings->check( $entry->singular, $entry->plural, $entry->translations, $locale ) );
+			/**
+			 * Filters the warnings of imported translations of a translation set.
+			 *
+			 * @since 4.2.0
+			 *
+			 * @param array            $warnings The warnings array.
+			 * @param Translation_Entry $entry   The translation entry being imported.
+			 */
+			$entry->warnings = apply_filters( 'gp_translation_set_import_warnings', maybe_unserialize( GP::$translation_warnings->check( $entry->singular, $entry->plural, $entry->translations, $locale ) ), $entry );
 			if ( ! empty( $entry->warnings ) && 'current' === $entry->status ) {
 				$entry->status = 'waiting';
 			}

--- a/tests/phpunit/testcases/tests_things/test_thing_translation_set.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_translation_set.php
@@ -152,6 +152,45 @@ class GP_Test_Thing_Translation_set extends GP_UnitTestCase {
 
 	}
 
+	function test_filter_translation_set_import_warnings() {
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => 'A string with %s' ) );
+
+		$translations_for_import = new Translations;
+		$translations_for_import->add_entry( array( 'singular' => 'A string with %s', 'translations' => array( 'No Placeholder' ) ) );
+
+		add_filter( 'gp_translation_set_import_warnings', '__return_empty_array' );
+		$set->import( $translations_for_import );
+		remove_filter( 'gp_translation_set_import_warnings', '__return_empty_array' );
+
+		$translations = GP::$translation->all();
+		$this->assertEquals( 'current', $translations[0]->status );
+		$this->assertNull( $translations[0]->warnings );
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => 'A string with %s' ) );
+
+		$custom_warnings = array(
+			array(
+				'warning'   => 'custom_warning',
+				'position'  => 0,
+				'reference' => 'singular',
+			),
+		);
+
+		$custom_callback = function () use ( $custom_warnings ) {
+			return $custom_warnings;
+		};
+
+		add_filter( 'gp_translation_set_import_warnings', $custom_callback );
+		$set->import( $translations_for_import );
+		remove_filter( 'gp_translation_set_import_warnings', $custom_callback );
+
+		$translations = GP::$translation->all();
+		$this->assertSame( $custom_warnings, $translations[1]->warnings );
+		$this->assertEquals( 'waiting', $translations[1]->status );
+	}
+
 	function test_filter_translation_set_import_over_existing() {
 		$set = $this->factory->translation_set->create_with_project_and_locale();
 		$original = $this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => 'A string' ) );


### PR DESCRIPTION
## Problem

When importing translations via `GP_Translation_Set::import()`, warnings are auto-generated from `GP::$translation_warnings->check()` and assigned to `$entry->warnings` with no filter to modify them. Integrators who want to suppress, replace, or augment those warnings during import (e.g. to avoid known false positives, or to attach extra metadata) have no extension point.

The sibling `gp_translation_set_import_status` filter already exists for the import status, so the missing-warnings-filter gap is inconsistent.

Fixes #1853

## Solution

Add a new `gp_translation_set_import_warnings` filter, applied right after the warnings check in `GP_Translation_Set::import()`. It receives the warnings array and the `Translation_Entry`, mirroring the shape of the existing `gp_translation_set_import_status` filter.

```php
$entry->warnings = apply_filters( &#39;gp_translation_set_import_warnings&#39;, maybe_unserialize( GP::$translation_warnings->check( $entry->singular, $entry->plural, $entry->translations, $locale ) ), $entry );
```

When no callback is attached, behavior is identical to before. The `@since` tag is set to `4.2.0` (current `GP_VERSION` is `4.1.0`).

## To-do

- [x] Implement filter
- [x] Add unit test
- [x] Run PHPUnit and PHPCS

## Testing Instructions

Automated:

1. Run the full PHPUnit suite inside `wp-env`:
   ```
   npm run env:phpunit
   ```
2. The new test `test_filter_translation_set_import_warnings` in `tests/phpunit/testcases/tests_things/test_thing_translation_set.php` covers two cases:
   - A filter that returns an empty array: the entry is imported as `current` (no demotion to `waiting`).
   - A filter that returns a custom warnings array: the entry is demoted to `waiting` and the stored warnings match the custom array.
3. Run PHPCS:
   ```
   composer lint
   ```
   No new violations are introduced.

Manual (optional):

1. Add the following to an mu-plugin or a small custom plugin:
   ```php
   add_filter( &#39;gp_translation_set_import_warnings&#39;, &#39;__return_empty_array&#39; );
   ```
2. In GlotPress, open a translation set, import a PO file that contains translations with missing placeholders (which normally trigger a `placeholders` warning).
3. With the filter active, the imported translations land as `current` and the Warnings tab stays empty. Without the filter, the same entries land as `waiting` and the warning shows.
4. Remove the filter and confirm the warnings come back on the next import.

## Use of AI Tools

- AI assistance: Yes
- Tool(s): Claude Code (CLI)
- Model(s): GLM 5.3
- Used for: implementation and test writing, reviewed and edited by me
