### PR TITLE
fix: skip glossary terms bounded by hyphens

### DIFF
--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -553,14 +553,14 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary 
 
 		// Build the regular expression.
 		$placeholders_search = '%(?:(?:\d+\$)?(?:\d+)?)?[bcdefglosuxEFGX%@]';
-		$terms_search        = '(?:(\b|' . $placeholders_search . ')(';
+		$terms_search        = '(?:(?<!-)(\b|' . $placeholders_search . ')(';
 		foreach ( $regex_group as $suffix => $terms ) {
 			$terms_search .= '(?:' . implode( '|', $terms ) . ')' . $suffix . '|';
 		}
 
 		// Remove the trailing |.
 		$terms_search  = rtrim( $terms_search, '|' );
-		$terms_search .= ')\b)|(' . $placeholders_search . ')';
+		$terms_search .= ')(?=\b(?!-)))|(' . $placeholders_search . ')';
 	}
 	// Split the singular string on glossary terms boundaries.
 	$singular_split = preg_split( '/' . $terms_search . '/i', $translation->singular, 0, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE );

--- a/tests/phpunit/testcases/test_template_helper_functions.php
+++ b/tests/phpunit/testcases/test_template_helper_functions.php
@@ -84,6 +84,114 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 	}
 
 	/**
+	 * Expects that a single-word glossary term does not match inside a hyphenated compound
+	 * (e.g. term `add` in `add-on`).
+	 */
+	function test_glossary_term_does_not_match_inside_hyphenated_compound() {
+		$test_string       = 'Install the add-on now.';
+		$expected_result   = 'Install the add-on now.';
+
+		$entry = new Translation_Entry( array( 'singular' => $test_string ) );
+
+		$set      = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
+
+		GP::$glossary_entry->create_and_select(
+			array(
+				'term'           => 'add',
+				'part_of_speech' => 'verb',
+				'translation'    => 'toevoegen',
+				'glossary_id'    => $glossary->id,
+			)
+		);
+
+		$orig = map_glossary_entries_to_translation_originals( $entry, $glossary );
+
+		$this->assertEquals( $expected_result, $orig->singular_glossary_markup );
+	}
+
+	/**
+	 * Expects that a glossary term does not match when the original contains a longer word that
+	 * has the term as a prefix joined by a hyphen (e.g. term `content` in `wp-content`).
+	 */
+	function test_glossary_term_does_not_match_hyphenated_compound_of_term() {
+		$test_string       = 'Edit the wp-content directory.';
+		$expected_result   = 'Edit the wp-content directory.';
+
+		$entry = new Translation_Entry( array( 'singular' => $test_string ) );
+
+		$set      = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
+
+		GP::$glossary_entry->create_and_select(
+			array(
+				'term'           => 'content',
+				'part_of_speech' => 'noun',
+				'translation'    => 'inhoud',
+				'glossary_id'    => $glossary->id,
+			)
+		);
+
+		$orig = map_glossary_entries_to_translation_originals( $entry, $glossary );
+
+		$this->assertEquals( $expected_result, $orig->singular_glossary_markup );
+	}
+
+	/**
+	 * Expects that a single-word glossary term still matches at the end of the string.
+	 * Sanity check that the hyphen-aware right boundary does not regress the end-of-string case.
+	 */
+	function test_glossary_term_still_matches_at_end_of_string() {
+		$test_string     = 'Click add';
+		$expected_result = 'Click ' . $this->glossary_match( 'toevoegen', 'verb', 'add' );
+
+		$entry = new Translation_Entry( array( 'singular' => $test_string ) );
+
+		$set      = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
+
+		GP::$glossary_entry->create_and_select(
+			array(
+				'term'           => 'add',
+				'part_of_speech' => 'verb',
+				'translation'    => 'toevoegen',
+				'glossary_id'    => $glossary->id,
+			)
+		);
+
+		$orig = map_glossary_entries_to_translation_originals( $entry, $glossary );
+
+		$this->assertEquals( $expected_result, $orig->singular_glossary_markup );
+	}
+
+	/**
+	 * Expects that a single-word glossary term still matches when followed by a space or
+	 * punctuation. Guards against accidentally regressing non-hyphen word boundaries.
+	 */
+	function test_glossary_term_still_matches_before_space_and_punctuation() {
+		$test_string     = 'Click add. Then add now.';
+		$expected_result = 'Click ' . $this->glossary_match( 'toevoegen', 'verb', 'add' ) . '. Then ' . $this->glossary_match( 'toevoegen', 'verb', 'add' ) . ' now.';
+
+		$entry = new Translation_Entry( array( 'singular' => $test_string ) );
+
+		$set      = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
+
+		GP::$glossary_entry->create_and_select(
+			array(
+				'term'           => 'add',
+				'part_of_speech' => 'verb',
+				'translation'    => 'toevoegen',
+				'glossary_id'    => $glossary->id,
+			)
+		);
+
+		$orig = map_glossary_entries_to_translation_originals( $entry, $glossary );
+
+		$this->assertEquals( $expected_result, $orig->singular_glossary_markup );
+	}
+
+	/**
 	 * Expects matching a term with space and hyphen mixed [GlotPress WP-Team].
 	 */
 	function test_map_glossary_entries_to_translation_originals_with_spaces_and_hyphens_in_glossary() {


### PR DESCRIPTION
## Problem

A single-word glossary entry is incorrectly highlighted inside a hyphenated compound in the source string. For example, a glossary term `add` is matched and wrapped in when it appears as the first part of `add-on`. The same happens for `content` inside `wp-content`, `byte` inside `multi-byte`, etc.

This false positive is visible to translators and breaks downstream tooling such as GlotDict, which uses the span markup to enforce the glossary-approved translation and ends up blocking translators from keeping `add-on` untranslated.

The root cause is the regex built in `map_glossary_entries_to_translation_originals()` in `gp-templates/helper-functions.php`. It uses `\b` (PCRE word boundary) on the right side of the term alternation. `\b` fires on the transition between `\w` and `\W`, and `-` is `\W`, so the match goes through. The same applies to the left boundary when the term is preceded by `-` (e.g. `content` in `wp-content`).

Fixes #1832

## Solution

Tighten both boundaries in the glossary regex so a term no longer matches when the adjacent character is a hyphen.

- Left boundary: `(\b|placeholder)` → `(?` around `add`, and no glossary tooltip on hover.
6. Add another glossary entry: term `content`, translation `inhoud`.
7. Add an original with singular `Edit the wp-content directory.`.
8. Confirm `content` is not highlighted inside `wp-content`.
9. Add an original with the whole compound as the term itself: glossary term `add-on`, original `Install the add-on now.`. Confirm the whole `add-on` is still highlighted as a single glossary term.
10. Add originals `Click add.` and `Click add now.`. Confirm `add` is highlighted in both, before `.` and before the space.
11. Add a placeholder-glued original: singular `I %sshow this.`. Confirm `show` is still highlighted and the `%s` chunk is preserved.

Expected result: hyphen-bounded false positives are gone, every prior match case still works.

## Screenshots or screencast

Not applicable. No UI change.

## Use of AI Tools

- AI assistance: Yes
- Tool(s): Claude Code (CLI)
- Model(s): GLM 5.3
- Used for: implementation and test writing, reviewed and edited by me
