### PR TITLE
Skip the case warning when the translation begins with a name copied from the original

### DIFF
--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -965,13 +965,103 @@ class GP_Builtin_Translation_Warnings {
 		$is_first_letter_uppercase_translation = preg_match( '/^\p{Lu}/u', $translation );
 		$is_first_letter_lowercase_original    = preg_match( '/^\p{Ll}/u', $original );
 		$is_first_letter_lowercase_translation = preg_match( '/^\p{Ll}/u', $translation );
-		if ( $is_first_letter_uppercase_original && $is_first_letter_lowercase_translation ) {
-			return __( 'The translation appears to be missing the initial uppercase.', 'glotpress' );
-		}
-		if ( $is_first_letter_lowercase_original && $is_first_letter_uppercase_translation ) {
-			return __( 'The translation appears to be missing the initial lowercase.', 'glotpress' );
+
+		$missing_uppercase = $is_first_letter_uppercase_original && $is_first_letter_lowercase_translation;
+		$missing_lowercase = $is_first_letter_lowercase_original && $is_first_letter_uppercase_translation;
+
+		if ( ! $missing_uppercase && ! $missing_lowercase ) {
+			return true;
 		}
 
-		return true;
+		/*
+		 * The check compares the first letter of the original with the first letter
+		 * of the translation, which assumes both sentences begin with the same term.
+		 * Languages that reorder the sentence can begin the translation with a name
+		 * carried over from the original, such as `WordPress.org`, `bbPress`, `v2`,
+		 * or `foo_bar`. The case of such a name comes from the original rather than
+		 * from the translator, so there is nothing to correct.
+		 */
+		if ( $this->begins_with_name_from_original( $original, $translation ) ) {
+			return true;
+		}
+
+		if ( $missing_uppercase ) {
+			return __( 'The translation appears to be missing the initial uppercase.', 'glotpress' );
+		}
+
+		return __( 'The translation appears to be missing the initial lowercase.', 'glotpress' );
+	}
+
+	/**
+	 * Determines whether the translation begins with a name copied from the original.
+	 *
+	 * Only names are considered, meaning terms that carry their own casing, such as
+	 * `WordPress.org`, `bbPress`, `v2` or `foo_bar`. Ordinary words, including
+	 * hyphenated compounds such as `front-end`, are not names, so a translation
+	 * beginning with one is still checked.
+	 *
+	 * The comparison is case sensitive and matches whole terms, so a translation
+	 * beginning with `Word` is not treated as a copy of `WordPress`.
+	 *
+	 * @since 4.2.0
+	 * @access private
+	 *
+	 * @param string $original    The source string.
+	 * @param string $translation The translation.
+	 *
+	 * @return bool True if the translation begins with a name from the original.
+	 */
+	private function begins_with_name_from_original( string $original, string $translation ): bool {
+		if ( ! preg_match( '/^\S+/u', $translation, $matches ) ) {
+			return false;
+		}
+
+		$first_term = $this->trim_punctuation( $matches[0] );
+
+		if ( '' === $first_term || ! preg_match( '/[\p{Lu}\p{Ll}]/u', $first_term ) ) {
+			return false;
+		}
+
+		/*
+		 * A name carries its own casing: an uppercase letter, or one of the
+		 * characters identifiers use and ordinary words do not, meaning a digit,
+		 * `.`, `_`, `/` or `\`. Marks and punctuation that occur inside ordinary
+		 * words are deliberately excluded, so a dash as in `front-end`, an
+		 * apostrophe as in `don't`, a middle dot as in `col·legi` and a
+		 * combining accent as in a decomposed `équipe` all stay ordinary words.
+		 *
+		 * The consequence is that an all-lowercase hyphenated identifier such as
+		 * `wp-admin` is also read as an ordinary word, because it is shaped
+		 * exactly like `front-end`. Telling the two apart needs a dictionary
+		 * rather than a boundary rule, so the check keeps the warning for both
+		 * instead of risking the loss of a real one.
+		 */
+		$carries_own_case = preg_match( '/\p{Lu}/u', $first_term ) || preg_match( '/[\p{N}._\/\\\\]/u', $first_term );
+
+		if ( ! $carries_own_case ) {
+			return false;
+		}
+
+		foreach ( preg_split( '/\s+/u', $original, -1, PREG_SPLIT_NO_EMPTY ) as $term ) {
+			if ( $first_term === $this->trim_punctuation( $term ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Removes leading and trailing punctuation from a term.
+	 *
+	 * @since 4.2.0
+	 * @access private
+	 *
+	 * @param string $term The term to trim.
+	 *
+	 * @return string The trimmed term.
+	 */
+	private function trim_punctuation( string $term ): string {
+		return (string) preg_replace( '/^[\p{P}\p{S}]+|[\p{P}\p{S}]+$/u', '', $term );
 	}
 }

--- a/tests/phpunit/testcases/test_builtin_warnings.php
+++ b/tests/phpunit/testcases/test_builtin_warnings.php
@@ -719,6 +719,149 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 			"Expected 1 space at the beginning, got 3.\nExpected 1 space at the end, got 3." );
 	}
 
+	/**
+	 * Tests that a translation beginning with a term copied from the original
+	 * does not warn, because the case of that term comes from the original.
+	 *
+	 * Languages that reorder the sentence can begin the translation with a
+	 * different term from the original, such as a product name.
+	 *
+	 * @see https://github.com/GlotPress/GlotPress/issues/1969
+	 */
+	public function test_missing_uppercase_beginning_ignores_terms_copied_from_the_original() {
+		$this->l->slug     = 'bn';
+		$this->l->alphabet = 'bengali';
+
+		// The original begins with a deliberately lowercase product name.
+		$this->assertNoWarnings(
+			'missing_uppercase_beginning',
+			'bbPress is part of WordPress.org',
+			'WordPress.org মূলত bbPress এরই অংশ',
+			$this->l
+		);
+
+		$this->l->slug     = 'hi';
+		$this->l->alphabet = 'devanagari';
+
+		$this->assertNoWarnings(
+			'missing_uppercase_beginning',
+			'bbPress is part of WordPress.org',
+			'WordPress.org का हिस्सा bbPress है',
+			$this->l
+		);
+
+		// A name whose casing is internal rather than initial.
+		$this->assertNoWarnings(
+			'missing_uppercase_beginning',
+			'visit bbPress',
+			'bbPress पर जाएँ',
+			$this->l
+		);
+
+		// A version identifier.
+		$this->assertNoWarnings(
+			'missing_uppercase_beginning',
+			'Use v2 now',
+			'v2 का उपयोग करें',
+			$this->l
+		);
+
+		// A code identifier.
+		$this->assertNoWarnings(
+			'missing_uppercase_beginning',
+			'Set foo_bar here',
+			'foo_bar सेट करें',
+			$this->l
+		);
+	}
+
+	/**
+	 * Tests that a term which merely resembles one in the original still warns.
+	 *
+	 * @see https://github.com/GlotPress/GlotPress/issues/1969
+	 */
+	public function test_missing_uppercase_beginning_still_warns_for_marks_inside_ordinary_words() {
+		$this->l->slug     = 'hi';
+		$this->l->alphabet = 'devanagari';
+
+		/*
+		 * A leading term counts as a name only when it carries its own casing: an
+		 * uppercase letter, a digit, or one of `.`, `_`, `/` or `\\`. Marks and
+		 * punctuation that occur inside ordinary words of other scripts must not
+		 * qualify, or the warning is silently lost for those languages.
+		 */
+
+		$middle_dot = "col\u{00B7}legi";        // Catalan, ordinary word.
+		$decomposed = "e\u{0301}quipe";         // French, accent as a combining mark.
+		$hindi_word = "\u{092C}\u{0926}\u{0932}\u{0947}\u{0902}";
+
+		$this->assertHasWarningsAndContainsOutput(
+			'missing_uppercase_beginning',
+			"Change {$middle_dot} setting",
+			"{$middle_dot} {$hindi_word}",
+			'The translation appears to be missing the initial uppercase.',
+			$this->l
+		);
+
+		$this->assertHasWarningsAndContainsOutput(
+			'missing_uppercase_beginning',
+			"Change {$decomposed} setting",
+			"{$decomposed} {$hindi_word}",
+			'The translation appears to be missing the initial uppercase.',
+			$this->l
+		);
+	}
+
+	public function test_missing_uppercase_beginning_still_warns_for_terms_not_in_the_original() {
+		$this->l->slug     = 'hi';
+		$this->l->alphabet = 'devanagari';
+
+		// `word` is not a term in the original, it is only part of `WordPress`.
+		$this->assertHasWarningsAndContainsOutput(
+			'missing_uppercase_beginning',
+			'WordPress plugin',
+			'word प्लगइन',
+			'The translation appears to be missing the initial uppercase.',
+			$this->l
+		);
+
+		// `Press` is not a term in the original, it is only part of `bbPress`.
+		$this->assertHasWarningsAndContainsOutput(
+			'missing_uppercase_beginning',
+			'bbPress forum',
+			'Press फोरम',
+			'The translation appears to be missing the initial lowercase.',
+			$this->l
+		);
+
+		// The original spells the term with a different case.
+		$this->assertHasWarningsAndContainsOutput(
+			'missing_uppercase_beginning',
+			'Settings page',
+			'settings पेज',
+			'The translation appears to be missing the initial uppercase.',
+			$this->l
+		);
+
+		// An ordinary lowercase word is not a name, even when copied from the original.
+		$this->assertHasWarningsAndContainsOutput(
+			'missing_uppercase_beginning',
+			'Change settings',
+			'settings बदलें',
+			'The translation appears to be missing the initial uppercase.',
+			$this->l
+		);
+
+		// A hyphenated compound is an ordinary word, not a name.
+		$this->assertHasWarningsAndContainsOutput(
+			'missing_uppercase_beginning',
+			'Check front-end settings',
+			'front-end सेटिंग्स जांचें',
+			'The translation appears to be missing the initial uppercase.',
+			$this->l
+		);
+	}
+
 	public function test_missing_uppercase_beginning() {
 		$this->l->slug = 'ga';
 		$this->l->alphabet = 'latin';


### PR DESCRIPTION
## What?

Closes #1969

Stops the `missing_uppercase_beginning` warning firing when a translation begins with a name copied from the original.

## Why?

The check compares only the first character of the original with the first character of the translation, which assumes both sentences start with the same word. Sentence-reordering languages often begin with a name carried over from the original, so it compares two unrelated words.

The string reported in the issue:

    Original:    bbPress is part of WordPress.org
    Translation: WordPress.org মূলত bbPress এরই অংশ
    Warning:     The translation appears to be missing the initial lowercase.

The case of `WordPress.org` comes from the original, so there is nothing for the translator to correct. The warning also restricts the row to validator-only approval, so the false positive has a real cost.

Worth noting for the issue title: the warning never fires on non-Latin text itself, since those characters are neither uppercase nor lowercase in Unicode. The cause is the copied name, not the script.

## How?

The warning is skipped only when the translation's first term is a name that appears verbatim in the original. A term counts as a name when it carries its own casing: an uppercase letter, or a digit, `.`, `_`, `/` or `\`. Matching is case sensitive and whole-term, so `Word` is not treated as a copy of `WordPress`.

No locale is muted and no setting is added. Ordinary copied words still warn, `front-end` still warns, and marks inside ordinary words do not make a term a name, so Catalan `col·legi` and a decomposed `équipe` still warn.

One known limit, noted in the code: an all-lowercase hyphenated identifier such as `wp-admin` reads as an ordinary word, because it is shaped exactly like `front-end`. Separating them needs a dictionary rather than a boundary rule, so the check keeps the warning for both.

I used `@since 4.2.0` for the new private helpers, but I'm happy to adjust that if another version is expected.

## Testing Instructions

1. Set a translation set to a reordering locale such as `bn` or `hi`.
2. Use an original that starts with a lowercase word and contains a name, for example `bbPress is part of WordPress.org`.
3. Save a translation beginning with that name.
4. Before this change the row warns "missing the initial lowercase". After it, no warning.
5. Confirm an ordinary copied word still warns: `Change settings` to `settings ...`.

Three tests added in `tests/phpunit/testcases/test_builtin_warnings.php`. Full suite on the current `develop`: 516 tests, 1966 assertions, no failures. PHPCS reports no new issues on either file.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code, Codex (for review and testing)
Used for: Investigation, implementation and tests. I reviewed the reasoning and every result, and I take responsibility for the contribution.